### PR TITLE
Adding scripts to generate NDJSON and TTL dumps of the entity database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,5 @@ imageFactory
 notes
 db/couchdb/migration_docs
 run
+./dumps
 

--- a/config/universal_path.coffee
+++ b/config/universal_path.coffee
@@ -51,6 +51,7 @@ module.exports =
     logs: '/logs'
     uploads: '/client/public/uploads'
     modulesBin: '/node_modules/.bin'
+    dumps: '/dumps'
   path: (route, name)->
     path = @paths[route]
     rootedPath = "#{appRoot}#{path}"

--- a/package.json
+++ b/package.json
@@ -87,6 +87,8 @@
     "request": "^2.72.0",
     "rss": "^1.2.2",
     "serve-favicon": "^2.3.2",
+    "split": "^1.0.1",
+    "through": "^2.3.8",
     "wikidata-edit": "^1.6.0",
     "wikidata-lang": "^2.0.3",
     "wikidata-sdk": "^5.2.9",

--- a/scripts/actions/backup_databases.coffee
+++ b/scripts/actions/backup_databases.coffee
@@ -6,12 +6,11 @@ forcedArgs = {}
 if port? then forcedArgs.port = port
 if suffix? then forcedArgs.suffix = suffix
 CONFIG = require('./lib/get_custom_config')(forcedArgs)
-
 __ = CONFIG.universalPath
 _ = __.require 'builders', 'utils'
 fs = require 'fs'
 promises_ = __.require 'lib', 'promises'
-execa = require 'execa'
+
 { username, password, host, port } = CONFIG.db
 dbsNames = Object.keys __.require('couch', 'list')
 allDbsUrl = CONFIG.db.fullHost() + '/_all_dbs'
@@ -19,56 +18,24 @@ allDbsUrl = CONFIG.db.fullHost() + '/_all_dbs'
 backupGeneralFolder = __.path 'couchdb', 'backups'
 day = _.simpleDay()
 backupFolder = "#{backupGeneralFolder}/#{day}"
+
 try fs.mkdirSync backupFolder
 catch err then _.warn err, 'mkdirSync err'
-
-# Depends on 'couchdb-backup' (from https://github.com/danielebailo/couchdb-dump)
-# being accessible from the $PATH
-buildArgsArray = (dbName)->
-  outputFile = "#{backupFolder}/#{dbName}.json"
-  return [
-    # Common parameters
-    '-b' # backup mode
-    '-H', host
-    '-P', port
-    '-u', username
-    '-p', password
-    # Database-specific
-    '-d', dbName
-    '-f', outputFile
-  ]
-
-backupDatabase = (dbName)->
-  args = buildArgsArray dbName
-
-  execa 'couchdb-backup', args
-  .then (res)->
-    _.log res.stdout, "#{dbName} stdout"
-    _.warn res.stderr, "#{dbName} stderr"
 
 # Filtering-out _replicator and _users
 isDatabase = (dbName)-> dbName[0] isnt '_'
 
-zipBackupFolder = ->
-  execa 'tar', [
-      '-zcf'
-      # Output
-      "#{backupFolder}.tar.gz"
-      # Change directory (cf http://stackoverflow.com/a/18681628/3324977 )
-      '-C', backupGeneralFolder
-      # Input path from the changed directory
-      day
-    ]
-  .then deleteFolder
+backupDatabase = require './lib/backup_database'
+zipBackupFolder = require './lib/zip_backup_folder'
 
-deleteFolder = -> execa 'rm', [ '-rf', backupFolder ]
+params = { host, port, username, password, backupFolder }
 
 promises_.get allDbsUrl
 .filter isDatabase
 .filter (dbName)-> dbName.match(suffix)
 .then _.Log('databases to backup')
-.map backupDatabase
+.map backupDatabase.bind(null, params)
 .then -> _.log 'done doing backup'
-.then zipBackupFolder
+.then -> zipBackupFolder backupGeneralFolder, backupFolder, day
 .then -> _.log 'cleaned'
 .catch _.Error('databases backup err')

--- a/scripts/actions/lib/backup_database.coffee
+++ b/scripts/actions/lib/backup_database.coffee
@@ -1,0 +1,34 @@
+# If the need arise to use CONFIG directly, make sure to use get_custom_config
+# to be in lined with scripts/actions/backup_databases
+__ = require('config').universalPath
+_ = __.require 'builders', 'utils'
+execa = require 'execa'
+
+module.exports = (params, dbName)->
+  args = buildArgsArray params, dbName
+
+  execa 'couchdb-backup', args
+  .then (res)->
+    _.log res.stdout, "#{dbName} stdout"
+    _.warn res.stderr, "#{dbName} stderr"
+
+# Depends on 'couchdb-backup' (from https://github.com/danielebailo/couchdb-dump)
+# being accessible from the $PATH
+buildArgsArray = (params, dbName)->
+  { host, port, username, password, backupFolder } = params
+  _.types [ host, username, password, dbName, backupFolder ], 'strings...'
+  _.type port, 'number|string'
+
+  outputFile = "#{backupFolder}/#{dbName}.json"
+
+  return [
+    # Common parameters
+    '-b' # backup mode
+    '-H', host
+    '-P', port
+    '-u', username
+    '-p', password
+    # Database-specific
+    '-d', dbName
+    '-f', outputFile
+  ]

--- a/scripts/actions/lib/zip_backup_folder.coffee
+++ b/scripts/actions/lib/zip_backup_folder.coffee
@@ -1,0 +1,15 @@
+execa = require 'execa'
+
+module.exports = (backupGeneralFolder, backupFolder, day)->
+  execa 'tar', [
+      '-zcf'
+      # Output
+      "#{backupFolder}.tar.gz"
+      # Change directory (cf http://stackoverflow.com/a/18681628/3324977 )
+      '-C', backupGeneralFolder
+      # Input path from the changed directory
+      day
+    ]
+  .then -> deleteFolder backupFolder
+
+deleteFolder = (backupFolder)-> execa 'rm', [ '-rf', backupFolder ]

--- a/scripts/dumps/convert_ndjson_dump_to_ttl
+++ b/scripts/dumps/convert_ndjson_dump_to_ttl
@@ -1,0 +1,30 @@
+#!/usr/bin/env coffee
+CONFIG = require 'config'
+__ = CONFIG.universalPath
+_ = __.require 'builders', 'utils'
+split = require 'split'
+through = require 'through'
+fs = require 'fs'
+serializeEntityInTurtle = require './lib/serialize_entity_in_turtle'
+
+headers = fs.readFileSync(__dirname + '/headers.ttl').toString()
+  .split '\n'
+  # Filtering-out commented out lines
+  .filter (line)-> line[0] isnt '#'
+  .join '\n'
+
+console.log(headers)
+
+parse = (line)->
+  try
+    unless _.isNonEmptyString(line) then return
+    json = JSON.parse line
+    console.log serializeEntityInTurtle(json)
+  catch err
+    console.log 'line', line
+    console.error 'err', err
+
+process.stdin
+.pipe split()
+.pipe through(parse)
+.on 'error', _.Error('conversion error')

--- a/scripts/dumps/convert_ndjson_dump_to_ttl
+++ b/scripts/dumps/convert_ndjson_dump_to_ttl
@@ -8,21 +8,19 @@ fs = require 'fs'
 serializeEntityInTurtle = require './lib/serialize_entity_in_turtle'
 
 headers = fs.readFileSync(__dirname + '/headers.ttl').toString()
-  .split '\n'
-  # Filtering-out commented out lines
-  .filter (line)-> line[0] isnt '#'
-  .join '\n'
-
+# Prefix the dump by the headers
 console.log(headers)
 
 parse = (line)->
   try
+    # Omit the last empty line
     unless _.isNonEmptyString(line) then return
     json = JSON.parse line
+    # Output on process.stdin
     console.log serializeEntityInTurtle(json)
   catch err
-    console.log 'line', line
-    console.error 'err', err
+    console.error 'error line', line
+    console.error 'error', err
 
 process.stdin
 .pipe split()

--- a/scripts/dumps/headers.ttl
+++ b/scripts/dumps/headers.ttl
@@ -1,0 +1,29 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix wikibase: <http://wikiba.se/ontology-beta#> .
+# @prefix wdata: <https://www.wikidata.org/wiki/Special:EntityData/> .
+@prefix wd: <http://www.wikidata.org/entity/> .
+# @prefix wds: <http://www.wikidata.org/entity/statement/> .
+# @prefix wdref: <http://www.wikidata.org/reference/> .
+# @prefix wdv: <http://www.wikidata.org/value/> .
+@prefix wdt: <http://www.wikidata.org/prop/direct/> .
+# @prefix wdtn: <http://www.wikidata.org/prop/direct-normalized/> .
+# @prefix p: <http://www.wikidata.org/prop/> .
+# @prefix ps: <http://www.wikidata.org/prop/statement/> .
+# @prefix psv: <http://www.wikidata.org/prop/statement/value/> .
+# @prefix psn: <http://www.wikidata.org/prop/statement/value-normalized/> .
+# @prefix pq: <http://www.wikidata.org/prop/qualifier/> .
+# @prefix pqv: <http://www.wikidata.org/prop/qualifier/value/> .
+# @prefix pqn: <http://www.wikidata.org/prop/qualifier/value-normalized/> .
+# @prefix pr: <http://www.wikidata.org/prop/reference/> .
+# @prefix prv: <http://www.wikidata.org/prop/reference/value/> .
+# @prefix prn: <http://www.wikidata.org/prop/reference/value-normalized/> .
+# @prefix wdno: <http://www.wikidata.org/prop/novalue/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix schema: <http://schema.org/> .
+# @prefix cc: <http://creativecommons.org/ns#> .
+# @prefix geo: <http://www.opengis.net/ont/geosparql#> .
+# @prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix inv: <http://inventaire.io/entity/> .

--- a/scripts/dumps/headers.ttl
+++ b/scripts/dumps/headers.ttl
@@ -3,27 +3,8 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix wikibase: <http://wikiba.se/ontology-beta#> .
-# @prefix wdata: <https://www.wikidata.org/wiki/Special:EntityData/> .
 @prefix wd: <http://www.wikidata.org/entity/> .
-# @prefix wds: <http://www.wikidata.org/entity/statement/> .
-# @prefix wdref: <http://www.wikidata.org/reference/> .
-# @prefix wdv: <http://www.wikidata.org/value/> .
 @prefix wdt: <http://www.wikidata.org/prop/direct/> .
-# @prefix wdtn: <http://www.wikidata.org/prop/direct-normalized/> .
-# @prefix p: <http://www.wikidata.org/prop/> .
-# @prefix ps: <http://www.wikidata.org/prop/statement/> .
-# @prefix psv: <http://www.wikidata.org/prop/statement/value/> .
-# @prefix psn: <http://www.wikidata.org/prop/statement/value-normalized/> .
-# @prefix pq: <http://www.wikidata.org/prop/qualifier/> .
-# @prefix pqv: <http://www.wikidata.org/prop/qualifier/value/> .
-# @prefix pqn: <http://www.wikidata.org/prop/qualifier/value-normalized/> .
-# @prefix pr: <http://www.wikidata.org/prop/reference/> .
-# @prefix prv: <http://www.wikidata.org/prop/reference/value/> .
-# @prefix prn: <http://www.wikidata.org/prop/reference/value-normalized/> .
-# @prefix wdno: <http://www.wikidata.org/prop/novalue/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <http://schema.org/> .
-# @prefix cc: <http://creativecommons.org/ns#> .
-# @prefix geo: <http://www.opengis.net/ont/geosparql#> .
-# @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix inv: <http://inventaire.io/entity/> .

--- a/scripts/dumps/lib/serialize_entity_in_turtle.coffee
+++ b/scripts/dumps/lib/serialize_entity_in_turtle.coffee
@@ -27,7 +27,7 @@ module.exports = (entity)->
         text += formatPropClaims property, datesValues
 
   # Replace the last ';' by a '.'
-  return text.replace /;$/, '.\n'
+  return text.replace /;$/, '.'
 
 formatStringValue = (str)->
   # May also be of type number

--- a/scripts/dumps/lib/serialize_entity_in_turtle.coffee
+++ b/scripts/dumps/lib/serialize_entity_in_turtle.coffee
@@ -1,0 +1,39 @@
+CONFIG = require 'config'
+__ = CONFIG.universalPath
+_ = __.require 'builders', 'utils'
+{ properties } = __.require 'controllers','entities/lib/properties'
+
+module.exports = (entity)->
+  { _id } = entity
+
+  text = "\ninv:#{_id} a wikibase:Item ;"
+
+  for lang, value of entity.labels
+    text += """\n  rdfs:label "#{escapeDoubleQuotes(value)}"@#{lang} ;"""
+    text += """\n  skos:prefLabel "#{escapeDoubleQuotes(value)}"@#{lang} ;"""
+
+  for property, propClaims of entity.claims
+    switch properties[property].datatype
+      when 'entity'
+        text += formatPropClaims property, propClaims
+      when 'string'
+        stringValues = propClaims.map formatStringValue
+        text += formatPropClaims property, stringValues
+      when 'positive-integer'
+        prefixedIntegers = propClaims.map formatPositiveInteger
+        text += formatPropClaims property, prefixedIntegers
+      when 'simple-day'
+        datesValues = propClaims.map formatDate
+        text += formatPropClaims property, datesValues
+
+  return text + '\n'
+
+escapeDoubleQuotes = (str)-> str.replace '"', '\\"'
+formatStringValue = (str)-> '"' + str + '"'
+formatPositiveInteger = (number)-> '+"' + number + '"^^xsd:decimal'
+formatDate = (simpleDay)->
+  if simpleDay.length is 4 then simpleDay += '-01-01'
+  return '"' + simpleDay + 'T00:00:00Z"^^xsd:dateTime'
+
+formatPropClaims = (property, formattedPropClaims)->
+  """\n  #{property} #{formattedPropClaims.join(',\n    ')} ;"""

--- a/scripts/dumps/lib/serialize_entity_in_turtle.coffee
+++ b/scripts/dumps/lib/serialize_entity_in_turtle.coffee
@@ -19,7 +19,8 @@ module.exports = (entity)->
       formattedPropClaims = formatter propClaims
       text += formatPropClaims property, formattedPropClaims
 
-  # Replace the last ';' by a '.'
+  # Replace the last ';' by a '.' and add a line break
+  # to have one line between each entity
   return text.replace /;$/, '.\n'
 
 datatypePropClaimsFormatter =

--- a/scripts/dumps/lib/serialize_entity_in_turtle.coffee
+++ b/scripts/dumps/lib/serialize_entity_in_turtle.coffee
@@ -6,11 +6,11 @@ _ = __.require 'builders', 'utils'
 module.exports = (entity)->
   { _id } = entity
 
-  text = "\ninv:#{_id} a wikibase:Item ;"
+  text = "inv:#{_id} a wikibase:Item ;"
 
   for lang, value of entity.labels
-    text += """\n  rdfs:label "#{escapeDoubleQuotes(value)}"@#{lang} ;"""
-    text += """\n  skos:prefLabel "#{escapeDoubleQuotes(value)}"@#{lang} ;"""
+    text += """\n  rdfs:label #{formatStringValue(value)}@#{lang} ;"""
+    text += """\n  skos:prefLabel #{formatStringValue(value)}@#{lang} ;"""
 
   for property, propClaims of entity.claims
     switch properties[property].datatype
@@ -23,17 +23,31 @@ module.exports = (entity)->
         prefixedIntegers = propClaims.map formatPositiveInteger
         text += formatPropClaims property, prefixedIntegers
       when 'simple-day'
-        datesValues = propClaims.map formatDate
+        datesValues = propClaims.filter(validSimpleDay).map formatDate
         text += formatPropClaims property, datesValues
 
-  return text + '\n'
+  # Replace the last ';' by a '.'
+  return text.replace /;$/, '.\n'
 
-escapeDoubleQuotes = (str)-> str.replace '"', '\\"'
-formatStringValue = (str)-> '"' + str + '"'
-formatPositiveInteger = (number)-> '+"' + number + '"^^xsd:decimal'
+formatStringValue = (str)->
+  # May also be of type number
+  str = str.toString()
+
+  # Remove parts of a string that would not validate
+  # ex: Alone with You (Harlequin Blaze\Made in Montana)
+  str = str.replace /\(.*\.*\)/g, ''
+
+  if str.match('"')? then "'''" +  str.replace(/'''/g, '') + "'''"
+  else '"' + str + '"'
+
+formatPositiveInteger = (number)-> '"+' + number + '"^^xsd:decimal'
 formatDate = (simpleDay)->
   if simpleDay.length is 4 then simpleDay += '-01-01'
   return '"' + simpleDay + 'T00:00:00Z"^^xsd:dateTime'
 
+# Shouldn't be 0000-00-00 or 0000
+validSimpleDay = (simpleDay)-> not /^[0-]+$/.test(simpleDay)
+
 formatPropClaims = (property, formattedPropClaims)->
+  if formattedPropClaims.length is 0 then return ''
   """\n  #{property} #{formattedPropClaims.join(',\n    ')} ;"""

--- a/scripts/dumps/prepare_entities_ndjson_dump
+++ b/scripts/dumps/prepare_entities_ndjson_dump
@@ -1,0 +1,48 @@
+#!/usr/bin/env zsh
+
+set -eu
+
+folder=$(node -p "require('config').universalPath.path('dumps')")
+db_param(){ node -p "require('config').db.$1" }
+
+host=$(db_param host)
+port=$(db_param port)
+username=$(db_param username)
+password=$(db_param password)
+db_name='entities-prod'
+today=$(date +'20%y-%m-%d')
+output_file="${folder}/${today}_${db_name}.json"
+
+[ -f "$output_file" ] && echo "$output_file already exist" || {
+  couchdb-backup -b -H "$host" -P "$port" -u "$username" -p "$password" -d "$db_name" -f "$output_file"
+}
+
+filtered_dump_filename="${today}.ndjson"
+filtered_dump_filename_with_seeds="${today}_with_seeds.ndjson"
+redirections_dump="${today}_redirections.ndjson"
+
+cd "$folder"
+
+echo "filtering $output_file into $folder/$filtered_dump_filename"
+
+alias drop_colon="sed 's/,$//'"
+
+cat "$output_file" | grep '"type":"entity","redirect":' | drop_colon > "$redirections_dump"
+
+cat "$output_file" |
+  # Filter-out removed:placeholders
+  grep '"type":"entity"' |
+  # Filter-out redirections
+  grep -v "redirect" |
+  # Filter-out entities empty canvas (entity creation process failure)
+  grep -v '_rev":"1-' |
+  drop_colon > "${filtered_dump_filename_with_seeds}"
+
+cat "${filtered_dump_filename_with_seeds}" |
+  # Filter-out entities that are just unedited data seeds
+  grep -v '_rev":"2-' > "$filtered_dump_filename"
+
+echo compressing $folder/$today*.ndjson
+gzip -9kf $folder/$today*.ndjson
+
+echo "done"

--- a/scripts/dumps/prepare_entities_ndjson_dump
+++ b/scripts/dumps/prepare_entities_ndjson_dump
@@ -21,8 +21,8 @@ output_file="${folder}/${raw_db_json_filename}"
   couchdb-backup -b -H "$host" -P "$port" -u "$username" -p "$password" -d "$db_name" -f "$output_file"
 }
 
-filtered_dump_filename="${today}.ndjson"
-filtered_dump_filename_with_seeds="${today}_with_seeds.ndjson"
+filtered_dump_filename="${today}_entities.ndjson"
+filtered_dump_filename_with_seeds="${today}_entities_with_seeds.ndjson"
 redirections_dump="${today}_redirections.ndjson"
 root_cwd="$(pwd)"
 alias drop_colon="sed 's/,$//'"
@@ -50,7 +50,7 @@ cat "${filtered_dump_filename_with_seeds}" |
   grep -v '_rev":"2-' > "$filtered_dump_filename"
 
 echo compressing $today*.ndjson
-gzip -9kf $today*.ndjson
+gzip -9f $today*.ndjson
 
 
 # TTL dump
@@ -58,11 +58,12 @@ gzip -9kf $today*.ndjson
 # We need to return to the root directory so that convert_ndjson_dump_to_ttl
 # can find the CONFIG
 cd $root_cwd
-turtle_filename="${today}.ttl"
+turtle_filename="${today}_entities.ttl"
 turtle_filepath="${folder}/${turtle_filename}"
 echo "converting to turtle $turtle_filename"
-cat "$folder/$filtered_dump_filename" | ./scripts/dumps/convert_ndjson_dump_to_ttl > "$turtle_filepath"
-gzip -9kf "$turtle_filepath"
+cat "$folder/${filtered_dump_filename}.gz" | gzip -d | ./scripts/dumps/convert_ndjson_dump_to_ttl > "$turtle_filepath"
+gzip -9f "$turtle_filepath"
 
+rm "$output_file"
 
 echo "done"

--- a/scripts/dumps/prepare_entities_ndjson_dump
+++ b/scripts/dumps/prepare_entities_ndjson_dump
@@ -11,9 +11,10 @@ username=$(db_param username)
 password=$(db_param password)
 db_name='entities-prod'
 today=$(date +'20%y-%m-%d')
-output_file="${folder}/${today}_${db_name}.json"
+raw_db_json_filename="${today}_${db_name}.json"
+output_file="${folder}/${raw_db_json_filename}"
 
-[ -f "$output_file" ] && echo "$output_file already exist" || {
+[ -f "$output_file" ] && echo "$raw_db_json_filename already exist" || {
   couchdb-backup -b -H "$host" -P "$port" -u "$username" -p "$password" -d "$db_name" -f "$output_file"
 }
 
@@ -21,15 +22,19 @@ filtered_dump_filename="${today}.ndjson"
 filtered_dump_filename_with_seeds="${today}_with_seeds.ndjson"
 redirections_dump="${today}_redirections.ndjson"
 
-cd "$folder"
+root_cwd="$(pwd)"
 
-echo "filtering $output_file into $folder/$filtered_dump_filename"
+alias convert_ndjson_dump_to_ttl="$(pwd)/scripts/dumps/convert_ndjson_dump_to_ttl"
+
+cd "$folder"
 
 alias drop_colon="sed 's/,$//'"
 
-cat "$output_file" | grep '"type":"entity","redirect":' | drop_colon > "$redirections_dump"
+echo "filtering $raw_db_json_filename redirections into ${redirections_dump}"
+cat "$raw_db_json_filename" | grep '"type":"entity","redirect":' | drop_colon > "$redirections_dump"
 
-cat "$output_file" |
+echo "filtering $raw_db_json_filename with seeds into $filtered_dump_filename_with_seeds"
+cat "$raw_db_json_filename" |
   # Filter-out removed:placeholders
   grep '"type":"entity"' |
   # Filter-out redirections
@@ -38,11 +43,21 @@ cat "$output_file" |
   grep -v '_rev":"1-' |
   drop_colon > "${filtered_dump_filename_with_seeds}"
 
+echo "filtering $raw_db_json_filename without seeds into $filtered_dump_filename"
 cat "${filtered_dump_filename_with_seeds}" |
   # Filter-out entities that are just unedited data seeds
   grep -v '_rev":"2-' > "$filtered_dump_filename"
 
-echo compressing $folder/$today*.ndjson
-gzip -9kf $folder/$today*.ndjson
+echo compressing $today*.ndjson
+gzip -9kf $today*.ndjson
+
+# We need to return to the root directory so that convert_ndjson_dump_to_ttl
+# can find the CONFIG
+cd $root_cwd
+turtle_filename="${today}.ttl"
+turtle_filepath="${folder}/${turtle_filename}"
+echo "converting to turtle $turtle_filename"
+cat "$folder/$filtered_dump_filename" | ./scripts/dumps/convert_ndjson_dump_to_ttl > "$turtle_filepath"
+gzip -9kf "$turtle_filepath"
 
 echo "done"

--- a/scripts/dumps/prepare_entities_ndjson_dump
+++ b/scripts/dumps/prepare_entities_ndjson_dump
@@ -5,6 +5,7 @@ set -eu
 folder=$(node -p "require('config').universalPath.path('dumps')")
 db_param(){ node -p "require('config').db.$1" }
 
+# Getting the database parameters to get ready for couchdb-dump
 host=$(db_param host)
 port=$(db_param port)
 username=$(db_param username)
@@ -14,6 +15,8 @@ today=$(date +'20%y-%m-%d')
 raw_db_json_filename="${today}_${db_name}.json"
 output_file="${folder}/${raw_db_json_filename}"
 
+# Dumping the database only if the file doesn't already exist,
+# which means that this file should be deleted to start a new dump version
 [ -f "$output_file" ] && echo "$raw_db_json_filename already exist" || {
   couchdb-backup -b -H "$host" -P "$port" -u "$username" -p "$password" -d "$db_name" -f "$output_file"
 }
@@ -21,14 +24,12 @@ output_file="${folder}/${raw_db_json_filename}"
 filtered_dump_filename="${today}.ndjson"
 filtered_dump_filename_with_seeds="${today}_with_seeds.ndjson"
 redirections_dump="${today}_redirections.ndjson"
-
 root_cwd="$(pwd)"
-
-alias convert_ndjson_dump_to_ttl="$(pwd)/scripts/dumps/convert_ndjson_dump_to_ttl"
-
-cd "$folder"
-
 alias drop_colon="sed 's/,$//'"
+
+
+# NDJSON dumps
+cd "$folder"
 
 echo "filtering $raw_db_json_filename redirections into ${redirections_dump}"
 cat "$raw_db_json_filename" | grep '"type":"entity","redirect":' | drop_colon > "$redirections_dump"
@@ -51,6 +52,9 @@ cat "${filtered_dump_filename_with_seeds}" |
 echo compressing $today*.ndjson
 gzip -9kf $today*.ndjson
 
+
+# TTL dump
+
 # We need to return to the root directory so that convert_ndjson_dump_to_ttl
 # can find the CONFIG
 cd $root_cwd
@@ -59,5 +63,6 @@ turtle_filepath="${folder}/${turtle_filename}"
 echo "converting to turtle $turtle_filename"
 cat "$folder/$filtered_dump_filename" | ./scripts/dumps/convert_ndjson_dump_to_ttl > "$turtle_filepath"
 gzip -9kf "$turtle_filepath"
+
 
 echo "done"


### PR DESCRIPTION
to be published on dumps.inventaire.io. Also unlocking the possibility to load a dump in a BlazeGraph instance