### PR TITLE
feedback endpoint: allow to pass entity URIs

### DIFF
--- a/server/controllers/feedback.coffee
+++ b/server/controllers/feedback.coffee
@@ -6,12 +6,17 @@ radio = __.require 'lib', 'radio'
 module.exports =
   post: (req, res, next)->
     { user } = req
-    { subject, message, unknownUser } = req.body
-    _.log { subject, message, unknownUser }, 'feedback'
+    { subject, message, uris, unknownUser } = req.body
+    _.log { subject, message, uris, unknownUser }, 'feedback'
 
     unless subject? or message?
       return error_.bundle req, res, 'message is empty', 400
 
-    radio.emit 'received:feedback', subject, message, user, unknownUser
+    if uris?
+      for uri in uris
+        unless _.isEntityUri uri
+          return error_.bundle req, res, 'invalid entity uri', 400, { uri }
+
+    radio.emit 'received:feedback', subject, message, user, unknownUser, uris
 
     _.ok res, 201

--- a/server/lib/emails/email.coffee
+++ b/server/lib/emails/email.coffee
@@ -88,7 +88,7 @@ module.exports =
       template: 'group'
       context: { title, button, group, groupContext, lang, host }
 
-  feedback: (subject, message, user, unknownUser)->
+  feedback: (subject, message, user, unknownUser, uris)->
     # no email settings to check here ;)
     username = user?.username or 'anonymous'
     return data =
@@ -96,7 +96,7 @@ module.exports =
       replyTo: user?.email
       subject: "[feedback][#{username}] #{subject}"
       template: 'feedback'
-      context: { subject, message, user , unknownUser }
+      context: { subject, message, user , unknownUser, uris, host }
 
   FriendInvitation: (inviter, message)->
     # No email settings to check here:

--- a/server/lib/emails/send_email.coffee
+++ b/server/lib/emails/send_email.coffee
@@ -38,8 +38,8 @@ module.exports =
     .catch helpers_.catchDisabledEmails
     .catch Err("group #{action}", actingUserId, userToNotifyId)
 
-  feedback: (subject, message, user, unknownUser)->
-    email = email_.feedback(subject, message, user, unknownUser)
+  feedback: (subject, message, user, unknownUser, uris)->
+    email = email_.feedback subject, message, user, unknownUser, uris
     transporter_.sendMail email
     .catch _.Error('feedback')
 

--- a/server/lib/emails/views/feedback.hbs
+++ b/server/lib/emails/views/feedback.hbs
@@ -14,4 +14,13 @@
   <p>
     {{message}}
   </p>
+  {{#if uris}}
+    <ul>
+      {{#each uris}}
+        <li>
+          <a href="{{../host}}/entity/{{this}}">{{this}}</a>
+        </li>
+      {{/each}}
+    </ul>
+  {{/if}}
 {{>paragraph_bottom}}


### PR DESCRIPTION
so that the email can generate links, very helpful for feedback such as 'possible work duplicate',
'entity type', or 'data error' automatic messages, where you have to open the associated entities pages to solve the reported issue