### PR TITLE
cleaning properties

### DIFF
--- a/api_tests/entities/update_claims.test.coffee
+++ b/api_tests/entities/update_claims.test.coffee
@@ -23,6 +23,23 @@ describe 'entities:update-claims', ->
 
     return
 
+  it 'should reject an update with an inappropriate property datatype', (done)->
+    createWork()
+    .then (work)->
+      authReq 'put', '/api/entities?action=update-claim',
+        id: work._id
+        # A work entity should not have pages count
+        property: 'wdt:P50'
+        'new-value': 124
+      .then undesiredRes(done)
+      .catch (err)->
+        err.body.status_verbose.should.startWith 'invalid value datatype'
+        err.statusCode.should.equal 400
+        done()
+    .catch undesiredErr(done)
+
+    return
+
   it 'should reject an update removing a critical claim', (done)->
     createEdition()
     .then (edition)->

--- a/api_tests/entities/update_claims.test.coffee
+++ b/api_tests/entities/update_claims.test.coffee
@@ -33,7 +33,7 @@ describe 'entities:update-claims', ->
         'new-value': 124
       .then undesiredRes(done)
       .catch (err)->
-        err.body.status_verbose.should.startWith 'invalid value datatype'
+        err.body.status_verbose.should.equal 'invalid value datatype: expected string, got number'
         err.statusCode.should.equal 400
         done()
     .catch undesiredErr(done)

--- a/server/controllers/entities/lib/alias_uris.coffee
+++ b/server/controllers/entities/lib/alias_uris.coffee
@@ -1,7 +1,7 @@
 __ = require('config').universalPath
 _ = __.require 'builders', 'utils'
 reverseClaims = require './reverse_claims'
-{ underLimitString } = __.require 'models', 'tests/common'
+{ BoundedString } = __.require 'models', 'tests/common'
 
 # Find properties regex on properties P1793 claims
 regexValidator = (regex)-> (str)-> regex.test str
@@ -12,7 +12,7 @@ twitter =
 
 facebook =
   property: 'wdt:P2013'
-  validator: underLimitString 100
+  validator: BoundedString 1, 100
 
 openlibrary =
   property: 'wdt:P648'

--- a/server/controllers/entities/lib/entities.coffee
+++ b/server/controllers/entities/lib/entities.coffee
@@ -83,7 +83,8 @@ module.exports = entities_ =
     .then -> validateClaimValue params
 
   # Assumes that the property is valid
-  validatePropertyValueSync: (property, value)-> properties[property].test value
+  validatePropertyValueSync: (property, value)->
+    properties[property].validate value
 
   getLastChangedEntitiesUris: (since, limit)->
     db.changes

--- a/server/controllers/entities/lib/properties.coffee
+++ b/server/controllers/entities/lib/properties.coffee
@@ -106,21 +106,12 @@ properties =
 
 whitelist = Object.keys properties
 
-# which type those datatype should returned when passed to _.typeOf
-datatypePrimordialType =
-  string: 'string'
-  entity: 'string'
-  'ipfs-path': 'string'
-  'positive-integer': 'number'
-  'simple-day': 'string'
-
-propertyDatatypePrimordialType = (property)->
-  { datatype } = properties[property]
-  return datatypePrimordialType[datatype]
+expectedDatatype = (property)->
+  properties[property].primordialDatatype or properties[property].datatype
 
 module.exports =
   properties: properties
-  propertyDatatypePrimordialType: propertyDatatypePrimordialType
+  expectedDatatype: expectedDatatype
 
   validateProperty: (property)->
     unless /^wdt:P\d+$/.test property
@@ -130,4 +121,4 @@ module.exports =
       throw error_.new "property isn't whitelisted", 400, property
 
   validateDataType: (property, value)->
-    _.typeOf(value) is propertyDatatypePrimordialType(property)
+    _.typeOf(value) is expectedDatatype property

--- a/server/controllers/entities/lib/properties.coffee
+++ b/server/controllers/entities/lib/properties.coffee
@@ -106,12 +106,13 @@ properties =
 
 whitelist = Object.keys properties
 
-expectedDatatype = (property)->
-  properties[property].primordialDatatype or properties[property].datatype
+# Which type a property value should return when passed to _.typeOf
+expectedType = (property)->
+  properties[property].type or properties[property].datatype
 
 module.exports =
   properties: properties
-  expectedDatatype: expectedDatatype
+  expectedType: expectedType
 
   validateProperty: (property)->
     unless /^wdt:P\d+$/.test property
@@ -120,5 +121,5 @@ module.exports =
     unless property in whitelist
       throw error_.new "property isn't whitelisted", 400, property
 
-  validateDataType: (property, value)->
-    _.typeOf(value) is expectedDatatype property
+  validateType: (property, value)->
+    _.typeOf(value) is expectedType property

--- a/server/controllers/entities/lib/properties.coffee
+++ b/server/controllers/entities/lib/properties.coffee
@@ -2,164 +2,109 @@ CONFIG = require 'config'
 __ = CONFIG.universalPath
 _ = __.require 'builders', 'utils'
 error_ = __.require 'lib', 'error/error'
-wdk = require 'wikidata-sdk'
-isbn_ = __.require 'lib', 'isbn/isbn'
-{ EntityUri, SimpleDay } = __.require 'sharedLibs', 'regex'
 
-entityBase =
-  datatype: 'entity'
-  test: EntityUri.test.bind EntityUri
-  format: _.identity
+# Each property configuration object is made of the following attributes:
 
-entityUniqueValue = _.extend {}, entityBase, { uniqueValue: true }
+# datatype: {String}
+# format: {Function}
+# test: {Function}
+# uniqueValue: {Boolean} (default: false)
+# concurrency: {Boolean} (default: false)
+# adminUpdateOnly: {Boolean} (default: false)
+# restrictedType: {String} (only for properties of datatype 'entity' )
 
-restrictedType = (base)-> (type)-> _.extend { restrictedType: type }, entityBase
+# Those attributes aim to constrain the claims properties and values
+# to keep those consistent.
 
-entityRestrictedType = restrictedType entityBase
-entityUniqueValueRestrictedType = restrictedType entityUniqueValue
-workEntity = entityRestrictedType 'work'
-serieEntity = entityRestrictedType 'serie'
-humanEntity = entityRestrictedType 'human'
-
-ipfsPathBase =
-  datatype: 'ipfs-path'
-  test: _.isIpfsPath
-  format: _.identity
-  uniqueValue: true
-
-positiveIntegerBase =
-  datatype: 'positive-integer'
-  test: (value)-> _.isNumber(value) and value % 1 is 0 and value > 0
-  format: _.identity
-  uniqueValue: true
-
-simpleDayUniqueValueBase =
-  datatype: 'simple-day'
-  # See SimpleDay specifications in [inventaire-client]/test/106-regex.coffee
-  test: _.isSimpleDay
-  format: _.identity
-  uniqueValue: true
-
-stringUniqueBase =
-  datatype: 'string'
-  format: _.identity
-  # Arbitrary max length
-  test: (str)-> _.isString(str) and 0 < str.length < 5000
-  uniqueValue: true
-
-urlBase =
-  datatype: 'string'
-  test: _.isUrl
-  format: _.identity
-
-stringConcurrentBase = _.extend {}, stringUniqueBase, { concurrency: true }
-# External ids regexs can be found on their Wikidata property page P1793 statement
-externalId = (regex)-> _.extend {}, stringConcurrentBase, { test: regex.test.bind(regex) }
-
-isbnProperty = (num)->
-  _.extend {}, stringConcurrentBase,
-    test: (isbn)-> isbn? and isbn is isbn_.parse(isbn)?["isbn#{num}h"]
-    uniqueValue: true
-    format: isbn_["toIsbn#{num}h"]
-    adminUpdateOnly: true
-
-# For the moment, ordinals can be only positive integers, but stringified
-# to stay consistent with Wikidata and let the door open to custom ordinals later
-# (ex: roman numbers, letters, etc.)
-ordinalBase =
-  datatype: 'string'
-  format: _.identity
-  test: _.isPositiveIntegerString
-  uniqueValue: true
+# Bases and builders are an attempt to keep those configuration objects DRY:
+# Bases represent the most common configuration objects, and can be extended
+# into more specific configs
+bases = require './properties_config_bases'
+# Builders are functions to generate config objects tailored as closely
+# as possible to the property exact needs
+builders = require './properties_config_builders'
 
 # Keep in sync with app/modules/entities/lib/properties
 # and app/modules/entities/lib/editor/properties_per_type
 properties =
   # image
-  'wdt:P18': ipfsPathBase
+  'wdt:P18': bases.ipfsPath
   # instance of
-  'wdt:P31': _.extend {}, entityUniqueValue, { adminUpdateOnly: true }
+  'wdt:P31': _.extend {}, bases.uniqueEntity, { adminUpdateOnly: true }
   # author
-  'wdt:P50': humanEntity
+  'wdt:P50': bases.humanEntity
   # publisher
-  'wdt:P123': entityUniqueValue
+  'wdt:P123': bases.uniqueEntity
   # movement
-  'wdt:P135': entityBase
+  'wdt:P135': bases.entity
   # genre
-  'wdt:P136': entityBase
+  'wdt:P136': bases.entity
   # based on
-  'wdt:P144': workEntity
+  'wdt:P144': bases.workEntity
   # serie
-  'wdt:P179': serieEntity
+  'wdt:P179': bases.serieEntity
   # ISBN 13
-  'wdt:P212': isbnProperty 13
+  'wdt:P212': builders.isbnProperty 13
   # VIAF id
-  'wdt:P214': externalId /^[1-9]\d(\d{0,7}|\d{17,20})$/
+  'wdt:P214': builders.externalId /^[1-9]\d(\d{0,7}|\d{17,20})$/
   # BNF id
-  'wdt:P268': externalId /^\d{8}[0-9bcdfghjkmnpqrstvwxz]$/
+  'wdt:P268': builders.externalId /^\d{8}[0-9bcdfghjkmnpqrstvwxz]$/
   # original language of work
-  'wdt:P364': entityBase
+  'wdt:P364': bases.entity
   # language of work
-  'wdt:P407': entityBase
+  'wdt:P407': bases.entity
   # date of birth
-  'wdt:P569': simpleDayUniqueValueBase
+  'wdt:P569': bases.uniqueSimpleDay
   # date of death
-  'wdt:P570': simpleDayUniqueValueBase
+  'wdt:P570': bases.uniqueSimpleDay
   # publication date
-  'wdt:P577': simpleDayUniqueValueBase
-  # edition or translation of
-  'wdt:P629': workEntity
+  'wdt:P577': bases.uniqueSimpleDay
+  # edition of
+  'wdt:P629': bases.workEntity
   # Open Library id
-  'wdt:P648': externalId /^OL[1-9]\d{0,7}[AMW]$/
+  'wdt:P648': builders.externalId /^OL[1-9]\d{0,7}[AMW]$/
   # translator
-  'wdt:P655': humanEntity
+  'wdt:P655': bases.humanEntity
   # influenced by
-  'wdt:P737': entityBase
+  'wdt:P737': bases.entity
   # narrative set in
-  'wdt:P840': entityBase
+  'wdt:P840': bases.entity
   # official website
-  'wdt:P856': urlBase
+  'wdt:P856': bases.url
   # main subject
-  'wdt:P921': entityBase
+  'wdt:P921': bases.entity
   # inspired by
-  'wdt:P941': workEntity
+  'wdt:P941': bases.workEntity
   # ISBN 10
-  'wdt:P957': isbnProperty 10
+  'wdt:P957': builders.isbnProperty 10
   # number of pages
-  'wdt:P1104': positiveIntegerBase
+  'wdt:P1104': bases.positiveInteger
   # languages of expression
-  'wdt:P1412': entityBase
+  'wdt:P1412': bases.entity
   # title
-  'wdt:P1476': stringUniqueBase
+  'wdt:P1476': bases.uniqueString
   # series ordinal
-  'wdt:P1545': ordinalBase
+  'wdt:P1545': bases.ordinal
   # subtitle
-  'wdt:P1680': stringUniqueBase
+  'wdt:P1680': bases.uniqueString
   # Twitter account
-  'wdt:P2002': externalId /^\w{1,15}$/
+  'wdt:P2002': builders.externalId /^\w{1,15}$/
   # Instagram username
-  'wdt:P2003': externalId /^(\w(?:(?:\w|(?:\\.(?!\\.))){0,28}(?:\w))?)$/
+  'wdt:P2003': builders.externalId /^(\w(?:(?:\w|(?:\\.(?!\\.))){0,28}(?:\w))?)$/
   # Facebook profile id
-  'wdt:P2013': externalId /^(\d+|[\w\.]+)$/
+  'wdt:P2013': builders.externalId /^(\d+|[\w\.]+)$/
   # YouTube channel ID
-  'wdt:P2397': externalId /^UC[\w\-]{21}[AQgw]$/
+  'wdt:P2397': builders.externalId /^UC[\w\-]{21}[AQgw]$/
   # number of volumes
-  'wdt:P2635': positiveIntegerBase
+  'wdt:P2635': bases.positiveInteger
   # author of foreword
-  'wdt:P2679': humanEntity
+  'wdt:P2679': bases.humanEntity
   # author of afterword
-  'wdt:P2680': humanEntity
+  'wdt:P2680': bases.humanEntity
   # Mastodon address
-  'wdt:P4033': externalId /^\w+@[a-z0-9\.\-]+[a-z0-9]+$/
+  'wdt:P4033': builders.externalId /^\w+@[a-z0-9\.\-]+[a-z0-9]+$/
 
 whitelist = Object.keys properties
-
-validateProperty = (property)->
-  unless /^wdt:P\d+$/.test property
-    throw error_.new 'invalid property', 400, property
-
-  unless property in whitelist
-    throw error_.new "property isn't whitelisted", 400, property
 
 # which type those datatype should returned when passed to _.typeOf
 datatypePrimordialType =
@@ -173,11 +118,16 @@ propertyDatatypePrimordialType = (property)->
   { datatype } = properties[property]
   return datatypePrimordialType[datatype]
 
-testDataType = (property, value)-> _.typeOf(value) is propertyDatatypePrimordialType(property)
+module.exports =
+  properties: properties
+  propertyDatatypePrimordialType: propertyDatatypePrimordialType
 
-module.exports = {
-  properties,
-  validateProperty,
-  testDataType,
-  propertyDatatypePrimordialType
-}
+  validateProperty: (property)->
+    unless /^wdt:P\d+$/.test property
+      throw error_.new 'invalid property', 400, property
+
+    unless property in whitelist
+      throw error_.new "property isn't whitelisted", 400, property
+
+  testDataType: (property, value)->
+    _.typeOf(value) is propertyDatatypePrimordialType(property)

--- a/server/controllers/entities/lib/properties.coffee
+++ b/server/controllers/entities/lib/properties.coffee
@@ -6,8 +6,8 @@ error_ = __.require 'lib', 'error/error'
 # Each property configuration object is made of the following attributes:
 
 # datatype: {String}
-# format: {Function}
-# test: {Function}
+# validate: {Function}
+# format: {Function} (optional)
 # uniqueValue: {Boolean} (default: false)
 # concurrency: {Boolean} (default: false)
 # adminUpdateOnly: {Boolean} (default: false)
@@ -129,5 +129,5 @@ module.exports =
     unless property in whitelist
       throw error_.new "property isn't whitelisted", 400, property
 
-  testDataType: (property, value)->
+  validateDataType: (property, value)->
     _.typeOf(value) is propertyDatatypePrimordialType(property)

--- a/server/controllers/entities/lib/properties_config_bases.coffee
+++ b/server/controllers/entities/lib/properties_config_bases.coffee
@@ -1,0 +1,64 @@
+CONFIG = require 'config'
+__ = CONFIG.universalPath
+_ = __.require 'builders', 'utils'
+error_ = __.require 'lib', 'error/error'
+wdk = require 'wikidata-sdk'
+isbn_ = __.require 'lib', 'isbn/isbn'
+{ EntityUri, SimpleDay } = __.require 'sharedLibs', 'regex'
+
+entity =
+  datatype: 'entity'
+  test: EntityUri.test.bind EntityUri
+  format: _.identity
+
+uniqueString =
+  datatype: 'string'
+  format: _.identity
+  # Arbitrary max length
+  test: (str)-> _.isString(str) and 0 < str.length < 5000
+  uniqueValue: true
+
+restrictedEntityType = (type)-> _.extend { restrictedType: type }, entity
+
+module.exports =
+  entity: entity
+  workEntity: restrictedEntityType 'work'
+  serieEntity: restrictedEntityType 'serie'
+  humanEntity: restrictedEntityType 'human'
+  uniqueEntity: _.extend {}, entity, { uniqueValue: true }
+
+  uniqueString: uniqueString
+  concurrentString: _.extend {}, uniqueString, { concurrency: true }
+  # For the moment, ordinals can be only positive integers, but stringified
+  # to stay consistent with Wikidata and let the door open to custom ordinals
+  # later (ex: roman numbers, letters, etc.)
+
+  url:
+    datatype: 'string'
+    test: _.isUrl
+    format: _.identity
+
+  uniqueSimpleDay:
+    datatype: 'simple-day'
+    # See SimpleDay specifications in [inventaire-client]/test/106-regex.coffee
+    test: _.isSimpleDay
+    format: _.identity
+    uniqueValue: true
+
+  positiveInteger:
+    datatype: 'positive-integer'
+    test: (value)-> _.isNumber(value) and value % 1 is 0 and value > 0
+    format: _.identity
+    uniqueValue: true
+
+  ordinal:
+    datatype: 'string'
+    format: _.identity
+    test: _.isPositiveIntegerString
+    uniqueValue: true
+
+  ipfsPath:
+    datatype: 'ipfs-path'
+    test: _.isIpfsPath
+    format: _.identity
+    uniqueValue: true

--- a/server/controllers/entities/lib/properties_config_bases.coffee
+++ b/server/controllers/entities/lib/properties_config_bases.coffee
@@ -9,7 +9,7 @@ isbn_ = __.require 'lib', 'isbn/isbn'
 
 entity =
   datatype: 'entity'
-  primordialDatatype: 'string'
+  type: 'string'
   validate: EntityUri.test.bind EntityUri
 
 uniqueString =
@@ -39,14 +39,14 @@ module.exports =
 
   uniqueSimpleDay:
     datatype: 'simple-day'
-    primordialDatatype: 'string'
+    type: 'string'
     # See SimpleDay specifications in [inventaire-client]/test/106-regex.coffee
     validate: _.isSimpleDay
     uniqueValue: true
 
   positiveInteger:
     datatype: 'positive-integer'
-    primordialDatatype: 'number'
+    type: 'number'
     validate: (value)-> _.isNumber(value) and value % 1 is 0 and value > 0
     uniqueValue: true
 
@@ -57,6 +57,6 @@ module.exports =
 
   ipfsPath:
     datatype: 'ipfs-path'
-    primordialDatatype: 'string'
+    type: 'string'
     validate: _.isIpfsPath
     uniqueValue: true

--- a/server/controllers/entities/lib/properties_config_bases.coffee
+++ b/server/controllers/entities/lib/properties_config_bases.coffee
@@ -9,12 +9,12 @@ isbn_ = __.require 'lib', 'isbn/isbn'
 
 entity =
   datatype: 'entity'
-  test: EntityUri.test.bind EntityUri
+  validate: EntityUri.test.bind EntityUri
 
 uniqueString =
   datatype: 'string'
   # Arbitrary max length
-  test: BoundedString 1, 5000
+  validate: BoundedString 1, 5000
   uniqueValue: true
 
 restrictedEntityType = (type)-> _.extend { restrictedType: type }, entity
@@ -34,25 +34,25 @@ module.exports =
 
   url:
     datatype: 'string'
-    test: _.isUrl
+    validate: _.isUrl
 
   uniqueSimpleDay:
     datatype: 'simple-day'
     # See SimpleDay specifications in [inventaire-client]/test/106-regex.coffee
-    test: _.isSimpleDay
+    validate: _.isSimpleDay
     uniqueValue: true
 
   positiveInteger:
     datatype: 'positive-integer'
-    test: (value)-> _.isNumber(value) and value % 1 is 0 and value > 0
+    validate: (value)-> _.isNumber(value) and value % 1 is 0 and value > 0
     uniqueValue: true
 
   ordinal:
     datatype: 'string'
-    test: _.isPositiveIntegerString
+    validate: _.isPositiveIntegerString
     uniqueValue: true
 
   ipfsPath:
     datatype: 'ipfs-path'
-    test: _.isIpfsPath
+    validate: _.isIpfsPath
     uniqueValue: true

--- a/server/controllers/entities/lib/properties_config_bases.coffee
+++ b/server/controllers/entities/lib/properties_config_bases.coffee
@@ -9,6 +9,7 @@ isbn_ = __.require 'lib', 'isbn/isbn'
 
 entity =
   datatype: 'entity'
+  primordialDatatype: 'string'
   validate: EntityUri.test.bind EntityUri
 
 uniqueString =
@@ -38,12 +39,14 @@ module.exports =
 
   uniqueSimpleDay:
     datatype: 'simple-day'
+    primordialDatatype: 'string'
     # See SimpleDay specifications in [inventaire-client]/test/106-regex.coffee
     validate: _.isSimpleDay
     uniqueValue: true
 
   positiveInteger:
     datatype: 'positive-integer'
+    primordialDatatype: 'number'
     validate: (value)-> _.isNumber(value) and value % 1 is 0 and value > 0
     uniqueValue: true
 
@@ -54,5 +57,6 @@ module.exports =
 
   ipfsPath:
     datatype: 'ipfs-path'
+    primordialDatatype: 'string'
     validate: _.isIpfsPath
     uniqueValue: true

--- a/server/controllers/entities/lib/properties_config_bases.coffee
+++ b/server/controllers/entities/lib/properties_config_bases.coffee
@@ -5,6 +5,7 @@ error_ = __.require 'lib', 'error/error'
 wdk = require 'wikidata-sdk'
 isbn_ = __.require 'lib', 'isbn/isbn'
 { EntityUri, SimpleDay } = __.require 'sharedLibs', 'regex'
+{ BoundedString } = __.require 'models', 'tests/common'
 
 entity =
   datatype: 'entity'
@@ -13,7 +14,7 @@ entity =
 uniqueString =
   datatype: 'string'
   # Arbitrary max length
-  test: (str)-> _.isString(str) and 0 < str.length < 5000
+  test: BoundedString 1, 5000
   uniqueValue: true
 
 restrictedEntityType = (type)-> _.extend { restrictedType: type }, entity

--- a/server/controllers/entities/lib/properties_config_bases.coffee
+++ b/server/controllers/entities/lib/properties_config_bases.coffee
@@ -9,11 +9,9 @@ isbn_ = __.require 'lib', 'isbn/isbn'
 entity =
   datatype: 'entity'
   test: EntityUri.test.bind EntityUri
-  format: _.identity
 
 uniqueString =
   datatype: 'string'
-  format: _.identity
   # Arbitrary max length
   test: (str)-> _.isString(str) and 0 < str.length < 5000
   uniqueValue: true
@@ -36,29 +34,24 @@ module.exports =
   url:
     datatype: 'string'
     test: _.isUrl
-    format: _.identity
 
   uniqueSimpleDay:
     datatype: 'simple-day'
     # See SimpleDay specifications in [inventaire-client]/test/106-regex.coffee
     test: _.isSimpleDay
-    format: _.identity
     uniqueValue: true
 
   positiveInteger:
     datatype: 'positive-integer'
     test: (value)-> _.isNumber(value) and value % 1 is 0 and value > 0
-    format: _.identity
     uniqueValue: true
 
   ordinal:
     datatype: 'string'
-    format: _.identity
     test: _.isPositiveIntegerString
     uniqueValue: true
 
   ipfsPath:
     datatype: 'ipfs-path'
     test: _.isIpfsPath
-    format: _.identity
     uniqueValue: true

--- a/server/controllers/entities/lib/properties_config_builders.coffee
+++ b/server/controllers/entities/lib/properties_config_builders.coffee
@@ -7,7 +7,7 @@ isbn_ = __.require 'lib', 'isbn/isbn'
 module.exports =
   isbnProperty: (num)->
     _.extend {}, concurrentString,
-      test: (isbn)-> isbn? and isbn is isbn_.parse(isbn)?["isbn#{num}h"]
+      validate: (isbn)-> isbn? and isbn is isbn_.parse(isbn)?["isbn#{num}h"]
       uniqueValue: true
       format: isbn_["toIsbn#{num}h"]
       adminUpdateOnly: true
@@ -16,4 +16,4 @@ module.exports =
   # on their Wikidata property page P1793 statement
   externalId: (regex)->
     _.extend {}, concurrentString,
-      test: regex.test.bind regex
+      validate: regex.test.bind regex

--- a/server/controllers/entities/lib/properties_config_builders.coffee
+++ b/server/controllers/entities/lib/properties_config_builders.coffee
@@ -1,0 +1,19 @@
+CONFIG = require 'config'
+__ = CONFIG.universalPath
+_ = __.require 'builders', 'utils'
+isbn_ = __.require 'lib', 'isbn/isbn'
+{ concurrentString } = require './properties_config_bases'
+
+module.exports =
+  isbnProperty: (num)->
+    _.extend {}, concurrentString,
+      test: (isbn)-> isbn? and isbn is isbn_.parse(isbn)?["isbn#{num}h"]
+      uniqueValue: true
+      format: isbn_["toIsbn#{num}h"]
+      adminUpdateOnly: true
+
+  # External ids regexs can be found
+  # on their Wikidata property page P1793 statement
+  externalId: (regex)->
+    _.extend {}, concurrentString,
+      test: regex.test.bind regex

--- a/server/controllers/entities/lib/validate_claim_value.coffee
+++ b/server/controllers/entities/lib/validate_claim_value.coffee
@@ -11,7 +11,7 @@ lateRequire = ->
   entities_ = require './entities'
 setTimeout lateRequire, 0
 
-{ properties, validateDataType, propertyDatatypePrimordialType } = require './properties'
+{ properties, validateDataType, expectedDatatype } = require './properties'
 
 module.exports = (db)->
   validateClaimValue = (params)->
@@ -29,9 +29,9 @@ module.exports = (db)->
       return error_.reject "updating property requires admin's rights", 403, property, newVal
 
     unless validateDataType property, newVal
-      expectedDatatype = propertyDatatypePrimordialType property
-      realDatatype = _.typeOf newVal
-      context = "expected #{expectedDatatype}, got #{realDatatype}"
+      expected = expectedDatatype(property)
+      actual = _.typeOf newVal
+      context = "expected #{expected}, got #{actual}"
       return error_.reject "invalid value datatype: #{context}", 400, property, newVal
 
     unless prop.validate newVal

--- a/server/controllers/entities/lib/validate_claim_value.coffee
+++ b/server/controllers/entities/lib/validate_claim_value.coffee
@@ -11,7 +11,7 @@ lateRequire = ->
   entities_ = require './entities'
 setTimeout lateRequire, 0
 
-{ properties, testDataType, propertyDatatypePrimordialType } = require './properties'
+{ properties, validateDataType, propertyDatatypePrimordialType } = require './properties'
 
 module.exports = (db)->
   validateClaimValue = (params)->
@@ -28,10 +28,10 @@ module.exports = (db)->
     if updatingValue and prop.adminUpdateOnly and not userIsAdmin
       return error_.reject "updating property requires admin's rights", 403, property, newVal
 
-    unless prop.test newVal
+    unless prop.validate newVal
       return error_.reject 'invalid property value', 400, property, newVal
 
-    unless testDataType property, newVal
+    unless validateDataType property, newVal
       expectedDatatype = propertyDatatypePrimordialType property
       realDatatype = _.typeOf newVal
       context = "expected #{expectedDatatype}, got #{realDatatype}"

--- a/server/controllers/entities/lib/validate_claim_value.coffee
+++ b/server/controllers/entities/lib/validate_claim_value.coffee
@@ -44,7 +44,7 @@ module.exports = (db)->
       if propArray?.length > 0 and oldVal isnt propArray[0]
         return error_.reject 'this property accepts only one value', 400, arguments
 
-    formattedValue = prop.format newVal
+    formattedValue = if prop.format? then prop.format(newVal) else newVal
 
     # Resolve only if all async tests pass
     return promises_.all [

--- a/server/controllers/entities/lib/validate_claim_value.coffee
+++ b/server/controllers/entities/lib/validate_claim_value.coffee
@@ -11,7 +11,7 @@ lateRequire = ->
   entities_ = require './entities'
 setTimeout lateRequire, 0
 
-{ properties, validateDataType, expectedDatatype } = require './properties'
+{ properties, validateType, expectedType } = require './properties'
 
 module.exports = (db)->
   validateClaimValue = (params)->
@@ -28,11 +28,11 @@ module.exports = (db)->
     if updatingValue and prop.adminUpdateOnly and not userIsAdmin
       return error_.reject "updating property requires admin's rights", 403, property, newVal
 
-    unless validateDataType property, newVal
-      expected = expectedDatatype(property)
+    unless validateType property, newVal
+      expected = expectedType property
       actual = _.typeOf newVal
-      context = "expected #{expected}, got #{actual}"
-      return error_.reject "invalid value datatype: #{context}", 400, property, newVal
+      message = "invalid value type: expected #{expected}, got #{actual}"
+      return error_.reject message, 400, property, newVal
 
     unless prop.validate newVal
       return error_.reject 'invalid property value', 400, property, newVal

--- a/server/controllers/entities/lib/validate_claim_value.coffee
+++ b/server/controllers/entities/lib/validate_claim_value.coffee
@@ -28,14 +28,14 @@ module.exports = (db)->
     if updatingValue and prop.adminUpdateOnly and not userIsAdmin
       return error_.reject "updating property requires admin's rights", 403, property, newVal
 
-    unless prop.validate newVal
-      return error_.reject 'invalid property value', 400, property, newVal
-
     unless validateDataType property, newVal
       expectedDatatype = propertyDatatypePrimordialType property
       realDatatype = _.typeOf newVal
       context = "expected #{expectedDatatype}, got #{realDatatype}"
       return error_.reject "invalid value datatype: #{context}", 400, property, newVal
+
+    unless prop.validate newVal
+      return error_.reject 'invalid property value', 400, property, newVal
 
     # If the property expects a uniqueValue and that there is already a value defined
     # any action other than editing the current value should be rejected

--- a/server/models/tests/common.coffee
+++ b/server/models/tests/common.coffee
@@ -35,11 +35,6 @@ tests.boundedString = boundedString = (str, minLength, maxLength)->
 tests.BoundedString = (minLength, maxLength)-> (str)->
   boundedString str, minLength, maxLength
 
-# no item of this app could have a timestamp before june 2014
-June2014 = 1402351200000
-tests.EpochMs =
-  test: (time)-> June2014 < time <= Date.now()
-
 tests.imgUrl = (url)-> tests.localImg(url) or _.isUrl(url) or _.isIpfsPath(url)
 
 tests.valid = (attribute, value, option)->

--- a/server/models/tests/common.coffee
+++ b/server/models/tests/common.coffee
@@ -29,11 +29,11 @@ module.exports = tests =
     if latLng is null then return true
     _.isArray(latLng) and latLng.length is 2 and _.all latLng, _.isNumber
 
-limitedString = (str, minLength, maxLength)->
+tests.boundedString = boundedString = (str, minLength, maxLength)->
   return _.isString(str) and minLength <= str.length <= maxLength
 
-tests.underLimitString = (maxLength)-> (str)-> limitedString str, 0, maxLength
-tests.nonEmptyString = (str, maxLength = 100)-> limitedString str, 1, maxLength
+tests.BoundedString = (minLength, maxLength)-> (str)->
+  boundedString str, minLength, maxLength
 
 # no item of this app could have a timestamp before june 2014
 June2014 = 1402351200000

--- a/server/models/tests/group.coffee
+++ b/server/models/tests/group.coffee
@@ -1,7 +1,8 @@
 CONFIG = require 'config'
 __ = CONFIG.universalPath
+_ = __.require 'builders', 'utils'
 slugify = __.require 'controllers', 'groups/lib/slugify'
-{ pass, underLimitString, nonEmptyString, localImg, boolean, position } = require './common'
+{ pass, boundedString, BoundedString, localImg, boolean, position } = require './common'
 
 module.exports =
   pass: pass
@@ -11,8 +12,8 @@ module.exports =
   # Group.tests[attribute](value)
 
   # Make sure the generated slug isn't an empty string
-  name: (str)-> nonEmptyString(str, 60) and nonEmptyString(slugify(str))
+  name: (str)-> boundedString(str, 1, 60) and _.isNonEmptyString(slugify(str))
   picture: localImg
-  description: underLimitString 5000
+  description: BoundedString 0, 5000
   searchable: boolean
   position: position

--- a/server/models/tests/item.coffee
+++ b/server/models/tests/item.coffee
@@ -1,7 +1,7 @@
 CONFIG = require 'config'
 __ = CONFIG.universalPath
 _ = __.require 'builders', 'utils'
-{ pass, itemId, userId, entityUri, nonEmptyString, imgUrl } = require './common'
+{ pass, itemId, userId, entityUri, BoundedString, imgUrl } = require './common'
 { constrained } = require '../attributes/item'
 
 module.exports = itemTests =
@@ -25,7 +25,7 @@ module.exports = itemTests =
     return true
 
 itemTests.snapshotTests = snapshotTests =
-  'entity:title': (str)-> nonEmptyString str, 500
+  'entity:title': BoundedString 1, 500
   'entity:image': _.isExtendedUrl
   'entity:lang': _.isLang
   'entity:authors': _.isString

--- a/server/models/tests/user.coffee
+++ b/server/models/tests/user.coffee
@@ -3,7 +3,7 @@ __ = CONFIG.universalPath
 _ = __.require 'builders', 'utils'
 notificationsSettingsList = __.require 'sharedLibs', 'notifications_settings_list'
 
-{ pass, userId, username, email, localImg, boolean, position } = require './common'
+{ pass, userId, username, email, localImg, boolean, position, BoundedString } = require './common'
 
 creationStrategies = ['local']
 
@@ -12,12 +12,12 @@ module.exports = tests =
   userId: userId
   username: username
   email: email
-  password: (password)->  8 <= password.length <= 60
+  password: BoundedString 8, 128
   # accepting second level languages (like es-AR) but only using first level yet
   language: (lang)-> /^\w{2}(-\w{2})?$/.test(lang)
   picture: localImg
   creationStrategy: (creationStrategy)-> creationStrategy in creationStrategies
-  bio: (bio)-> _.isString(bio) and bio.length < 1000
+  bio: BoundedString 0, 1000
   settings: boolean
   position: position
   summaryPeriodicity: (days)-> Number.isInteger(days) and days >= 1

--- a/test/controllers/011-properties.coffee
+++ b/test/controllers/011-properties.coffee
@@ -3,16 +3,16 @@ __ = CONFIG.universalPath
 _ = __.require 'builders', 'utils'
 should = require 'should'
 
-{ testDataType } = __.require 'controllers', 'entities/lib/properties'
+{ validateDataType } = __.require 'controllers', 'entities/lib/properties'
 
 describe 'properties', ->
-  describe 'testDataType', ->
+  describe 'validateDataType', ->
     it 'should return false when passed the wrong type', (done)->
-      testDataType('wdt:P50', 123).should.equal false
-      testDataType('wdt:P212', null).should.equal false
+      validateDataType('wdt:P50', 123).should.equal false
+      validateDataType('wdt:P212', null).should.equal false
       done()
 
     it 'should return true when passed the right type', (done)->
-      testDataType('wdt:P50', 'not a qid but a proper string').should.equal true
-      testDataType('wdt:P212', 'not an isbn but a proper string').should.equal true
+      validateDataType('wdt:P50', 'not a qid but a proper string').should.equal true
+      validateDataType('wdt:P212', 'not an isbn but a proper string').should.equal true
       done()

--- a/test/controllers/011-properties.coffee
+++ b/test/controllers/011-properties.coffee
@@ -3,16 +3,16 @@ __ = CONFIG.universalPath
 _ = __.require 'builders', 'utils'
 should = require 'should'
 
-{ validateDataType } = __.require 'controllers', 'entities/lib/properties'
+{ validateType } = __.require 'controllers', 'entities/lib/properties'
 
 describe 'properties', ->
-  describe 'validateDataType', ->
+  describe 'validateType', ->
     it 'should return false when passed the wrong type', (done)->
-      validateDataType('wdt:P50', 123).should.equal false
-      validateDataType('wdt:P212', null).should.equal false
+      validateType('wdt:P50', 123).should.equal false
+      validateType('wdt:P212', null).should.equal false
       done()
 
     it 'should return true when passed the right type', (done)->
-      validateDataType('wdt:P50', 'not a qid but a proper string').should.equal true
-      validateDataType('wdt:P212', 'not an isbn but a proper string').should.equal true
+      validateType('wdt:P50', 'not a qid but a proper string').should.equal true
+      validateType('wdt:P212', 'not an isbn but a proper string').should.equal true
       done()

--- a/test/models/022-user.coffee
+++ b/test/models/022-user.coffee
@@ -85,7 +85,7 @@ describe 'user model', ->
         done()
 
       it 'should throw on passwords too long', (done)->
-        tooLongPassword = [0..10].join('hello')
+        tooLongPassword = [0..10].join('hellohellohello')
         args = replaceParam 4, tooLongPassword
         (-> _create(args)).should.throw()
         done()


### PR DESCRIPTION
properties configuration object were a bit hard to read for new comers:
- splitted and restructed the main file
- removed the unnecessary `format: _.identity` functions
- took the occasion of cleaning a property config validation test to do some cleaning on string validation functions