### PR TITLE
entities: reverse claims: blacklisting properties with too many results

### DIFF
--- a/api_tests/entities/reverse_claims.test.coffee
+++ b/api_tests/entities/reverse_claims.test.coffee
@@ -1,0 +1,22 @@
+CONFIG = require 'config'
+__ = CONFIG.universalPath
+_ = __.require 'builders', 'utils'
+should = require 'should'
+{ Promise } = __.require 'lib', 'promises'
+{ nonAuthReq, undesiredErr, undesiredRes } = require '../utils/utils'
+{ createEdition, createWork, createItemFromEntityUri, addClaim, createSerie, createHuman } = require '../fixtures/entities'
+
+describe 'entities:reverse-claims', ->
+  it 'should reject wdt:P31 requests', (done)->
+    url = _.buildPath '/api/entities',
+      action: 'reverse-claims'
+      property: 'wdt:P31'
+      uri: 'wd:Q571'
+    nonAuthReq 'get', url
+    .then undesiredRes(done)
+    .catch (err)->
+      err.body.status_verbose.should.equal 'blacklisted property'
+      done()
+    .catch undesiredErr(done)
+
+    return

--- a/server/controllers/entities/lib/reverse_claims.coffee
+++ b/server/controllers/entities/lib/reverse_claims.coffee
@@ -1,5 +1,6 @@
 __ = require('config').universalPath
 _ = __.require 'builders', 'utils'
+error_ = __.require 'lib', 'error/error'
 wdk = require 'wikidata-sdk'
 wd_ = __.require 'lib', 'wikidata/wikidata'
 promises_ = __.require 'lib', 'promises'
@@ -15,9 +16,18 @@ caseInsensitiveProperties = [
   'wdt:P2002'
 ]
 
+blacklistedProperties = [
+  # Too many results, can't be sorted
+  'wdt:P31'
+]
+
 module.exports = (params)->
   { property, value, refresh, sort } = params
   _.types [ property, value ], 'strings...'
+
+  if property in blacklistedProperties
+    return error_.reject 'blacklisted property', 400, { property }
+
   promises = []
 
   isEntityValue = _.isEntityUri value


### PR DESCRIPTION
namely wdt:P31
Motivations:
- no use case for knowing all the entities matching a given P31
- allowing to query all the instances of Q571 or Q5 sorted by popularity was making the server eat all the RAM