### PR TITLE
improving tasks tests

### DIFF
--- a/server/controllers/entities/lib/get_entities_popularity.coffee
+++ b/server/controllers/entities/lib/get_entities_popularity.coffee
@@ -50,7 +50,7 @@ applyDefaultValue = (uri)-> (value)->
   # if the cache is empty, the entity isn't that popular
   return 0
 
-wdPopularityWorker = (jobId, uri, cb)->
+wdPopularityWorker = (jobId, uri)->
   key = buildKey uri
   _.log uri, 'wdPopularityWorker uri'
   # Check that the score wasn't calculated since this job was queued

--- a/server/controllers/tasks/check_entities.coffee
+++ b/server/controllers/tasks/check_entities.coffee
@@ -1,0 +1,19 @@
+CONFIG = require 'config'
+__ = CONFIG.universalPath
+_ = __.require 'builders', 'utils'
+error_ = __.require 'lib', 'error/error'
+responses_ = __.require 'lib', 'responses'
+checkEntity = require './lib/check_entity'
+sanitize = __.require 'lib', 'sanitize/sanitize'
+
+sanitization =
+  uris: {}
+
+module.exports = (req, res)->
+  sanitize req, res, sanitization
+  .then (params)->
+    { uris } = params
+    return Promise.all uris.map(checkEntity)
+  .then _.flatten
+  .then responses_.Wrap(res, 'tasks')
+  .catch error_.Handler(req, res)

--- a/server/controllers/tasks/collect_entities.coffee
+++ b/server/controllers/tasks/collect_entities.coffee
@@ -5,11 +5,8 @@ error_ = __.require 'lib', 'error/error'
 entities_ = __.require 'controllers', 'entities/lib/entities'
 responses_ = __.require 'lib', 'responses'
 { prefixifyInv } = __.require 'controllers', 'entities/lib/prefix'
-getEntityByUri = __.require 'controllers', 'entities/lib/get_entity_by_uri'
 jobs_ = __.require 'level', 'jobs'
-tasks_ = require './lib/tasks'
-buildTaskDocs = require './lib/build_task_docs'
-keepNewTasks = require './lib/keep_new_tasks'
+checkEntity = require './lib/check_entity'
 { interval } = CONFIG.jobs['inv:deduplicate']
 
 module.exports = (req, res)->
@@ -26,17 +23,8 @@ getInvHumanUris = ->
   entities_.byClaim 'wdt:P31', 'wd:Q5'
   .then (res)-> _.pluck(res.rows, 'id').map prefixifyInv
 
-deduplicateWorker = (jobId, uri, cb)->
-  getEntityByUri uri
-  .then (entity)->
-    unless entity? then throw error_.notFound { uri }
-
-    if entity.uri.split(':')[0] is 'wd'
-      throw error_.new 'entity is already a redirection', 400, { uri }
-
-    return buildTaskDocs entity
-  .then keepNewTasks
-  .map tasks_.create
+deduplicateWorker = (jobId, uri)->
+  checkEntity uri
   .delay interval
   .catch (err)->
     if err.statusCode is 400 then return

--- a/server/controllers/tasks/lib/check_entity.coffee
+++ b/server/controllers/tasks/lib/check_entity.coffee
@@ -1,0 +1,17 @@
+CONFIG = require 'config'
+__ = CONFIG.universalPath
+_ = __.require 'builders', 'utils'
+getEntityByUri = __.require 'controllers', 'entities/lib/get_entity_by_uri'
+tasks_ = require './tasks'
+buildTaskDocs = require './build_task_docs'
+keepNewTasks = require './keep_new_tasks'
+
+module.exports = (uri)->
+  getEntityByUri uri
+  .then (entity)->
+    unless entity? then throw error_.notFound { uri }
+    if entity.uri.split(':')[0] is 'wd'
+      throw error_.new 'entity is already a redirection', 400, { uri }
+    return buildTaskDocs entity
+  .then keepNewTasks
+  .map tasks_.create

--- a/server/controllers/tasks/tasks.coffee
+++ b/server/controllers/tasks/tasks.coffee
@@ -13,6 +13,7 @@ module.exports =
   post: ActionsControllers
     admin:
       'collect-entities': require './collect_entities'
+      'check-entities': require './check_entities'
 
   put: ActionsControllers
     admin:

--- a/tests/api/fixtures/entities.coffee
+++ b/tests/api/fixtures/entities.coffee
@@ -31,13 +31,14 @@ module.exports = API =
   editionLabel: -> randomWords()
   workLabel: -> randomWords(5)
   humanName: humanName
-  createWorkWithAuthor: (human)->
+  createWorkWithAuthor: (human, label)->
     humanPromise = if human then Promise.resolve(human) else API.createHuman()
+    label or= workLabel()
 
     humanPromise
     .then (human)->
       authReq 'post', '/api/entities?action=create',
-        labels: { en: humanName() }
+        labels: { en: label }
         claims:
           'wdt:P31': [ 'wd:Q571' ]
           'wdt:P50': [ human.uri ]

--- a/tests/api/tasks/check_entities.test.coffee
+++ b/tests/api/tasks/check_entities.test.coffee
@@ -1,0 +1,20 @@
+CONFIG = require 'config'
+__ = CONFIG.universalPath
+_ = __.require 'builders', 'utils'
+should = require 'should'
+{ checkEntities } = require '../utils/tasks'
+{ undesiredErr } = __.require 'apiTests', 'utils/utils'
+{ createHuman } = require '../fixtures/entities'
+
+describe 'tasks:check-entities', ->
+  it 'should directly create tasks for the requested URIs', (done)->
+    createHuman { labels: { en: 'Fred Vargas' } }
+    .then (human)->
+      checkEntities [ human.uri ]
+      .then (tasks)->
+        tasks.should.be.an.Array()
+        tasks[0].suspectUri.should.equal human.uri
+        done()
+    .catch undesiredErr(done)
+
+    return

--- a/tests/api/tasks/check_entities.test.coffee
+++ b/tests/api/tasks/check_entities.test.coffee
@@ -6,6 +6,7 @@ should = require 'should'
 { undesiredErr } = __.require 'apiTests', 'utils/utils'
 { createHuman } = require '../fixtures/entities'
 
+# Tests dependency: having a populated ElasticSearch wikidata index
 describe 'tasks:check-entities', ->
   it 'should directly create tasks for the requested URIs', (done)->
     createHuman { labels: { en: 'Fred Vargas' } }

--- a/tests/api/tasks/check_entities.test.coffee
+++ b/tests/api/tasks/check_entities.test.coffee
@@ -10,7 +10,7 @@ describe 'tasks:check-entities', ->
   it 'should directly create tasks for the requested URIs', (done)->
     createHuman { labels: { en: 'Fred Vargas' } }
     .then (human)->
-      checkEntities [ human.uri ]
+      checkEntities human.uri
       .then (tasks)->
         tasks.should.be.an.Array()
         tasks[0].suspectUri.should.equal human.uri
@@ -22,11 +22,10 @@ describe 'tasks:check-entities', ->
   it 'should not re-create existing tasks', (done)->
     createHuman { labels: { en: 'Fred Vargas' } }
     .then (human)->
-      checkEntities [ human.uri ]
-      .then -> checkEntities [ human.uri ]
+      checkEntities human.uri
+      .then -> checkEntities human.uri
       .then -> getBySuspectUri human.uri
       .then (tasks)->
-        _.log tasks, 'tasks'
         uniqSuspectUris = _.uniq _.pluck(tasks, 'suspectUri')
         tasks.length.should.equal uniqSuspectUris.length
         done()

--- a/tests/api/tasks/check_entities.test.coffee
+++ b/tests/api/tasks/check_entities.test.coffee
@@ -2,7 +2,7 @@ CONFIG = require 'config'
 __ = CONFIG.universalPath
 _ = __.require 'builders', 'utils'
 should = require 'should'
-{ checkEntities } = require '../utils/tasks'
+{ checkEntities, getBySuspectUri } = require '../utils/tasks'
 { undesiredErr } = __.require 'apiTests', 'utils/utils'
 { createHuman } = require '../fixtures/entities'
 
@@ -14,6 +14,21 @@ describe 'tasks:check-entities', ->
       .then (tasks)->
         tasks.should.be.an.Array()
         tasks[0].suspectUri.should.equal human.uri
+        done()
+    .catch undesiredErr(done)
+
+    return
+
+  it 'should not re-create existing tasks', (done)->
+    createHuman { labels: { en: 'Fred Vargas' } }
+    .then (human)->
+      checkEntities [ human.uri ]
+      .then -> checkEntities [ human.uri ]
+      .then -> getBySuspectUri human.uri
+      .then (tasks)->
+        _.log tasks, 'tasks'
+        uniqSuspectUris = _.uniq _.pluck(tasks, 'suspectUri')
+        tasks.length.should.equal uniqSuspectUris.length
         done()
     .catch undesiredErr(done)
 

--- a/tests/api/tasks/collect_entities.test.coffee
+++ b/tests/api/tasks/collect_entities.test.coffee
@@ -2,25 +2,24 @@ CONFIG = require 'config'
 __ = CONFIG.universalPath
 _ = __.require 'builders', 'utils'
 should = require 'should'
-{ collectEntities } = require '../fixtures/tasks'
-{ getByScore } = require '../utils/tasks'
+{ Promise } = __.require 'lib', 'promises'
+{ createHuman } = require '../fixtures/entities'
+{ getBySuspectUri, collectEntities } = require '../utils/tasks'
 { undesiredErr } = __.require 'apiTests', 'utils/utils'
 
 describe 'tasks:collect-entities', ->
   it 'should create new tasks', (done)->
-    collectEntities()
-    .then (res)->
-      suspectUri = res.humans[0].uri
-      getByScore()
-      .then (tasks)->
-        tasks.length.should.aboveOrEqual 1
-        # with a suspect
-        tasksUris = _.pluck tasks, 'suspectUri'
-        tasksUris.should.containEql suspectUri
-        # with a relationScore
-        taskRelationScores = _.pluck tasks, 'relationScore'
-        _.compact(taskRelationScores).length.should.equal taskRelationScores.length
-        done()
-      .catch undesiredErr(done)
+    Promise.all [
+      createHuman { labels: { en: 'Stanislas Lem' } }
+      createHuman { labels: { en: 'Stanislas Lem' } }
+    ]
+    .then (humans)->
+      uris = _.pluck humans, 'uri'
+      collectEntities()
+      .delay 5000
+      .then -> Promise.all uris.map(getBySuspectUri)
+      .map (tasks)-> tasks.length.should.aboveOrEqual 1
+      .then -> done()
+    .catch undesiredErr(done)
 
     return

--- a/tests/api/tasks/collect_entities.test.coffee
+++ b/tests/api/tasks/collect_entities.test.coffee
@@ -24,15 +24,3 @@ describe 'tasks:collect-entities', ->
       .catch undesiredErr(done)
 
     return
-
-  it 'should not re-create existing tasks', (done)->
-    collectEntities()
-    .then (res)->
-      getByScore()
-      .then (tasks)->
-        uniqSuspectUris = _.uniq _.pluck(tasks, 'suspectUri')
-        tasks.length.should.equal uniqSuspectUris.length
-        done()
-    .catch undesiredErr(done)
-
-    return

--- a/tests/api/tasks/collect_entities.test.coffee
+++ b/tests/api/tasks/collect_entities.test.coffee
@@ -7,6 +7,9 @@ should = require 'should'
 { getBySuspectUri, collectEntities } = require '../utils/tasks'
 { undesiredErr } = __.require 'apiTests', 'utils/utils'
 
+# Tests dependency:
+# - running after a database reset
+# - having a populated ElasticSearch wikidata index
 describe 'tasks:collect-entities', ->
   it 'should create new tasks', (done)->
     Promise.all [

--- a/tests/api/tasks/get.test.coffee
+++ b/tests/api/tasks/get.test.coffee
@@ -6,6 +6,7 @@ should = require 'should'
 { createSomeTasks } = require '../fixtures/tasks'
 { getBySuspectUri, getByScore } = require '../utils/tasks'
 
+# Tests dependency: having a populated ElasticSearch wikidata index
 describe 'tasks:byScore', ->
   it 'should returns 10 or less tasks to deduplicates, by default', (done)->
     createSomeTasks 'Gilbert Simondon'

--- a/tests/api/tasks/get.test.coffee
+++ b/tests/api/tasks/get.test.coffee
@@ -2,19 +2,15 @@ CONFIG = require 'config'
 __ = CONFIG.universalPath
 _ = __.require 'builders', 'utils'
 should = require 'should'
-{ authReq, undesiredErr } = __.require 'apiTests', 'utils/utils'
-{ createHuman } = require '../fixtures/entities'
-{ collectEntities } = require '../fixtures/tasks'
-{ getBySuspectUri } = require '../utils/tasks'
-byScore = '/api/tasks?action=by-score'
+{ undesiredErr } = __.require 'apiTests', 'utils/utils'
+{ createSomeTasks } = require '../fixtures/tasks'
+{ getBySuspectUri, getByScore } = require '../utils/tasks'
 
 describe 'tasks:byScore', ->
   it 'should returns 10 or less tasks to deduplicates, by default', (done)->
-    collectEntities()
-    .then -> authReq 'get', byScore
-    .then (res)->
-      res.should.be.an.Object()
-      { tasks } = res
+    createSomeTasks 'Gilbert Simondon'
+    .then getByScore
+    .then (tasks)->
       tasks.length.should.be.belowOrEqual 10
       tasks.length.should.be.aboveOrEqual 1
       done()
@@ -23,24 +19,22 @@ describe 'tasks:byScore', ->
     return
 
   it 'should returns a limited array of tasks to deduplicate', (done)->
-    authReq 'get', byScore + '&limit=1'
-    .then (res)->
-      res.tasks.length.should.equal 1
+    createSomeTasks 'Gilbert Simondon'
+    .then -> getByScore { limit: 1 }
+    .then (tasks)->
+      tasks.length.should.equal 1
       done()
     .catch undesiredErr(done)
 
     return
 
   it 'should take an offset parameter', (done)->
-    collectEntities()
-    .then -> authReq 'get', byScore
-    .then (res)->
-      offset = 1
-      firstOffsetTask = res.tasks[offset]
-      authReq 'get', byScore + "&offset=#{offset}"
-      .then (res)->
-        firstTask = res.tasks[0]
-        firstTask.should.deepEqual firstOffsetTask
+    createSomeTasks 'Gilbert Simondon'
+    .then getByScore
+    .then (tasksA)->
+      getByScore { offset: 1 }
+      .then (tasksB)->
+        tasksA[1].should.deepEqual tasksB[0]
         done()
     .catch undesiredErr(done)
 
@@ -48,7 +42,7 @@ describe 'tasks:byScore', ->
 
 describe 'tasks:bySuspectUri', ->
   it 'should return an array of tasks', (done)->
-    collectEntities()
+    createSomeTasks 'Gilbert Simondon'
     .then (res)-> getBySuspectUri res.humans[0].uri
     .then (tasks)->
       suspectUris = _.pluck tasks, 'suspectUri'

--- a/tests/api/tasks/has_encyclopedia_occurence.test.coffee
+++ b/tests/api/tasks/has_encyclopedia_occurence.test.coffee
@@ -2,29 +2,20 @@ CONFIG = require 'config'
 __ = CONFIG.universalPath
 _ = __.require 'builders', 'utils'
 should = require 'should'
-{ authReq, adminReq, nonAuthReq, undesiredErr } = __.require 'apiTests', 'utils/utils'
-{ collectEntities } = require '../fixtures/tasks'
-{ getByScore } = require '../utils/tasks'
+{ undesiredErr } = __.require 'apiTests', 'utils/utils'
+{ checkEntities } = require '../utils/tasks'
+{ createHuman, createWorkWithAuthor } = require '../fixtures/entities'
 
 describe 'tasks:has-encyclopedia-occurence', ->
   it 'should return true when author has work sourced in their wikipedia page', (done)->
-    authReq 'post', '/api/entities?action=create',
-      labels: { en: 'Victor Hugo' }
-      claims:
-        'wdt:P31': [ 'wd:Q5' ]
-    .then (res)->
-      authorUri = "inv:#{res._id}"
-      authReq 'post', '/api/entities?action=create',
-        labels: { en: 'Ruy Blas' }
-        claims:
-          'wdt:P31': [ 'wd:Q571' ]
-          'wdt:P50': [ authorUri ]
-      .then -> collectEntities { refresh: true }
-      .then getByScore
+    createHuman { labels: { en: 'Victor Hugo' } }
+    .then (human)->
+      createWorkWithAuthor human, 'Ruy Blas'
+      .then (work)-> checkEntities human.uri
       .then (tasks)->
         tasks.length.should.aboveOrEqual 1
-        hasEncyclopediaOccurences = _.pluck tasks, 'hasEncyclopediaOccurence'
-        _.includes(hasEncyclopediaOccurences, true).should.be.true()
+        Q535Task = tasks.find (task)-> task.suggestionUri is 'wd:Q535'
+        Q535Task.hasEncyclopediaOccurence.should.be.true()
         done()
       .catch undesiredErr(done)
 

--- a/tests/api/tasks/has_encyclopedia_occurence.test.coffee
+++ b/tests/api/tasks/has_encyclopedia_occurence.test.coffee
@@ -6,6 +6,7 @@ should = require 'should'
 { checkEntities } = require '../utils/tasks'
 { createHuman, createWorkWithAuthor } = require '../fixtures/entities'
 
+# Tests dependency: having a populated ElasticSearch wikidata index
 describe 'tasks:has-encyclopedia-occurence', ->
   it 'should return true when author has work sourced in their wikipedia page', (done)->
     createHuman { labels: { en: 'Victor Hugo' } }

--- a/tests/api/tasks/hooks.test.coffee
+++ b/tests/api/tasks/hooks.test.coffee
@@ -7,6 +7,7 @@ should = require 'should'
 { deleteByUris: deleteEntityByUris } = require '../utils/entities'
 { getByIds, getBySuspectUri, update, checkEntities } = require '../utils/tasks'
 
+# Tests dependency: having a populated ElasticSearch wikidata index
 describe 'tasks:hooks', ->
   describe 'entity merge', ->
     it 'should update same suspect tasks to merged state', (done) ->

--- a/tests/api/tasks/hooks.test.coffee
+++ b/tests/api/tasks/hooks.test.coffee
@@ -58,6 +58,7 @@ describe 'tasks:hooks', ->
           otherTask = tasks[1]
           { relationScore: taskRelationScore } = taskToUpdate
           update taskToUpdate._id, 'state', 'dismissed'
+          .delay 100
           .then -> getByIds otherTask._id
           .then (tasks)->
             updatedTask = tasks[0]

--- a/tests/api/tasks/hooks.test.coffee
+++ b/tests/api/tasks/hooks.test.coffee
@@ -2,38 +2,34 @@ CONFIG = require 'config'
 __ = CONFIG.universalPath
 _ = __.require 'builders', 'utils'
 should = require 'should'
-{ authReq, adminReq } = require '../utils/utils'
 { merge } = require '../utils/entities'
-{ collectEntities } = require '../fixtures/tasks'
 { createHuman } = require '../fixtures/entities'
 { deleteByUris: deleteEntityByUris } = require '../utils/entities'
-{ getByIds, getBySuspectUri, getByScore, update } = require '../utils/tasks'
+{ getByIds, getBySuspectUri, update, checkEntities } = require '../utils/tasks'
 
 describe 'tasks:hooks', ->
   describe 'entity merge', ->
     it 'should update same suspect tasks to merged state', (done) ->
       # Alexander Kennedy is expected to have several merge suggestions
       createHuman { labels: { en: 'Alexander Kennedy' } }
-      .then (human)->
-        collectEntities { refresh: true }
-        .then -> getBySuspectUri human.uri
+      .then (human)-> checkEntities human.uri
+      .then (tasks)->
+        task = tasks[0]
+        anotherTask = tasks[1]
+        merge task.suspectUri, task.suggestionUri
+        .delay 100
+        .then -> getByIds anotherTask._id
         .then (tasks)->
-          task = tasks[0]
-          anotherTask = tasks[1]
-          merge task.suspectUri, task.suggestionUri
-          .delay 100
-          .then -> getByIds anotherTask._id
-          .then (tasks)->
-            updatedTask = tasks[0]
-            updatedTask.state.should.equal 'merged'
-            done()
+          updatedTask = tasks[0]
+          updatedTask.state.should.equal 'merged'
+          done()
       .catch done
 
       return
 
     it 'should update task state to merged', (done) ->
-      collectEntities()
-      .then getByScore
+      createHuman { labels: { en: 'Fred Vargas' } }
+      .then (human)-> checkEntities human.uri
       .then (tasks)->
         task = tasks[0]
         merge task.suspectUri, task.suggestionUri
@@ -50,21 +46,19 @@ describe 'tasks:hooks', ->
     it 'should update relationScore of tasks with same suspect', (done)->
       # John Smith is expected to have several merge suggestions
       createHuman { labels: { en: 'John Smith' } }
-      .then (suspect)->
-        collectEntities { refresh: true }
-        .then -> getBySuspectUri suspect.uri
+      .then (human)-> checkEntities human.uri
+      .then (tasks)->
+        taskToUpdate = tasks[0]
+        otherTask = tasks[1]
+        { relationScore: taskRelationScore } = taskToUpdate
+        update taskToUpdate._id, 'state', 'dismissed'
+        .delay 100
+        .then -> getByIds otherTask._id
         .then (tasks)->
-          taskToUpdate = tasks[0]
-          otherTask = tasks[1]
-          { relationScore: taskRelationScore } = taskToUpdate
-          update taskToUpdate._id, 'state', 'dismissed'
-          .delay 100
-          .then -> getByIds otherTask._id
-          .then (tasks)->
-            updatedTask = tasks[0]
-            updatedTask.relationScore.should.not.equal taskRelationScore
-            done()
-        .catch done
+          updatedTask = tasks[0]
+          updatedTask.relationScore.should.not.equal taskRelationScore
+          done()
+      .catch done
 
       return
 
@@ -72,11 +66,10 @@ describe 'tasks:hooks', ->
     it 'should update tasks to merged state', (done) ->
       createHuman { labels: { en: 'Fred Vargas' } }
       .then (human)->
-        collectEntities { refresh: true }
-        .then -> getBySuspectUri human.uri
+        checkEntities human.uri
         .then (tasks)->
           tasks.length.should.be.aboveOrEqual 1
-          deleteEntityByUris human.uri
+          return deleteEntityByUris human.uri
         .then -> getBySuspectUri human.uri
       .then (tasks)->
         tasks.length.should.equal 0

--- a/tests/api/tasks/update.test.coffee
+++ b/tests/api/tasks/update.test.coffee
@@ -5,6 +5,7 @@ should = require 'should'
 { createHuman } = require '../fixtures/entities'
 { update, checkEntities } = require '../utils/tasks'
 
+# Tests dependency: having a populated ElasticSearch wikidata index
 describe 'tasks:update', ->
   it 'should update a task', (done)->
     createHuman { labels: { en: 'Fred Vargas' } }

--- a/tests/api/tasks/update.test.coffee
+++ b/tests/api/tasks/update.test.coffee
@@ -2,15 +2,13 @@ CONFIG = require 'config'
 __ = CONFIG.universalPath
 _ = __.require 'builders', 'utils'
 should = require 'should'
-{ authReq, adminReq } = require '../utils/utils'
-updateEndpoint = '/api/tasks?action=update'
-{ collectEntities } = require '../fixtures/tasks'
-{ getByScore, update } = require '../utils/tasks'
+{ createHuman } = require '../fixtures/entities'
+{ update, checkEntities } = require '../utils/tasks'
 
 describe 'tasks:update', ->
   it 'should update a task', (done)->
-    collectEntities()
-    .then getByScore
+    createHuman { labels: { en: 'Fred Vargas' } }
+    .then (human)-> checkEntities human.uri
     .then (tasks)->
       task = tasks[0]
       update task._id, 'state', 'dismissed'

--- a/tests/api/utils/tasks.coffee
+++ b/tests/api/utils/tasks.coffee
@@ -14,13 +14,20 @@ module.exports =
     nonAuthReq 'get', "#{endpoint}by-suspect-uri&uri=#{uri}"
     .get 'tasks'
 
-  getByScore: ->
-    nonAuthReq 'get', "#{endpoint}by-score&limit=1000"
+  getByScore: (options = {})->
+    url = "#{endpoint}by-score"
+    { limit, offset } = options
+    if limit? then url += "&limit=#{limit}"
+    if offset? then url += "&offset=#{offset}"
+    nonAuthReq 'get', url
     .get 'tasks'
 
   update: (id, attribute, value)->
     adminReq 'put', "#{endpoint}update", { id, attribute, value }
 
   checkEntities: (uris)->
+    uris = _.forceArray uris
     adminReq 'post', "#{endpoint}check-entities", { uris }
     .get 'tasks'
+
+  collectEntities: -> adminReq 'post', "#{endpoint}collect-entities"

--- a/tests/api/utils/tasks.coffee
+++ b/tests/api/utils/tasks.coffee
@@ -19,4 +19,8 @@ module.exports =
     .get 'tasks'
 
   update: (id, attribute, value)->
-    adminReq 'put', '/api/tasks?action=update', { id, attribute, value }
+    adminReq 'put', "#{endpoint}update", { id, attribute, value }
+
+  checkEntities: (uris)->
+    adminReq 'post', "#{endpoint}check-entities", { uris }
+    .get 'tasks'


### PR DESCRIPTION
mainly by the introduction of a `check-entities` endpoint (0802afd) that allows to reliably test tasks creation without the hazards of `collect-entities` job creation