### PR TITLE
send search engine update requests for entities with no known type

### DIFF
--- a/server/controllers/entities/lib/update_search_engine.coffee
+++ b/server/controllers/entities/lib/update_search_engine.coffee
@@ -39,6 +39,10 @@ module.exports = ->
   lazyRequestUpdate = _.throttle requestUpdate, delay, { leading: false }
 
   add = (uri, type='other')->
+    # Also include entities without known type
+    # so that a Wikidata entity that got a wdt:P31 update
+    # that doesn't match any known type still triggers an update
+    # to unindex the formerly known type
     pluralizedType = type + 's'
     urisPerType[pluralizedType] or= []
 


### PR DESCRIPTION
to let the [entities search engine unindex entities](https://github.com/inventaire/wikidata-subset-search-engine/commit/6aebcbc) that formerly had a known type