### PR TITLE
make `GET /api/entities?action=by-uris` accept a `relatives` parameter

### DIFF
--- a/api_tests/entities/get.test.coffee
+++ b/api_tests/entities/get.test.coffee
@@ -2,9 +2,10 @@ CONFIG = require 'config'
 __ = CONFIG.universalPath
 _ = __.require 'builders', 'utils'
 should = require 'should'
+{ Promise } = __.require 'lib', 'promises'
 { authReq, nonAuthReq, undesiredErr, undesiredRes } = require '../utils/utils'
 { getByUris } = require '../utils/entities'
-{ ensureEditionExists, createWorkWithAuthor } = require '../fixtures/entities'
+{ ensureEditionExists, createWorkWithAuthor, createEditionWithWorkAuthorAndSerie } = require '../fixtures/entities'
 endpointBase = '/api/entities?action=by-uris&uris='
 workWithAuthorPromise = createWorkWithAuthor()
 
@@ -133,6 +134,34 @@ describe 'entities:get:by-uris', ->
           err.statusCode.should.equal 400
           err.body.status_verbose.should.equal 'invalid relative: wdt:P31'
           done()
+      .catch undesiredErr(done)
+
+      return
+
+    it "should be able to include the works, authors, and series of an edition", (done)->
+      createEditionWithWorkAuthorAndSerie()
+      .get 'uri'
+      .then (editionUri)->
+        relatives = 'relatives=wdt:P50|wdt:P179|wdt:P629'
+        nonAuthReq 'get', "#{endpointBase}#{editionUri}&#{relatives}"
+        .then (res)->
+          edition = res.entities[editionUri]
+          edition.should.be.an.Object()
+
+          workUri = edition.claims['wdt:P629'][0]
+          work = res.entities[workUri]
+          work.should.be.an.Object()
+
+          authorUri = work.claims['wdt:P50'][0]
+          author = res.entities[authorUri]
+          author.should.be.an.Object()
+
+          serieUri = work.claims['wdt:P179'][0]
+          serie = res.entities[serieUri]
+          serie.should.be.an.Object()
+
+          done()
+
       .catch undesiredErr(done)
 
       return

--- a/api_tests/entities/get.test.coffee
+++ b/api_tests/entities/get.test.coffee
@@ -46,62 +46,62 @@ describe 'entities:get:by-uris', ->
     return
 
   describe 'alias URIs', ->
-  it 'should accept twitter URIs', (done)->
-    aliasUri = 'twitter:bouletcorp'
-    getByUris aliasUri
-    .then (res)->
-      { entities, redirects } = res
-      canonicalUri = redirects[aliasUri]
-      canonicalUri.should.equal 'wd:Q1524522'
-      entity = entities[canonicalUri]
-      entity.should.be.an.Object()
-      entity.type.should.equal 'human'
-      entity.uri.should.equal canonicalUri
-      done()
-    .catch undesiredErr(done)
+    it 'should accept twitter URIs', (done)->
+      aliasUri = 'twitter:bouletcorp'
+      getByUris aliasUri
+      .then (res)->
+        { entities, redirects } = res
+        canonicalUri = redirects[aliasUri]
+        canonicalUri.should.equal 'wd:Q1524522'
+        entity = entities[canonicalUri]
+        entity.should.be.an.Object()
+        entity.type.should.equal 'human'
+        entity.uri.should.equal canonicalUri
+        done()
+      .catch undesiredErr(done)
 
-    return
+      return
 
-  it 'should accept alias URIs with inexact case', (done)->
-    aliasUri = 'twitter:Bouletcorp'
-    getByUris aliasUri
-    .then (res)->
-      { entities, redirects } = res
-      canonicalUri = redirects[aliasUri]
-      canonicalUri.should.equal 'wd:Q1524522'
-      done()
-    .catch undesiredErr(done)
+    it 'should accept alias URIs with inexact case', (done)->
+      aliasUri = 'twitter:Bouletcorp'
+      getByUris aliasUri
+      .then (res)->
+        { entities, redirects } = res
+        canonicalUri = redirects[aliasUri]
+        canonicalUri.should.equal 'wd:Q1524522'
+        done()
+      .catch undesiredErr(done)
 
-    return
+      return
 
-  it 'should accept Wikimedia project URIs', (done)->
-    aliasUri = 'frwiki:Lucien_Suel'
-    getByUris aliasUri
-    .then (res)->
-      { entities, redirects } = res
-      canonicalUri = redirects[aliasUri]
-      canonicalUri.should.equal 'wd:Q3265721'
-      entity = entities[canonicalUri]
-      entity.should.be.an.Object()
-      entity.type.should.equal 'human'
-      entity.uri.should.equal canonicalUri
-      done()
-    .catch undesiredErr(done)
+    it 'should accept Wikimedia project URIs', (done)->
+      aliasUri = 'frwiki:Lucien_Suel'
+      getByUris aliasUri
+      .then (res)->
+        { entities, redirects } = res
+        canonicalUri = redirects[aliasUri]
+        canonicalUri.should.equal 'wd:Q3265721'
+        entity = entities[canonicalUri]
+        entity.should.be.an.Object()
+        entity.type.should.equal 'human'
+        entity.uri.should.equal canonicalUri
+        done()
+      .catch undesiredErr(done)
 
-    return
+      return
 
-  it 'should accept Wikimedia project URIs with spaces', (done)->
-    aliasUri = 'eswikiquote:J. K. Rowling'
-    getByUris aliasUri
-    .then (res)->
-      { entities, redirects } = res
-      canonicalUri = redirects[aliasUri]
-      canonicalUri.should.equal 'wd:Q34660'
-      entity = entities[canonicalUri]
-      entity.should.be.an.Object()
-      entity.type.should.equal 'human'
-      entity.uri.should.equal canonicalUri
-      done()
-    .catch undesiredErr(done)
+    it 'should accept Wikimedia project URIs with spaces', (done)->
+      aliasUri = 'eswikiquote:J. K. Rowling'
+      getByUris aliasUri
+      .then (res)->
+        { entities, redirects } = res
+        canonicalUri = redirects[aliasUri]
+        canonicalUri.should.equal 'wd:Q34660'
+        entity = entities[canonicalUri]
+        entity.should.be.an.Object()
+        entity.type.should.equal 'human'
+        entity.uri.should.equal canonicalUri
+        done()
+      .catch undesiredErr(done)
 
-    return
+      return

--- a/api_tests/entities/get.test.coffee
+++ b/api_tests/entities/get.test.coffee
@@ -5,6 +5,7 @@ should = require 'should'
 { authReq, nonAuthReq, undesiredErr } = require '../utils/utils'
 { getByUris } = require '../utils/entities'
 { ensureEditionExists } = require '../fixtures/entities'
+endpointBase = '/api/entities?action=by-uris&uris='
 
 describe 'entities:get:by-uris', ->
   it 'should accept alternative ISBN 13 syntax', (done)->

--- a/api_tests/fixtures/entities.coffee
+++ b/api_tests/fixtures/entities.coffee
@@ -6,7 +6,7 @@ _ = __.require 'builders', 'utils'
 randomString = __.require 'lib', './utils/random_string'
 isbn_ = __.require 'lib', 'isbn/isbn'
 wdLang = require 'wikidata-lang'
-{ getByUris } = require '../utils/entities'
+{ getByUris, addClaim } = require '../utils/entities'
 
 defaultEditionData = ->
   labels: {}
@@ -88,9 +88,9 @@ module.exports = API =
         editionData.claims['wdt:P629'] = [ workEntity.uri ]
         authReq 'post', '/api/entities?action=create', editionData
 
-addEntityClaim = (createFn, property)-> (subjectEntity)->
-  API[createFn]()
-  .tap (entity)-> API.addClaim subjectEntity.uri, property, entity.uri
+addEntityClaim = (createFnName, property)-> (subjectEntity)->
+  API[createFnName]()
+  .tap (entity)-> addClaim subjectEntity.uri, property, entity.uri
 
 API.addAuthor = addEntityClaim 'createHuman', 'wdt:P50'
 API.addSerie = addEntityClaim 'createSerie', 'wdt:P179'

--- a/api_tests/items/snapshot.test.coffee
+++ b/api_tests/items/snapshot.test.coffee
@@ -8,7 +8,7 @@ should = require 'should'
 { getByUris, merge, updateLabel, updateClaim } = require '../utils/entities'
 { ensureEditionExists } = require '../fixtures/entities'
 randomString = __.require 'lib', './utils/random_string'
-{ createWork, createHuman, addAuthor, addSerie, createEditionFromWorks, createWorkWithAuthor } = require '../fixtures/entities'
+{ createWork, createHuman, createSerie, addAuthor, addSerie, createEditionFromWorks, createWorkWithAuthor } = require '../fixtures/entities'
 
 describe 'items:snapshot', ->
   it 'should be updated when its local edition entity title changes', (done)->

--- a/api_tests/items/snapshot.test.coffee
+++ b/api_tests/items/snapshot.test.coffee
@@ -8,7 +8,7 @@ should = require 'should'
 { getByUris, merge, updateLabel, updateClaim } = require '../utils/entities'
 { ensureEditionExists } = require '../fixtures/entities'
 randomString = __.require 'lib', './utils/random_string'
-{ createWork, createHuman, createSerie, createEditionFromWorks, createWorkWithAuthor } = require '../fixtures/entities'
+{ createWork, createHuman, addAuthor, addSerie, createEditionFromWorks, createWorkWithAuthor } = require '../fixtures/entities'
 
 describe 'items:snapshot', ->
   it 'should be updated when its local edition entity title changes', (done)->

--- a/server/controllers/entities/by_uris.coffee
+++ b/server/controllers/entities/by_uris.coffee
@@ -2,14 +2,29 @@ __ = require('config').universalPath
 _ = __.require 'builders', 'utils'
 error_ = __.require 'lib', 'error/error'
 getEntitiesByUris = require './lib/get_entities_by_uris'
+addRelatives = require './lib/add_relatives'
+whitelistedRelativesProperties = [
+  'wdt:P50'
+]
 
 module.exports = (req, res, next)->
-  { uris, refresh } = req.query
+  { uris, refresh, relatives } = req.query
   # Accept URIs in a POST body
   uris or= req.body?.uris
 
   unless _.isNonEmptyString(uris) or _.isNonEmptyArray(uris)
     return error_.bundleMissingQuery req, res, 'uris'
+
+  # Include a 'relatives' parameter to request to include entities
+  # that you know in advance you will need. For instance, when requesting
+  # works, you can request to have their authors entities directly included
+  # before even knowning the authors URIs: relatives=wdt:P50
+  if relatives?
+    relatives = relatives.split '|'
+    _.log relatives, 'include relative entities'
+    for relative in relatives
+      unless relative in whitelistedRelativesProperties
+        return error_.bundleInvalid req, res, 'relative', relative
 
   if _.isString uris then uris = uris.split '|'
 
@@ -18,5 +33,6 @@ module.exports = (req, res, next)->
   refresh = _.parseBooleanString refresh
 
   getEntitiesByUris uris, refresh
+  .then addRelatives(relatives, refresh)
   .then res.json.bind(res)
   .catch error_.Handler(req, res)

--- a/server/controllers/entities/by_uris.coffee
+++ b/server/controllers/entities/by_uris.coffee
@@ -5,6 +5,8 @@ getEntitiesByUris = require './lib/get_entities_by_uris'
 addRelatives = require './lib/add_relatives'
 whitelistedRelativesProperties = [
   'wdt:P50'
+  'wdt:P179'
+  'wdt:P629'
 ]
 
 module.exports = (req, res, next)->

--- a/server/controllers/entities/by_uris.coffee
+++ b/server/controllers/entities/by_uris.coffee
@@ -23,7 +23,6 @@ module.exports = (req, res, next)->
   # before even knowning the authors URIs: relatives=wdt:P50
   if relatives?
     relatives = relatives.split '|'
-    _.log relatives, 'include relative entities'
     for relative in relatives
       unless relative in whitelistedRelativesProperties
         return error_.bundleInvalid req, res, 'relative', relative

--- a/server/controllers/entities/lib/add_relatives.coffee
+++ b/server/controllers/entities/lib/add_relatives.coffee
@@ -1,0 +1,29 @@
+# Enrich ../by_uris results with entities related to the directly
+# requested entities, following those entities claims.
+
+__ = require('config').universalPath
+_ = __.require 'builders', 'utils'
+getEntitiesByUris = require './get_entities_by_uris'
+
+module.exports = (relatives, refresh)-> (results)->
+  { entities } = results
+  unless relatives? then return results
+
+  additionalEntitiesUris = []
+
+  for uri, entity of entities
+    for relative in relatives
+      propUris = entity.claims[relative]
+      if propUris?
+        for propUri in propUris
+          unless entities[propUri]? then additionalEntitiesUris.push propUri
+
+  if additionalEntitiesUris.length is 0 then return results
+
+  getEntitiesByUris _.uniq(additionalEntitiesUris), refresh
+  .then (additionalResults)->
+    # We only need to extend entities, as those additional URIs
+    # should already be the canonical URIs (no redirection needed)
+    # and all URIs should resolve to an existing entity
+    _.extend results.entities, additionalResults.entities
+    return results

--- a/server/controllers/entities/lib/add_relatives.coffee
+++ b/server/controllers/entities/lib/add_relatives.coffee
@@ -1,14 +1,34 @@
 # Enrich ../by_uris results with entities related to the directly
-# requested entities, following those entities claims.
+# requested entities, following those entities claims
 
 __ = require('config').universalPath
 _ = __.require 'builders', 'utils'
 getEntitiesByUris = require './get_entities_by_uris'
 
-module.exports = (relatives, refresh)-> (results)->
-  { entities } = results
-  unless relatives? then return results
+module.exports = (relatives, refresh)->
+  unless relatives? then return _.identity
 
+  addRelatives = (results)->
+    { entities } = results
+
+    additionalEntitiesUris = getAdditionalEntitiesUris entities, relatives
+
+    if additionalEntitiesUris.length is 0 then return results
+
+    getEntitiesByUris additionalEntitiesUris, refresh
+    # Recursively add relatives, so that an edition could be sent
+    # with its works, and its works authors and series
+    .then addRelatives
+    .then (additionalResults)->
+      # We only need to extend entities, as those additional URIs
+      # should already be the canonical URIs (no redirection needed)
+      # and all URIs should resolve to an existing entity
+      _.extend results.entities, additionalResults.entities
+      return results
+
+  return addRelatives
+
+getAdditionalEntitiesUris = (entities, relatives)->
   additionalEntitiesUris = []
 
   for uri, entity of entities
@@ -18,12 +38,4 @@ module.exports = (relatives, refresh)-> (results)->
         for propUri in propUris
           unless entities[propUri]? then additionalEntitiesUris.push propUri
 
-  if additionalEntitiesUris.length is 0 then return results
-
-  getEntitiesByUris _.uniq(additionalEntitiesUris), refresh
-  .then (additionalResults)->
-    # We only need to extend entities, as those additional URIs
-    # should already be the canonical URIs (no redirection needed)
-    # and all URIs should resolve to an existing entity
-    _.extend results.entities, additionalResults.entities
-    return results
+  return _.uniq additionalEntitiesUris

--- a/server/controllers/entities/lib/add_relatives.coffee
+++ b/server/controllers/entities/lib/add_relatives.coffee
@@ -29,13 +29,12 @@ module.exports = (relatives, refresh)->
   return addRelatives
 
 getAdditionalEntitiesUris = (entities, relatives)->
-  additionalEntitiesUris = []
+  _(entities)
+  .values()
+  .map getEntityRelativesUris(relatives)
+  .flattenDeep()
+  .uniq()
+  .value()
 
-  for uri, entity of entities
-    for relative in relatives
-      propUris = entity.claims[relative]
-      if propUris?
-        for propUri in propUris
-          unless entities[propUri]? then additionalEntitiesUris.push propUri
-
-  return _.uniq additionalEntitiesUris
+getEntityRelativesUris = (relatives)-> (entity)->
+  _.values _.pick(entity.claims, relatives)


### PR DESCRIPTION
make `GET /api/entities?action=by-uris` accept a `relatives` parameter to include entities related to the requested entities by following those entities claims
ex:
- fetch a work by URI, and set `relatives=wdt:P50` to also get its authors entities in the response
- fetch an edition by URI, and set `relatives=wdt:P629|wdt:P50|wdt:P179` to also get the associated works, authors, and series

This feature is currently only needed by in [inventaire/inventaire-client#isbns-importer](https://github.com/inventaire/inventaire-client/tree/isbns-importer), so we should wait for the isbns importer feature to be finished to confirm the need for this `relatives` feature. Unless this feature gets consensually accepted as a nice to have for the API, in which we could keep it despite not having any client code relying on it for now