### PR TITLE
Design doc sync

### DIFF
--- a/config/default.coffee
+++ b/config/default.coffee
@@ -57,6 +57,8 @@ module.exports = config =
       delay: 5000
     # logs Couchdb requests parameters
     debug: false
+    # Keep the design doc files in sync with CouchDB design docs
+    enableDesignDocSync: false
     # db settings for script actions
     # see scripts/lib/action_by_input.coffee
     actionsScripts:

--- a/config/dev.coffee
+++ b/config/dev.coffee
@@ -7,3 +7,5 @@ module.exports =
     enabled: true
   entitiesSearchEngine:
     delay: 5000
+  db:
+    enableDesignDocSync: true

--- a/db/couchdb/design_docs/comments.json
+++ b/db/couchdb/design_docs/comments.json
@@ -1,15 +1,15 @@
 {
-   "_id": "_design/comments",
-   "language": "coffeescript",
-   "views": {
-       "byItemId": {
-           "map": "(doc)->\n  if doc.item?\n    emit doc.item, null"
-       },
-       "byTransactionId": {
-           "map": "(doc)->\n  if doc.transaction?\n    emit doc.transaction, null"
-       },
-       "bySubjectAndUserId": {
-           "map": "(doc)->\n  if doc.item? then emit ['item', doc.user], null\n  else if doc.transaction? then emit ['transaction', doc.user], null"
-       }
-   }
+  "_id": "_design/comments",
+  "language": "coffeescript",
+  "views": {
+    "byItemId": {
+      "map": "(doc)->\n  if doc.item?\n    emit doc.item, null"
+    },
+    "byTransactionId": {
+      "map": "(doc)->\n  if doc.transaction?\n    emit doc.transaction, null"
+    },
+    "bySubjectAndUserId": {
+      "map": "(doc)->\n  if doc.item? then emit ['item', doc.user], null\n  else if doc.transaction? then emit ['transaction', doc.user], null"
+    }
+  }
 }

--- a/db/couchdb/design_docs/entities.json
+++ b/db/couchdb/design_docs/entities.json
@@ -1,16 +1,16 @@
 {
-   "_id": "_design/entities",
-   "language": "coffeescript",
-   "views": {
-       "byClaim": {
-           "map": "(doc)->\n  if doc.type is 'entity'\n    for property, statements of doc.claims\n      for value in statements\n        emit [property, value], doc.claims['wdt:P31'][0]"
-       },
-       "byClaimValue": {
-           "map": "(doc)->\n  if doc.type is 'entity'\n    for property, statements of doc.claims\n      for value in statements\n        emit value, property"
-       }
-   },
-   "filters": {
-       "entities:only": "(doc)-> doc.type is 'entity'",
-       "patches:only": "(doc)-> doc.type is 'patch'"
-   }
+  "_id": "_design/entities",
+  "language": "coffeescript",
+  "views": {
+    "byClaim": {
+      "map": "(doc)->\n  if doc.type is 'entity'\n    for property, statements of doc.claims\n      for value in statements\n        emit [property, value], doc.claims['wdt:P31'][0]"
+    },
+    "byClaimValue": {
+      "map": "(doc)->\n  if doc.type is 'entity'\n    for property, statements of doc.claims\n      for value in statements\n        emit value, property"
+    }
+  },
+  "filters": {
+    "entities:only": "(doc)-> doc.type is 'entity'",
+    "patches:only": "(doc)-> doc.type is 'patch'"
+  }
 }

--- a/db/couchdb/design_docs/entities_deduplicate.json
+++ b/db/couchdb/design_docs/entities_deduplicate.json
@@ -1,10 +1,10 @@
 {
-   "_id": "_design/entities_deduplicate",
-   "language": "coffeescript",
-   "views": {
-       "findHumansHomonymes": {
-           "map": "(doc)->\n  if doc.type isnt 'entity' then return\n\n  normalize = (label)->\n    label\n    .trim()\n    .replace(/\\s\\w{1}\\.\\s?/g, ' ')\n    .replace(/\\s\\s/g, ' ')\n    .toLowerCase()\n\n  # Keep only humans\n  unless doc.claims?['wdt:P31']?[0] is 'wd:Q5' then return\n\n  if doc.labels? and doc.claims?\n\n    labelsSet = {}\n\n    for lang, label of doc.labels\n      normalizedLabel = normalize label\n      labelsSet[normalizedLabel] = true\n\n    # Use a set to prevent emitting several times the same label\n    # just because an entity as the same label in several languages\n    Object.keys(labelsSet).forEach (label)-> emit label, null\n",
-           "reduce": "_count"
-       }
-   }
+  "_id": "_design/entities_deduplicate",
+  "language": "coffeescript",
+  "views": {
+    "findHumansHomonymes": {
+      "map": "(doc)->\n  if doc.type isnt 'entity' then return\n\n  normalize = (label)->\n    label\n    .trim()\n    .replace(/\\s\\w{1}\\.\\s?/g, ' ')\n    .replace(/\\s\\s/g, ' ')\n    .toLowerCase()\n\n  # Keep only humans\n  unless doc.claims?['wdt:P31']?[0] is 'wd:Q5' then return\n\n  if doc.labels? and doc.claims?\n\n    labelsSet = {}\n\n    for lang, label of doc.labels\n      normalizedLabel = normalize label\n      labelsSet[normalizedLabel] = true\n\n    # Use a set to prevent emitting several times the same label\n    # just because an entity as the same label in several languages\n    Object.keys(labelsSet).forEach (label)-> emit label, null\n",
+      "reduce": "_count"
+    }
+  }
 }

--- a/db/couchdb/design_docs/followedEntities.json
+++ b/db/couchdb/design_docs/followedEntities.json
@@ -1,9 +1,9 @@
 {
-   "_id": "_design/followedEntities",
-   "language": "coffeescript",
-   "views": {
-       "byUser": {
-           "map": "(doc)->\n  if doc.transaction is 'following'\n    emit doc._id.split(':')[0], null"
-       }
-   }
+  "_id": "_design/followedEntities",
+  "language": "coffeescript",
+  "views": {
+    "byUser": {
+      "map": "(doc)->\n  if doc.transaction is 'following'\n    emit doc._id.split(':')[0], null"
+    }
+  }
 }

--- a/db/couchdb/design_docs/followedEntities.json
+++ b/db/couchdb/design_docs/followedEntities.json
@@ -1,9 +1,0 @@
-{
-  "_id": "_design/followedEntities",
-  "language": "coffeescript",
-  "views": {
-    "byUser": {
-      "map": "(doc)->\n  if doc.transaction is 'following'\n    emit doc._id.split(':')[0], null"
-    }
-  }
-}

--- a/db/couchdb/design_docs/groups.json
+++ b/db/couchdb/design_docs/groups.json
@@ -1,27 +1,27 @@
 {
-   "_id": "_design/groups",
-   "language": "coffeescript",
-   "views": {
-       "byId": {
-           "map": "(doc)->\n  if doc.type is 'group'\n    emit doc._id, null"
-       },
-       "bySlug": {
-           "map": "(doc)->\n  if doc.type is 'group'\n    emit doc.slug, null"
-       },
-       "byUser": {
-           "map": "(doc)->\n  if doc.type is 'group'\n    for member in doc.members\n      emit member.user, null\n    for admin in doc.admins\n      emit admin.user, null"
-       },
-       "byName": {
-           "map": "(doc)->\n  if doc.type is 'group'\n    emit doc.name.toLowerCase(), null"
-       },
-       "byInvitedUser": {
-           "map": "(doc)->\n  if doc.type is 'group'\n    for invitation in doc.invited\n      emit invitation.user, null"
-       },
-       "byCreation": {
-           "map": "(doc)->\n  if doc.type is 'group'\n    emit doc.created, null"
-       },
-       "byGeoSquare": {
-           "map": "(doc)->\n  if doc.type is 'group' and doc.position?\n    [lat, lng] = doc.position\n    lat = Math.floor lat\n    lng = Math.floor lng\n    emit [lat,lng], null"
-       }
-   }
+  "_id": "_design/groups",
+  "language": "coffeescript",
+  "views": {
+    "byId": {
+      "map": "(doc)->\n  if doc.type is 'group'\n    emit doc._id, null"
+    },
+    "bySlug": {
+      "map": "(doc)->\n  if doc.type is 'group'\n    emit doc.slug, null"
+    },
+    "byUser": {
+      "map": "(doc)->\n  if doc.type is 'group'\n    for member in doc.members\n      emit member.user, null\n    for admin in doc.admins\n      emit admin.user, null"
+    },
+    "byName": {
+      "map": "(doc)->\n  if doc.type is 'group'\n    emit doc.name.toLowerCase(), null"
+    },
+    "byInvitedUser": {
+      "map": "(doc)->\n  if doc.type is 'group'\n    for invitation in doc.invited\n      emit invitation.user, null"
+    },
+    "byCreation": {
+      "map": "(doc)->\n  if doc.type is 'group'\n    emit doc.created, null"
+    },
+    "byGeoSquare": {
+      "map": "(doc)->\n  if doc.type is 'group' and doc.position?\n    [lat, lng] = doc.position\n    lat = Math.floor lat\n    lng = Math.floor lng\n    emit [lat,lng], null"
+    }
+  }
 }

--- a/db/couchdb/design_docs/invited.json
+++ b/db/couchdb/design_docs/invited.json
@@ -3,10 +3,10 @@
   "language": "coffeescript",
   "views": {
     "byId": {
-       "map": "(doc)->\n  if doc.type is 'invited'\n    emit doc._id, null"
+      "map": "(doc)->\n  if doc.type is 'invited'\n    emit doc._id, null"
     },
     "byEmail": {
-       "map": "(doc)->\n  if doc.type is 'invited'\n    emit doc.email.toLowerCase(), null"
+      "map": "(doc)->\n  if doc.type is 'invited'\n    emit doc.email.toLowerCase(), null"
     }
   }
 }

--- a/db/couchdb/design_docs/items.json
+++ b/db/couchdb/design_docs/items.json
@@ -1,30 +1,30 @@
 {
-   "_id": "_design/items",
-   "language": "coffeescript",
-   "views": {
-       "byDate": {
-           "map": "(doc)->\n  emit doc.created, [doc._id, doc.title]"
-       },
-       "byListing": {
-           "map": "(doc)->\n  if doc.listing?\n    emit [doc.owner,doc.listing], null"
-       },
-       "publicByDate": {
-           "map": "(doc)->\n  if doc.listing is 'public'\n    emit doc.created, null"
-       },
-       "byOwnerAndEntityAndListing": {
-           "map": "(doc)->\n  emit [doc.owner, doc.entity, doc.listing], null"
-       },
-       "byEntity": {
-           "map": "(doc)->\n    if doc.entity?\n      emit [doc.entity, doc.listing], null"
-       },
-       "missingPicture": {
-           "map": "(doc)->\n  if doc.title?\n    if doc.pictures.length is 0\n      emit doc.created, null"
-       },
-       "byPreviousEntity": {
-           "map": "(doc)->\n    if doc.previousEntity?\n      for uri in doc.previousEntity\n        emit uri, null"
-       },
-       "publicByLangAndDate": {
-           "map": "(doc)->\n  if doc.listing is 'public' and doc.snapshot?\n    lang = doc.snapshot['entity:lang']\n    emit [ lang, doc.created ], null"
-       }
-   }
+  "_id": "_design/items",
+  "language": "coffeescript",
+  "views": {
+    "byDate": {
+      "map": "(doc)->\n  emit doc.created, [doc._id, doc.title]"
+    },
+    "byListing": {
+      "map": "(doc)->\n  if doc.listing?\n    emit [doc.owner,doc.listing], null"
+    },
+    "publicByDate": {
+      "map": "(doc)->\n  if doc.listing is 'public'\n    emit doc.created, null"
+    },
+    "byOwnerAndEntityAndListing": {
+      "map": "(doc)->\n  emit [doc.owner, doc.entity, doc.listing], null"
+    },
+    "byEntity": {
+      "map": "(doc)->\n    if doc.entity?\n      emit [doc.entity, doc.listing], null"
+    },
+    "missingPicture": {
+      "map": "(doc)->\n  if doc.title?\n    if doc.pictures.length is 0\n      emit doc.created, null"
+    },
+    "byPreviousEntity": {
+      "map": "(doc)->\n    if doc.previousEntity?\n      for uri in doc.previousEntity\n        emit uri, null"
+    },
+    "publicByLangAndDate": {
+      "map": "(doc)->\n  if doc.listing is 'public' and doc.snapshot?\n    lang = doc.snapshot['entity:lang']\n    emit [ lang, doc.created ], null"
+    }
+  }
 }

--- a/db/couchdb/design_docs/notifications.json
+++ b/db/couchdb/design_docs/notifications.json
@@ -1,12 +1,12 @@
 {
-   "_id": "_design/notifications",
-   "language": "coffeescript",
-   "views": {
-       "byUserAndTime": {
-           "map": "(doc)->\n  emit [doc.user, doc.time], null"
-       },
-       "bySubject": {
-           "map": "(doc)->\n  data = doc.data\n  emit doc.user, 'user'\n  if data.user isnt doc.user then emit data.user, 'data:user'\n  switch doc.type\n    when 'newCommentOnFollowedItem' then emit data.item, 'item'\n    when 'groupUpdate', 'userMadeAdmin' then emit data.group, 'data:group'\n"
-       }
-   }
+  "_id": "_design/notifications",
+  "language": "coffeescript",
+  "views": {
+    "byUserAndTime": {
+      "map": "(doc)->\n  emit [doc.user, doc.time], null"
+    },
+    "bySubject": {
+      "map": "(doc)->\n  data = doc.data\n  emit doc.user, 'user'\n  if data.user isnt doc.user then emit data.user, 'data:user'\n  switch doc.type\n    when 'newCommentOnFollowedItem' then emit data.item, 'item'\n    when 'groupUpdate', 'userMadeAdmin' then emit data.group, 'data:group'\n"
+    }
+  }
 }

--- a/db/couchdb/design_docs/patches.json
+++ b/db/couchdb/design_docs/patches.json
@@ -1,17 +1,17 @@
 {
-   "_id": "_design/patches",
-   "language": "coffeescript",
-   "views": {
-       "byEntityId": {
-           "map": "(doc)->\n  emit doc._id.split(':')[0], null"
-       },
-       "byUserId": {
-           "map": "(doc)->\n  emit [doc.user, doc.timestamp], null",
-           "reduce": "_count"
-       },
-       "byDay": {
-           "map": "(doc)->\n  day = new Date(doc.timestamp).toISOString().split('T')[0]\n  emit [day, doc.user], null",
-           "reduce": "_count"
-       }
-   }
+  "_id": "_design/patches",
+  "language": "coffeescript",
+  "views": {
+    "byEntityId": {
+      "map": "(doc)->\n  emit doc._id.split(':')[0], null"
+    },
+    "byUserId": {
+      "map": "(doc)->\n  emit [doc.user, doc.timestamp], null",
+      "reduce": "_count"
+    },
+    "byDay": {
+      "map": "(doc)->\n  day = new Date(doc.timestamp).toISOString().split('T')[0]\n  emit [day, doc.user], null",
+      "reduce": "_count"
+    }
+  }
 }

--- a/db/couchdb/design_docs/relations.json
+++ b/db/couchdb/design_docs/relations.json
@@ -1,13 +1,13 @@
 {
-   "_id": "_design/relations",
-   "language": "coffeescript",
-   "views": {
-       "byStatus": {
-           "map": "(doc)->\n  if doc.type is 'relation'\n    [a, b] = doc._id.split ':'\n    switch doc.status\n      when 'friends'\n        emit [a,'friends'], b\n        emit [b,'friends'], a\n      when 'a-requested'\n        emit [a,'userRequested'], b\n        emit [b,'otherRequested'], a\n      when 'b-requested'\n        emit [b,'userRequested'], a\n        emit [a,'otherRequested'], b"
-       },
-       "friendsCount": {
-           "map": "(doc)->\n  if doc.type is 'relation'\n    [a, b] = doc._id.split ':'\n    switch doc.status\n      when 'friends'\n        emit a, null\n        emit b, null\n",
-           "reduce": "_count"
-       }
-   }
+  "_id": "_design/relations",
+  "language": "coffeescript",
+  "views": {
+    "byStatus": {
+      "map": "(doc)->\n  if doc.type is 'relation'\n    [a, b] = doc._id.split ':'\n    switch doc.status\n      when 'friends'\n        emit [a,'friends'], b\n        emit [b,'friends'], a\n      when 'a-requested'\n        emit [a,'userRequested'], b\n        emit [b,'otherRequested'], a\n      when 'b-requested'\n        emit [b,'userRequested'], a\n        emit [a,'otherRequested'], b"
+    },
+    "friendsCount": {
+      "map": "(doc)->\n  if doc.type is 'relation'\n    [a, b] = doc._id.split ':'\n    switch doc.status\n      when 'friends'\n        emit a, null\n        emit b, null\n",
+      "reduce": "_count"
+    }
+  }
 }

--- a/db/couchdb/design_docs/transactions.json
+++ b/db/couchdb/design_docs/transactions.json
@@ -1,9 +1,9 @@
 {
-   "_id": "_design/transactions",
-   "language": "coffeescript",
-   "views": {
-       "byUserAndItem": {
-           "map": "(doc)->\n  emit [doc.owner, doc.item], null\n  emit [doc.requester, doc.item], null"
-       }
-   }
+  "_id": "_design/transactions",
+  "language": "coffeescript",
+  "views": {
+    "byUserAndItem": {
+      "map": "(doc)->\n  emit [doc.owner, doc.item], null\n  emit [doc.requester, doc.item], null"
+    }
+  }
 }

--- a/db/couchdb/design_docs/users.json
+++ b/db/couchdb/design_docs/users.json
@@ -1,24 +1,24 @@
 {
-   "_id": "_design/users",
-   "language": "coffeescript",
-   "views": {
-       "byEmail": {
-           "map": "(doc)->\n  if doc.type is 'user'\n    emit doc.email.toLowerCase(), null"
-       },
-       "byUsername": {
-           "map": "(doc)->\n  if doc.type is 'user'\n    emit doc.username.toLowerCase(), null"
-       },
-       "byCreation": {
-           "map": "(doc)->\n  if doc.type is 'user'\n    emit doc.created, doc.username"
-       },
-       "byId": {
-           "map": "(doc)->\n  if doc.type is 'user'\n    emit doc._id, null"
-       },
-       "nextSummary": {
-           "map": "(doc)->\n  unless doc.type is 'user' then return\n  if doc.settings.notifications.global is false then return\n  if doc.settings.notifications['inventories_activity_summary'] is false then return\n  if doc.undeliveredEmail > 1 then return\n\n  lastSummary = doc.lastSummary or doc.created\n  summaryPeriodicity = doc.summaryPeriodicity or 20\n  nextSummary = lastSummary + summaryPeriodicity*24*3600*1000\n  emit nextSummary, null"
-       },
-       "byGeoSquare": {
-           "map": "(doc)->\n  if doc.type is 'user' and doc.position?\n    [lat, lng] = doc.position\n    lat = Math.floor lat\n    lng = Math.floor lng\n    emit [lat,lng], null"
-       }
-   }
+  "_id": "_design/users",
+  "language": "coffeescript",
+  "views": {
+    "byEmail": {
+      "map": "(doc)->\n  if doc.type is 'user'\n    emit doc.email.toLowerCase(), null"
+    },
+    "byUsername": {
+      "map": "(doc)->\n  if doc.type is 'user'\n    emit doc.username.toLowerCase(), null"
+    },
+    "byCreation": {
+      "map": "(doc)->\n  if doc.type is 'user'\n    emit doc.created, doc.username"
+    },
+    "byId": {
+      "map": "(doc)->\n  if doc.type is 'user'\n    emit doc._id, null"
+    },
+    "nextSummary": {
+      "map": "(doc)->\n  unless doc.type is 'user' then return\n  if doc.settings.notifications.global is false then return\n  if doc.settings.notifications['inventories_activity_summary'] is false then return\n  if doc.undeliveredEmail > 1 then return\n\n  lastSummary = doc.lastSummary or doc.created\n  summaryPeriodicity = doc.summaryPeriodicity or 20\n  nextSummary = lastSummary + summaryPeriodicity*24*3600*1000\n  emit nextSummary, null"
+    },
+    "byGeoSquare": {
+      "map": "(doc)->\n  if doc.type is 'user' and doc.position?\n    [lat, lng] = doc.position\n    lat = Math.floor lat\n    lng = Math.floor lng\n    emit [lat,lng], null"
+    }
+  }
 }

--- a/server/db/couch/init.coffee
+++ b/server/db/couch/init.coffee
@@ -4,6 +4,7 @@ _ = __.require 'builders', 'utils'
 couchInit = require 'couch-init2'
 dbBaseUrl = CONFIG.db.fullHost()
 initHardCodedDocuments = require './init_hard_coded_documents'
+initDesignDocSync = require './init_design_doc_sync'
 
 dbsList = require './list'
 formattedList = []
@@ -15,11 +16,12 @@ for dbName, designDocsNames of dbsList
     name: CONFIG.db.name dbName
     designDocs: designDocsNames
 
-designDocFolder = __.path('couchdb', 'design_docs')
+designDocFolder = __.path 'couchdb', 'design_docs'
 
 module.exports = ->
   couchInit dbBaseUrl, formattedList, designDocFolder
   .tap initHardCodedDocuments
+  .tap initDesignDocSync
   .catch (err)->
     if err.message isnt 'CouchDB name or password is incorrect' then throw err
 

--- a/server/db/couch/init_design_doc_sync.coffee
+++ b/server/db/couch/init_design_doc_sync.coffee
@@ -34,7 +34,7 @@ isDesignDoc = (designDocsNames)-> (doc)->
   return true
 
 syncDesignDocFile = (change)->
-  { id, deleted, doc } = change
+  { id, doc } = change
   designDocName = id.split('/')[1]
   designDocPath = "#{designDocFolder}/#{designDocName}.json"
 

--- a/server/db/couch/init_design_doc_sync.coffee
+++ b/server/db/couch/init_design_doc_sync.coffee
@@ -1,0 +1,53 @@
+# Keep the design doc files in sync with CouchDB design docs
+# once CouchDB design docs were updated to match the design doc files
+# This allows to modify design docs in CouchDB GUI instead of having
+# to change files manually, with all the formatting implied.
+# This only make sense in development
+
+CONFIG = require 'config'
+__ = CONFIG.universalPath
+_ = __.require 'builders', 'utils'
+fs_ = __.require 'lib', 'fs'
+follow = __.require 'lib', 'follow'
+dbsList = require './list'
+designDocFolder = __.path 'couchdb', 'design_docs'
+
+module.exports = ->
+  unless CONFIG.db.enableDesignDocSync then return
+  # Wait for the end of the server initalization
+  setTimeout init, 2000
+
+init = ->
+  for dbBaseName, designDocsNames of dbsList
+    follow
+      dbBaseName: dbBaseName
+      filter: isDesignDoc designDocsNames
+      onChange: syncDesignDocFile
+
+isDesignDoc = (designDocsNames)-> (doc)->
+  [ prefix, designDocsName ] = doc._id.split('/')
+  if prefix isnt '_design' then return false
+  # Design docs that aren't in the list aren't persisted:
+  # this allows to have draft design docs in CouchDB that aren't worth
+  # to be tracked by git without turning them into untracked files
+  if designDocsName not in designDocsNames then return false
+  return true
+
+syncDesignDocFile = (change)->
+  { id, deleted, doc } = change
+  designDocName = id.split('/')[1]
+  designDocPath = "#{designDocFolder}/#{designDocName}.json"
+
+  updatedDesignDoc = formatDesignDoc doc
+
+  fs_.readFile designDocPath, { encoding: 'utf-8'}
+  .then (file)->
+    if updatedDesignDoc is file then return
+    fs_.writeFile designDocPath, updatedDesignDoc
+    .then -> _.success "#{designDocName} design doc updated"
+  .catch _.Error("#{designDocName} design doc update err")
+
+formatDesignDoc = (doc)->
+  # Design docs are persisted without their _rev
+  doc = _.omit doc, '_rev'
+  return JSON.stringify doc, null, 2

--- a/server/db/couch/list.coffee
+++ b/server/db/couch/list.coffee
@@ -8,7 +8,7 @@
 module.exports =
   users: [ 'users', 'relations', 'invited' ]
   groups: [ 'groups' ]
-  items: [ 'items', 'followedEntities' ]
+  items: [ 'items' ]
   transactions: [ 'transactions' ]
   comments: [ 'comments' ]
   entities: [ 'entities', 'entities_deduplicate' ]

--- a/server/lib/follow.coffee
+++ b/server/lib/follow.coffee
@@ -46,7 +46,6 @@ module.exports = (params)->
 
 initFollow = (dbName)-> (lastSeq=0)->
   if resetFollow then lastSeq = 0
-  _.log lastSeq, "#{dbName} last seq"
   _.type lastSeq, 'number'
 
   config =
@@ -72,7 +71,6 @@ SetLastSeq = (dbName)->
   # as it could miss updates due to the debouncer
   setLastSeq = (seq)->
     meta.put key, seq
-    .then -> _.log seq, "#{dbName} last seq updated"
     .catch _.Error("#{dbName} setLastSeq err")
   # setLastSeq might be triggered many times if a log of changes arrive at once
   # no need to write to the database at each times, just the last


### PR DESCRIPTION
Keep the design doc files in sync with CouchDB design docs once CouchDB design docs were updated to match the design doc files. This allows to modify design docs in CouchDB GUI instead of having
to change files manually, with all the formatting implied.
This only make sense in development.