### PR TITLE
entities properties: added SUDOC and ORCID IDs

### DIFF
--- a/server/controllers/entities/lib/properties.coffee
+++ b/server/controllers/entities/lib/properties.coffee
@@ -45,6 +45,8 @@ properties =
   'wdt:P179': bases.serieEntity
   # ISBN 13
   'wdt:P212': builders.isbnProperty 13
+  # SUDOC authorities ID
+  'wdt:P269': builders.externalId /^\d{8}[\dX]?$/
   # VIAF id
   'wdt:P214': builders.externalId /^[1-9]\d(\d{0,7}|\d{17,20})$/
   # BNF id
@@ -53,6 +55,8 @@ properties =
   'wdt:P364': bases.entity
   # language of work
   'wdt:P407': bases.entity
+  # ORCID ID
+  'wdt:P496': builders.externalId /^0000-000(1-[5-9]|2-[0-9]|3-[0-4])\d{3}-\d{3}[\dX]?$/
   # date of birth
   'wdt:P569': bases.uniqueSimpleDay
   # date of death

--- a/server/lib/wikidata/whitelisted_properties.coffee
+++ b/server/lib/wikidata/whitelisted_properties.coffee
@@ -30,11 +30,13 @@ module.exports = [
   'P195' # collection
   'P212' # isbn 13
   'P268' # BnF ID
+  'P269' # SUDOC authorities ID
   'P279' # subclass of
   'P356' # DOI
   'P361' # part of
   'P364' # original language of work
   'P407' # language of work
+  'P496' # ORCID ID
   'P577' # publication date
   'P569' # date of birth
   'P570' # date of death
@@ -52,6 +54,7 @@ module.exports = [
   'P957' # isbn 10
   'P1066' # student of
   'P1104' # number of pages
+  'P1433' # published in
   'P1412' # languages spoken, written or signed
   'P1476' # title
   'P1545' # series ordinal


### PR DESCRIPTION
and whitelisted SUDOC, ORCID IDs, and 'published in'

Adding SUDOC and ORCID IDs will allow to add those ids to inv entities, while just whitelisting 'published in' (P1433) will allow to display this relation on wd entities without supporting it for inv entities yet