### PR TITLE
user snapshot: fixed items:last-add timestamp

### DIFF
--- a/api_tests/items/create.test.coffee
+++ b/api_tests/items/create.test.coffee
@@ -62,11 +62,13 @@ describe 'items:create', ->
 
   it 'should increment the user items counter', (done)->
     userPromise = createUser()
+    timestamp = Date.now()
     createItem userPromise, { listing: 'public' }
     .delay debounceDelay
     .then -> getRefreshedUser userPromise
     .then (user)->
       user.snapshot.public['items:count'].should.equal 1
+      user.snapshot.public['items:last-add'].should.be.greaterThan(timestamp)
       user.snapshot.network['items:count'].should.equal 0
       user.snapshot.private['items:count'].should.equal 0
       done()

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "blue-cot": "^3.4.5",
     "bluebird": "^3.4.0",
-    "bluereq": "^2.1.1",
+    "bluereq": "^2.1.5",
     "body-parser": "^1.18.2",
     "chalk": "^1.1.3",
     "coffee-script": "^1.11.1",

--- a/server/controllers/user/lib/update_snapshot_items_counts.coffee
+++ b/server/controllers/user/lib/update_snapshot_items_counts.coffee
@@ -24,7 +24,8 @@ aggregateCounts = (index, item)->
   { listing, created } = item
   index[listing]['items:count'] += 1
 
-  if created > index[listing]['items:last-add']
+  lastAdd = index[listing]['items:last-add']
+  if not lastAdd? or created > lastAdd
     index[listing]['items:last-add'] = created
 
   return index


### PR DESCRIPTION
`user.snapshot['items:last-add']` was never set, as `created > index[listing]['items:last-add']` was always false