### PR TITLE
users: byUsername: index by lowercased username

### DIFF
--- a/api_tests/users/by_username.test.coffee
+++ b/api_tests/users/by_username.test.coffee
@@ -3,18 +3,24 @@ __ = CONFIG.universalPath
 _ = __.require 'builders', 'utils'
 should = require 'should'
 { nonAuthReq, getUser, undesiredErr } = require '../utils/utils'
+{ createUser } = require '../fixtures/users'
+randomString = __.require 'lib', './utils/random_string'
 
 describe 'users:by-usernames', ->
-  it 'should get a user', (done)->
-    getUser()
+  it 'should get a user with a non lowercase username', (done)->
+    username = 'notAllLowerCase' + randomString(4)
+    lowerCasedUsername = username.toLowerCase()
+    createUser { username }
     .delay 10
     .then (user)->
       { username } = user
       nonAuthReq 'get', "/api/users?action=by-usernames&usernames=#{username}"
       .then (res)->
-        res.users.should.be.an.Object()
-        res.users[username].should.be.an.Object()
-        res.users[username].username.should.equal username
+        { users } = res
+        users.should.be.an.Object()
+        should(users[username]).not.be.ok()
+        users[lowerCasedUsername].should.be.an.Object()
+        users[lowerCasedUsername].username.should.equal username
         done()
     .catch undesiredErr(done)
 

--- a/server/controllers/user/lib/user.coffee
+++ b/server/controllers/user/lib/user.coffee
@@ -80,7 +80,7 @@ user_ =
 
   getUsersIndexByUsernames: (reqUserId)-> (usernames)->
     user_.getUsersAuthorizedData user_.byUsernames(usernames), reqUserId
-    .then _.IndexBy('username')
+    .then (users)-> users.reduce indexByLowerCasedUsername, {}
 
   incrementUndeliveredMailCounter: (email)->
     user_.findOneByEmail email
@@ -119,6 +119,11 @@ findNearby = (latLng, meterRange, iterations = 0, strict = false)->
     else
       iterations += 1
       return findNearby latLng, meterRange * 2, iterations
+
+indexByLowerCasedUsername = (users, user)->
+  lowercasedUsername = user.username.toLowerCase()
+  users[lowercasedUsername] = user
+  return users
 
 token_ = require('./token')(db, user_)
 


### PR DESCRIPTION
to prevent having keys mismatches: whatever the requested username case
the username used as keys are all returned lowercased

=> tolerant on the input, consistent on the output