### PR TITLE
Fix db follow

### DIFF
--- a/server/controllers/user/lib/geo/follow.coffee
+++ b/server/controllers/user/lib/geo/follow.coffee
@@ -14,7 +14,7 @@ module.exports = (db)->
 
     return false
 
-  onChange = (change)->
+  updatePosition = (change)->
     { id, deleted, doc } = change
     { position } = doc
 
@@ -26,7 +26,7 @@ module.exports = (db)->
       db.getByKey id
       .catch (err)-> if err.notFound then return null else throw err
       .then updateIfNeeded.bind(null, id, lat, lon)
-      .catch _.Error('user geo onChange err')
+      .catch _.Error('user geo updatePosition err')
 
   updateIfNeeded = (id, lat, lon, res)->
     if res?
@@ -35,14 +35,8 @@ module.exports = (db)->
 
     db.put { lat, lon }, id, null
 
-  startFollowing = (res)-> follow { dbBaseName, filter, onChange }
+  reset = ->
+    _.log "reseting #{dbBaseName} geo index", null, 'yellow'
+    return db.reset()
 
-  resetIfNeeded = ->
-    if resetFollow then db.reset()
-    else promises_.resolved
-
-  resetIfNeeded()
-  .then startFollowing
-  # catching the error without rethrowing
-  # as nobody is listening/waiting for it
-  .catch _.Error('geo follow init error')
+  follow { dbBaseName, filter, onChange: updatePosition, reset }

--- a/server/db/couch/init_design_doc_sync.coffee
+++ b/server/db/couch/init_design_doc_sync.coffee
@@ -22,7 +22,7 @@ init = ->
     follow
       dbBaseName: dbBaseName
       filter: isDesignDoc designDocsNames
-      onChange: syncDesignDocFile
+      onChange: _.debounce syncDesignDocFile, 1000
 
 isDesignDoc = (designDocsNames)-> (doc)->
   [ prefix, designDocsName ] = doc._id.split('/')

--- a/server/lib/follow.coffee
+++ b/server/lib/follow.coffee
@@ -4,11 +4,12 @@
 CONFIG = require 'config'
 __ = CONFIG.universalPath
 _ = __.require 'builders', 'utils'
+promises_ = __.require 'lib', 'promises'
 follow = require 'follow'
 meta = __.require 'lib', 'meta'
 breq = require 'bluereq'
 dbHost = CONFIG.db.fullHost()
-{ reset:resetFollow, freeze:freezeFollow, delay:delayFollow } = CONFIG.db.follow
+{ reset: resetFollow, freeze: freezeFollow, delay: delayFollow } = CONFIG.db.follow
 
 # Never follow in non-server mode.
 # This behaviors allows, in API tests environement, to have the tests server
@@ -20,8 +21,11 @@ freezeFollow = freezeFollow or not CONFIG.serverMode
 followers = {}
 
 module.exports = (params)->
-  { dbBaseName, filter, onChange } = params
-  _.types [ dbBaseName, filter, onChange ], [ 'string', 'function', 'function' ]
+  { dbBaseName, filter, onChange, reset } = params
+  _.type dbBaseName, 'string'
+  _.type filter, 'function'
+  _.type onChange, 'function'
+  _.type reset, 'function|undefined'
 
   dbName = CONFIG.db.name dbBaseName
 
@@ -40,12 +44,14 @@ module.exports = (params)->
     meta.get buildKey(dbName)
     # after a bit, to let other followers the time to register, and CouchDB
     # the time to initialize, while letting other initialization functions
-    # with a higher priority level some time to run
+    # with a higher priority level some time to run.
+    # It won't miss any changes as CouchDB will send everything that happened since
+    # the last saved sequence number
     .delay delayFollow
-    .then initFollow(dbName)
+    .then initFollow(dbName, reset)
     .catch _.ErrorRethrow('init follow err')
 
-initFollow = (dbName)-> (lastSeq = 0)->
+initFollow = (dbName, reset)-> (lastSeq = 0)->
   if resetFollow then lastSeq = 0
   _.type lastSeq, 'number'
 
@@ -62,19 +68,28 @@ initFollow = (dbName)-> (lastSeq = 0)->
       lastSeq = 0
       setLastSeq lastSeq
 
-    config =
-      db: dbUrl
-      include_docs: true
-      feed: 'continuous'
-      since: lastSeq
+    resetIfNeeded dbName, lastSeq, reset
+    .then -> startFollowingDb { dbName, dbUrl, lastSeq, setLastSeq }
 
-    follow config, (err, change)->
-      if err? then return _.error err, "#{dbName} follow err"
+resetIfNeeded = (dbName, lastSeq, reset)->
+  if lastSeq is 0 and reset? then reset()
+  else promises_.resolve()
 
-      { seq } = change
-      setLastSeq seq
-      for follower in followers[dbName]
-        if follower.filter(change.doc) then follower.onChange change
+startFollowingDb = (params)->
+  { dbName, dbUrl, lastSeq, setLastSeq } = params
+  dbFollowers = followers[dbName]
+
+  config =
+    db: dbUrl
+    include_docs: true
+    feed: 'continuous'
+    since: lastSeq
+
+  follow config, (err, change)->
+    if err? then return _.error err, "#{dbName} follow err"
+    setLastSeq change.seq
+    for follower in dbFollowers
+      if follower.filter(change.doc) then follower.onChange change
 
 SetLastSeq = (dbName)->
   key = buildKey dbName


### PR DESCRIPTION
My dev setup was falling to update design docs files as requested by [`server/db/couch/init_design_doc_sync`](https://github.com/inventaire/inventaire/blob/aafa8b8/server/db/couch/init_design_doc_sync.coffee) when design docs on CouchDB change. After some joyful debugging, it appeared that it was because the leveldb-based `meta` db was keeping a `last_seq` value ahead of the current `last_seq`, thus never calling `onChange` functions despite new changes.
* 1a9aa84 fixes this by checking this kind of incoherence with the database before starting to follow changes
* 371da9a is then just a refactor of `reset` actions, currently only used by the users geo index