### PR TITLE
improve parallel entity editing

### DIFF
--- a/server/controllers/entities/lib/update_inv_claim.coffee
+++ b/server/controllers/entities/lib/update_inv_claim.coffee
@@ -3,12 +3,13 @@ _ = __.require 'builders', 'utils'
 error_ = __.require 'lib', 'error/error'
 entities_ = require './entities'
 radio = __.require 'lib', 'radio'
+retryOnConflict = __.require 'lib', 'retry_on_conflict'
 Entity = __.require 'models', 'entity'
 getEntityType = require './get_entity_type'
 validateClaimProperty = require './validate_claim_property'
 inferredClaimUpdates = require './inferred_claim_updates'
 
-module.exports = (user, id, property, oldVal, newVal)->
+updateInvClaim = (user, id, property, oldVal, newVal)->
   _.type user, 'object'
   { _id:userId, admin:userIsAdmin } = user
 
@@ -40,3 +41,5 @@ updateClaim = (params)->
   entities_.validateClaim params
   .then Entity.updateClaim.bind(null, updatedDoc, property, oldVal)
   .then (updatedDoc)-> entities_.putUpdate { userId, currentDoc, updatedDoc }
+
+module.exports = retryOnConflict updateInvClaim

--- a/server/controllers/entities/lib/update_inv_claim.coffee
+++ b/server/controllers/entities/lib/update_inv_claim.coffee
@@ -42,4 +42,4 @@ updateClaim = (params)->
   .then Entity.updateClaim.bind(null, updatedDoc, property, oldVal)
   .then (updatedDoc)-> entities_.putUpdate { userId, currentDoc, updatedDoc }
 
-module.exports = retryOnConflict updateInvClaim
+module.exports = retryOnConflict { updateFn: updateInvClaim }

--- a/server/controllers/entities/lib/update_inv_label.coffee
+++ b/server/controllers/entities/lib/update_inv_label.coffee
@@ -2,9 +2,10 @@ __ = require('config').universalPath
 _ = __.require 'builders', 'utils'
 entities_ = require './entities'
 radio = __.require 'lib', 'radio'
+retryOnConflict = __.require 'lib', 'retry_on_conflict'
 updateLabel = require './update_label'
 
-module.exports = (user, id, lang, value)->
+updateInvLabel = (user, id, lang, value)->
   { _id:reqUserId } = user
 
   unless _.isInvEntityId id then return error_.rejectInvalid 'id', id
@@ -12,3 +13,5 @@ module.exports = (user, id, lang, value)->
   entities_.byId id
   .then updateLabel.bind(null, lang, value, reqUserId)
   .then (updatedDoc)-> radio.emit 'entity:update:label', updatedDoc, lang, value
+
+module.exports = retryOnConflict updateInvLabel

--- a/server/controllers/entities/lib/update_inv_label.coffee
+++ b/server/controllers/entities/lib/update_inv_label.coffee
@@ -14,4 +14,4 @@ updateInvLabel = (user, id, lang, value)->
   .then updateLabel.bind(null, lang, value, reqUserId)
   .then (updatedDoc)-> radio.emit 'entity:update:label', updatedDoc, lang, value
 
-module.exports = retryOnConflict updateInvLabel
+module.exports = retryOnConflict { updateFn: updateInvLabel }

--- a/server/lib/retry_on_conflict.coffee
+++ b/server/lib/retry_on_conflict.coffee
@@ -1,0 +1,25 @@
+__ = require('config').universalPath
+_ = __.require 'builders', 'utils'
+promises_ = __.require 'lib', 'promises'
+error_ = __.require 'lib', 'error/error'
+
+module.exports = (updateFn, maxAttempts = 10)-> (args...)->
+  run = (attemptsCount)->
+    if attemptsCount > maxAttempts
+      throw error_.new 'maximum attempt reached', 400, { updateFn, maxAttempts, args }
+
+    attemptsCount += 1
+
+    updateFn.apply null, args
+    .catch (err)->
+      if err.statusCode is 409 then runAfterDelay run, attemptsCount, err
+      else throw err
+
+  return run 1
+
+runAfterDelay = (run, attemptsCount, err)->
+  delay = attemptsCount * 100 + Math.random() * 100
+
+  promises_.resolve()
+  .delay delay
+  .then -> run attemptsCount

--- a/server/lib/retry_on_conflict.coffee
+++ b/server/lib/retry_on_conflict.coffee
@@ -3,19 +3,22 @@ _ = __.require 'builders', 'utils'
 promises_ = __.require 'lib', 'promises'
 error_ = __.require 'lib', 'error/error'
 
-module.exports = (updateFn, maxAttempts = 10)-> (args...)->
-  run = (attemptsCount)->
-    if attemptsCount > maxAttempts
-      throw error_.new 'maximum attempt reached', 400, { updateFn, maxAttempts, args }
+module.exports = (params)->
+  { updateFn, maxAttempts } = params
+  maxAttempts or= 10
+  return (args...)->
+    run = (attemptsCount)->
+      if attemptsCount > maxAttempts
+        throw error_.new 'maximum attempt reached', 400, { updateFn, maxAttempts, args }
 
-    attemptsCount += 1
+      attemptsCount += 1
 
-    updateFn.apply null, args
-    .catch (err)->
-      if err.statusCode is 409 then runAfterDelay run, attemptsCount, err
-      else throw err
+      updateFn.apply null, args
+      .catch (err)->
+        if err.statusCode is 409 then runAfterDelay run, attemptsCount, err
+        else throw err
 
-  return run 1
+    return run 1
 
 runAfterDelay = (run, attemptsCount, err)->
   delay = attemptsCount * 100 + Math.random() * 100

--- a/server/lib/retry_on_conflict.coffee
+++ b/server/lib/retry_on_conflict.coffee
@@ -21,7 +21,7 @@ module.exports = (params)->
     return run 1
 
 runAfterDelay = (run, attemptsCount, err)->
-  delay = attemptsCount * 100 + Math.random() * 100
+  delay = attemptsCount * 100 + Math.trunc(Math.random() * 100)
 
   promises_.resolve()
   .delay delay

--- a/tests/api/entities/update_claims.test.coffee
+++ b/tests/api/entities/update_claims.test.coffee
@@ -5,7 +5,7 @@ should = require 'should'
 { Promise } = __.require 'lib', 'promises'
 { undesiredRes, undesiredErr } = require '../utils/utils'
 { createWork, createEdition } = require '../fixtures/entities'
-{ getByUris, updateClaim, merge } = require '../utils/entities'
+{ getByUri, updateClaim, merge } = require '../utils/entities'
 
 describe 'entities:update-claims', ->
   it 'should reject an update with an inappropriate property', (done)->
@@ -75,10 +75,8 @@ describe 'entities:update-claims', ->
       Promise.all authorsUris.map((uri)-> updateClaim work._id, 'wdt:P50', null, uri)
       .then (responses)->
         responses.forEach (res)-> should(res.ok).be.true()
-        getByUris work.uri
-        .get 'entities'
-        .then (entities)->
-          updatedWork = entities[workUri]
+        getByUri work.uri
+        .then (updatedWork)->
           addedAuthorsUris = updatedWork.claims['wdt:P50']
           authorsUris.forEach (uri)-> should(uri in addedAuthorsUris).be.true()
           done()

--- a/tests/api/entities/update_claims.test.coffee
+++ b/tests/api/entities/update_claims.test.coffee
@@ -68,7 +68,7 @@ describe 'entities:update-claims', ->
     return
 
   it 'should accept rapid updates on the same entity', (done)->
-    authorsUris = [ 'wd:Q192214', 'wd:Q206685', 'wd:Q281411', 'wd:Q312835', 'wd:Q309945' ]
+    authorsUris = [ 'wd:Q192214', 'wd:Q206685' ]
     createWork()
     .then (work)->
       { uri: workUri } = work

--- a/tests/api/entities/update_labels.test.coffee
+++ b/tests/api/entities/update_labels.test.coffee
@@ -4,7 +4,7 @@ _ = __.require 'builders', 'utils'
 should = require 'should'
 { undesiredRes, undesiredErr } = require '../utils/utils'
 { createHuman } = require '../fixtures/entities'
-{ updateLabel } = require '../utils/entities'
+{ getByUri, updateLabel } = require '../utils/entities'
 
 humanPromise = createHuman()
 
@@ -44,6 +44,23 @@ describe 'entities:update-labels', ->
         err.statusCode.should.equal 400
         err.body.status_verbose.should.startWith 'already up-to-date'
         done()
+    .catch undesiredErr(done)
+
+    return
+
+  it 'should accept rapid updates on the same entity', (done)->
+    name = 'Georges'
+    langs = [ 'en', 'fr', 'de', 'it', 'nl', 'es', 'pt' ]
+    humanPromise
+    .then (human)->
+      { _id: humanId, uri: humanUri } = human
+      Promise.all langs.map((lang)-> updateLabel humanId, lang, name)
+      .then (responses)->
+        responses.forEach (res)-> should(res.ok).be.true()
+        getByUri human.uri
+        .then (updatedHuman)->
+          langs.forEach (lang)-> updatedHuman.labels[lang].should.equal(name)
+          done()
     .catch undesiredErr(done)
 
     return

--- a/tests/api/entities/update_labels.test.coffee
+++ b/tests/api/entities/update_labels.test.coffee
@@ -50,7 +50,7 @@ describe 'entities:update-labels', ->
 
   it 'should accept rapid updates on the same entity', (done)->
     name = 'Georges'
-    langs = [ 'en', 'fr', 'de', 'it', 'nl', 'es', 'pt' ]
+    langs = [ 'en', 'fr' ]
     humanPromise
     .then (human)->
       { _id: humanId, uri: humanUri } = human

--- a/tests/api/utils/entities.coffee
+++ b/tests/api/utils/entities.coffee
@@ -13,6 +13,10 @@ module.exports = entitiesUtils =
     url = _.buildPath '/api/entities', { action: 'by-uris', uris, relatives }
     nonAuthReq 'get', url
 
+  getByUri: (uri)->
+    entitiesUtils.getByUris uri
+    .then (res)-> res.entities[uri]
+
   deleteByUris: (uris)->
     if _.isArray(uris) then uris = uris.join('|')
     adminReq 'delete', "/api/entities?action=by-uris&uris=#{uris}"


### PR DESCRIPTION
allow parallel requests to `/api/entities?action=update-claim` and `/api/entities?action=update-label` without throwing a conflict error.

This could come handy for when clients will implement one-click claim update such as adding authors from a list of suggestions: several edits could occur in a very short time span