### PR TITLE
Get entity type from wdt:P279

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "transifexify": "^1.0.6",
     "wikidata-edit": "^2.0.5",
     "wikidata-lang": "^2.0.3",
-    "wikidata-sdk": "^5.2.9",
+    "wikidata-sdk": "^5.7.6",
     "xml2js": "^0.4.13"
   },
   "devDependencies": {

--- a/server/controllers/entities/lib/get_entity_type.coffee
+++ b/server/controllers/entities/lib/get_entity_type.coffee
@@ -2,12 +2,21 @@ __ = require('config').universalPath
 _ = __.require 'builders', 'utils'
 { types } =  __.require 'lib', 'wikidata/aliases'
 
-# Takes an entity wdt:P31 claims array
+# Takes an entity wdt:P31 (instance of) claims array
 # Returns a entity type string: work, edition, article, human, genre
-module.exports = (wdtP31Array)->
+# If no type is found, try with the wdt:P279 (subclass of) claims array
+# (used for Wikidata entities only, as all inv entities have a known P31)
+module.exports = (wdtP31Array, wdtP279Array)->
   unless wdtP31Array? then return
 
   for value in wdtP31Array
+    type = types[value]
+    # return as soon as we get a type
+    if type? then return type
+
+  unless wdtP279Array? then return
+
+  for value in wdtP279Array
     type = types[value]
     # return as soon as we get a type
     if type? then return type

--- a/server/controllers/entities/lib/get_wikidata_enriched_entities.coffee
+++ b/server/controllers/entities/lib/get_wikidata_enriched_entities.coffee
@@ -49,10 +49,11 @@ mergeWdAndInvData = (entity, invEntity)->
     radio.emit 'wikidata:entity:cache:miss', entity.id
     return formatEmpty 'missing', entity
 
-  { P31 } = entity.claims
-  if P31
-    simplifiedP31 = wdk.simplifyPropertyClaims P31
-    entity.type = getEntityType simplifiedP31.map(prefixify)
+  { P31, P279 } = entity.claims
+  if P31? or P279?
+    simplifiedP31 = wdk.simplifyPropertyClaims(P31).map prefixify
+    simplifiedP279 = wdk.simplifyPropertyClaims(P279).map prefixify
+    entity.type = getEntityType simplifiedP31, simplifiedP279
   else
     # Make sure to override the type as Wikidata entities have a type with
     # another role in Wikibase, and we need this absence of known type to

--- a/server/controllers/entities/search_type.coffee
+++ b/server/controllers/entities/search_type.coffee
@@ -9,8 +9,6 @@ __ = CONFIG.universalPath
 _ = __.require 'builders', 'utils'
 error_ = __.require 'lib', 'error/error'
 searchType = require './lib/search_type'
-getEntityType = require './lib/get_entity_type'
-{ typesNames } = __.require 'lib', 'wikidata/aliases'
 
 indexedTypes = [ 'works', 'humans', 'series', 'genres', 'movements', 'publishers', 'collections']
 

--- a/server/lib/wikidata/whitelisted_properties.coffee
+++ b/server/lib/wikidata/whitelisted_properties.coffee
@@ -29,6 +29,7 @@ module.exports = [
   'P179' # series
   'P195' # collection
   'P212' # isbn 13
+  'P279' # subclass of
   'P356' # DOI
   'P361' # part of
   'P364' # original language of work


### PR DESCRIPTION
fallback on wdt:P279 claims values for Wikidata entities which type can't be identified from wdt:P31
ex: [Q28135131](https://www.wikidata.org/wiki/Q28135131) currently has a P279 claim that should make it be identified as a genre, but no P31. Consequently, adding it as a genre (wdt:P136) claim value is currently rejected by the editor