### PR TITLE
cleaning

### DIFF
--- a/api_tests/scripts/run_api_tests
+++ b/api_tests/scripts/run_api_tests
@@ -1,13 +1,7 @@
-#!/usr/bin/env zsh
-
-alias mochac="mocha --compilers coffee:coffee-script/register"
+#!/usr/bin/env bash
 files=$@
 # If no test file is passed as argument, run all tests
 [ -z "$1" ] && files=api_tests/**/*test.coffee
 
-# Split files names, using a ZSH eval trick
-# cf http://zsh.sourceforge.net/FAQ/zshfaq03.html
-eval "files=($files)"
-
 # Run the tests
-export NODE_ENV=tests NODE_APP_INSTANCE=tests-alt; mochac $files --timeout 20000
+export NODE_ENV=tests NODE_APP_INSTANCE=tests-alt; mocha --compilers coffee:coffee-script/register $files --timeout 20000

--- a/api_tests/scripts/start_entities_search_engine
+++ b/api_tests/scripts/start_entities_search_engine
@@ -1,4 +1,4 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
 search_engine_path=$(node -p "require('config').entitiesSearchEngine.localPath")
 cwd=$(pwd)
 

--- a/api_tests/scripts/start_tests_server
+++ b/api_tests/scripts/start_tests_server
@@ -1,4 +1,4 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
 
 # Use NODE_APP_INSTANCE=tests-alt to override local config with local-tests-alt
 export NODE_ENV=tests NODE_APP_INSTANCE=tests-alt FORCE_COLOR=true
@@ -9,7 +9,7 @@ entities_search_engine_host=$(node -p "require('config').entitiesSearchEngine.ho
 curl -s "$entities_search_engine_host" > /dev/null && echo "entities search engine found" || \
   # Using curly brackets to group those commands without starting a subshell from which exiting would be useless
   # cf https://ss64.com/bash/syntax-brackets.html
-  { ./api_tests/scripts/start_entities_search_engine && sleep 5 }
+  { ./api_tests/scripts/start_entities_search_engine && sleep 5 ; }
 
 # If the server is already up, return early
 (curl -s "$test_host" > /dev/null || [ "$(cat run/3009)" == "starting" ]) &&

--- a/package-lock.json
+++ b/package-lock.json
@@ -1768,6 +1768,12 @@
         }
       }
     },
+    "couchdb-backup": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/couchdb-backup/-/couchdb-backup-1.0.0.tgz",
+      "integrity": "sha512-b+AggprKhe8mB03AppcsIsFnyZSJci5/HWRMQboLIo/8LooYH5F7KT4zuBAV8YP1DvWi9JnRi7w7QOi5CBvHSA==",
+      "dev": true
+    },
     "crc": {
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/crc/-/crc-3.4.4.tgz",
@@ -5260,7 +5266,7 @@
     },
     "lodash.isempty": {
       "version": "4.4.0",
-      "resolved": "http://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
       "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
     },
     "lodash.keys": {
@@ -5783,7 +5789,7 @@
       "dependencies": {
         "cloudant-follow": {
           "version": "0.17.0",
-          "resolved": "http://registry.npmjs.org/cloudant-follow/-/cloudant-follow-0.17.0.tgz",
+          "resolved": "https://registry.npmjs.org/cloudant-follow/-/cloudant-follow-0.17.0.tgz",
           "integrity": "sha512-JQ1xvKAHh8rsnSVBjATLCjz/vQw1sWBGadxr2H69yFMwD7hShUGDwwEefdypaxroUJ/w6t1cSwilp/hRUxEW8w==",
           "requires": {
             "browser-request": "~0.3.0",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
   "devDependencies": {
     "coffee-errors": "^0.8.6",
     "coffeelint": "^1.16.2",
+    "couchdb-backup": "^1.0.0",
     "diff": "^2.2.1",
     "doctoc": "^1.2.0",
     "faker": "^4.1.0",

--- a/scripts/add_new_active_lang
+++ b/scripts/add_new_active_lang
@@ -1,4 +1,4 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
 
 set -eu
 

--- a/scripts/couch2elastic4sync/exec.coffee
+++ b/scripts/couch2elastic4sync/exec.coffee
@@ -10,6 +10,7 @@ folder = __.path 'scripts', 'couch2elastic4sync'
 logsFolder = __.path 'logs', 'couch2elastic4sync'
 fs  = require 'fs'
 { syncDataList } = __.require 'db', 'elasticsearch/list'
+{ red } = require 'chalk'
 
 # Mapping to couch2elastic4sync API:
 # cliArg='sync' => couch2elastic4sync
@@ -34,8 +35,7 @@ module.exports = (cliArg)->
 
     childProcess = spawn command, args
     childProcess.stdout.pipe logStream
-    # Unfortunately, couch2elastic4sync writes errors to stdout so this line doesn't have much effect
-    childProcess.stderr.pipe logStream
+    childProcess.stderr.on 'data', logError
     return childProcess
 
   killChildrenProcesses = -> childProcesses.forEach (childProc)-> childProc.kill()
@@ -51,3 +51,5 @@ getLogStream = (dbName)->
   logStream = fs.createWriteStream logFile, { flags: 'a' }
   logStream.write "\n--------- restarting: #{new Date} ---------\n"
   return logStream
+
+logError = (chunk)-> console.error red('couch2elastic4sync err'), chunk.toString()

--- a/scripts/dumps/get_wikidata_humans_dump
+++ b/scripts/dumps/get_wikidata_humans_dump
@@ -1,4 +1,4 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
 # Generate a pre-filtered dump of humans in Wikidata to ease development setup
 # cf https://github.com/inventaire/inventaire-deploy/blob/d280055/install_entities_search_engine#L24-L28
 

--- a/scripts/dumps/prepare_entities_ndjson_dump
+++ b/scripts/dumps/prepare_entities_ndjson_dump
@@ -1,9 +1,11 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
 
 set -eu
 
 folder=$(node -p "require('config').universalPath.path('dumps')")
-db_param(){ node -p "require('config').db.$1" }
+db_param(){
+  node -p "require('config').db.$1"
+}
 
 # Getting the database parameters to get ready for couchdb-dump
 host=$(db_param host)

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -1,4 +1,4 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
 
 set -eu
 
@@ -42,12 +42,14 @@ touch run/3006 run/3009
   npm run couch2elastic4sync:init && npm run couch2elastic4sync:load
 } || echo "ElasticSearch not found: init & load scripts skipped"
 
-# Create a local config file
-emptyConfigFile="
-# Override settings from ./default.coffee in this file
-module.exports =
-  db:
-    username: 'yourcouchdbusername'
-    password: 'yourcouchdbpassword'
-"
-echo "$emptyConfigFile" >> ./config/local.coffee
+[ -z ./config/local.coffee ] && {
+  # Create a local config file
+  emptyConfigFile="
+  # Override settings from ./default.coffee in this file
+  module.exports =
+    db:
+      username: 'yourcouchdbusername'
+      password: 'yourcouchdbpassword'
+  "
+  echo "$emptyConfigFile" >> ./config/local.coffee
+}

--- a/server/lib/before_startup.coffee
+++ b/server/lib/before_startup.coffee
@@ -4,5 +4,4 @@ module.exports = ->
   initUncaughtExceptionCatcher()
 
 initUncaughtExceptionCatcher = ->
-  process.on 'uncaughtException', (err)->
-    console.error red('uncaughtException'), err, err.stack
+  process.on 'uncaughtException', (err)-> console.error red('uncaughtException'), err


### PR DESCRIPTION
some cleanup made while trying to make this repo work well with [docker-inventaire](https://github.com/inventaire/docker-inventaire), especially:
* 03c1f251: removes the zsh dependency, allowing to use [`docker_npm`](https://github.com/inventaire/docker-inventaire/blob/docker-npm/scripts/docker_npm) to run scripts (using it for zsh script was failing as the `node:8` docker image misses zsh)