### PR TITLE
Fix items snapshot image

### DIFF
--- a/server/controllers/items/lib/snapshot/get_entities.coffee
+++ b/server/controllers/items/lib/snapshot/get_entities.coffee
@@ -5,8 +5,8 @@ getEntitiesByUris = __.require 'controllers', 'entities/lib/get_entities_by_uris
 { Promise } = __.require 'lib', 'promises'
 { aggregateClaims } = require './helpers'
 
-getRelativeEntities = (relationProperty)-> (work)->
-  uris = work.claims[relationProperty]
+getRelativeEntities = (relationProperty)-> (entity)->
+  uris = entity.claims[relationProperty]
   unless uris?.length > 0 then return Promise.resolve []
   getEntitiesByUris uris
   .then (res)-> _.values(res.entities)

--- a/server/controllers/items/lib/snapshot/refresh_snapshot.coffee
+++ b/server/controllers/items/lib/snapshot/refresh_snapshot.coffee
@@ -3,7 +3,7 @@ _ = __.require 'builders', 'utils'
 items_ = require '../items'
 entities_ = __.require 'controllers', 'entities/lib/entities'
 getEntityByUri = __.require 'controllers', 'entities/lib/get_entity_by_uri'
-getInvEntityCanonicalUri = __.require 'controllers', 'entities/lib/get_inv_entity_canonical_uri'
+getEntitiesByUris = __.require 'controllers', 'entities/lib/get_entities_by_uris'
 buildSnapshot = require './build_snapshot'
 { getWorkAuthorsAndSeries, getEditionGraphEntities } = require './get_entities'
 { getDocData } = require './helpers'
@@ -64,12 +64,13 @@ getWorkSnapshot = (uri, work, authors, series)->
 getEditionsSnapshots = (uri, works, authors, series)->
   _.types arguments, [ 'string', 'array', 'array', 'array' ]
 
-  entities_.byClaim 'wdt:P629', uri, true, true
+  entities_.urisByClaim 'wdt:P629', uri
+  .then getEntitiesByUris
+  .then (res)-> _.values res.entities
   .map (edition)-> getEditionSnapshot edition, works, authors, series
 
 getEditionSnapshot = (edition, works, authors, series)->
   _.types arguments, [ 'object', 'array', 'array', 'array' ]
-
-  # If it's a Wikidata entity, it will already have a uri
-  edition.uri or= getInvEntityCanonicalUri(edition)[0]
+  # Expects a formatted edition
+  _.type edition.uri, 'string'
   return buildSnapshot.edition edition, works, authors, series

--- a/tests/api/fixtures/entities.coffee
+++ b/tests/api/fixtures/entities.coffee
@@ -7,6 +7,7 @@ isbn_ = __.require 'lib', 'isbn/isbn'
 wdLang = require 'wikidata-lang'
 { getByUris, addClaim } = require '../utils/entities'
 faker = require 'faker'
+someImageHash = '00015893d54f5112b99b41b0dfd851f381798047'
 
 defaultEditionData = ->
   labels: {}
@@ -59,6 +60,7 @@ module.exports = API =
           'wdt:P629': worksUris
           'wdt:P1476': [ _.values(works[0].labels)[0] ]
           'wdt:P407': [ 'wd:' + wdLang.byCode[lang].wd ]
+          'invp:P2': [ someImageHash ]
 
   createEditionFromWorks: (works...)->
     params = { works }
@@ -94,6 +96,8 @@ module.exports = API =
           editionData.claims['wdt:P212'] = [ isbn_.toIsbn13h(id) ]
         editionData.claims['wdt:P629'] = [ workEntity.uri ]
         authReq 'post', '/api/entities?action=create', editionData
+
+  someImageHash: someImageHash
 
 addEntityClaim = (createFnName, property)-> (subjectEntity)->
   API[createFnName]()

--- a/tests/api/items/snapshot.test.coffee
+++ b/tests/api/items/snapshot.test.coffee
@@ -11,44 +11,6 @@ should = require 'should'
 { updateClaim } = require '../utils/entities'
 
 describe 'items:snapshot', ->
-  it 'should be updated when its local edition entity title changes', (done)->
-    createWork()
-    .then createEditionFromWorks
-    .then (res)->
-      { _id:entityId, uri } = res
-      authReq 'post', '/api/items', { entity: uri }
-      .then (item)->
-        currentTitle = item.snapshot['entity:title']
-        updatedTitle = currentTitle.split('$$')[0] + '$$' + new Date().toISOString()
-
-        updateClaim entityId, 'wdt:P1476', currentTitle, updatedTitle
-        .delay 100
-        .then -> getItem item
-        .then (updatedItem)->
-          updatedItem.snapshot['entity:title'].should.equal updatedTitle
-          done()
-    .catch undesiredErr(done)
-
-    return
-
-  it 'should be updated when its local work entity title changes', (done)->
-    createWork()
-    .then (res)->
-      { _id:entityId, uri } = res
-      authReq 'post', '/api/items', { entity: uri, lang: 'en' }
-      .then (item)->
-        currentTitle = item.snapshot['entity:title']
-        updatedTitle = currentTitle + ' ' + new Date().toISOString()
-        updateLabel entityId, 'en', updatedTitle
-        .delay 100
-        .then -> getItem item
-        .then (updatedItem)->
-          updatedItem.snapshot['entity:title'].should.equal updatedTitle
-          done()
-    .catch undesiredErr(done)
-
-    return
-
   it "should snapshot the item's work series names", (done)->
     createWork()
     .then (workEntity)->
@@ -60,30 +22,6 @@ describe 'items:snapshot', ->
           title = _.values(serieEntity.labels)[0]
           item.snapshot['entity:series'].should.equal title
           done()
-    .catch undesiredErr(done)
-
-    return
-
-  it 'should be updated when its local serie entity title changes', (done)->
-    createWork()
-    .then (workEntity)->
-      authReq 'post', '/api/items', { entity: workEntity.uri, lang: 'en' }
-      .delay 200
-      .then (item)->
-        addSerie workEntity
-        .delay 200
-        .then (serieEntity)->
-          title = _.values(serieEntity.labels)[0]
-          getItem item
-          .then (updatedItem)->
-            updatedItem.snapshot['entity:series'].should.equal title
-            updatedTitle = title + '-updated'
-            updateLabel serieEntity._id, 'en', updatedTitle
-            .delay 200
-            .then -> getItem item
-            .then (reupdatedItem)->
-              reupdatedItem.snapshot['entity:series'].should.equal updatedTitle
-              done()
     .catch undesiredErr(done)
 
     return
@@ -108,144 +46,6 @@ describe 'items:snapshot', ->
           .then (item)->
             item.snapshot['entity:ordinal'].should.equal '6'
             done()
-    .catch undesiredErr(done)
-
-    return
-
-  it 'should be updated when its local author entity title changes (edition entity)', (done)->
-    ensureEditionExists 'isbn:9788389920935', null,
-      labels: {}
-      claims:
-        'wdt:P31': [ 'wd:Q3331189' ]
-        'wdt:P212': [ '978-83-89920-93-5' ]
-        'wdt:P1476': [ 'some title' ]
-    .then (editionDoc)->
-      workUri = editionDoc.claims['wdt:P629'][0]
-      getByUris workUri
-    .then (res)->
-      workEntity = _.values(res.entities)[0]
-      trueAuthorUri = workEntity.claims['wdt:P50'][0]
-      authReq 'post', '/api/items', { entity: 'isbn:9788389920935' }
-      .delay 200
-      .then (item)->
-        updateAuthorName = humanName()
-        updateLabel trueAuthorUri, 'en', updateAuthorName
-        .delay 200
-        .then -> getItem item
-        .then (updatedItem)->
-          updatedItem.snapshot['entity:authors'].should.equal updateAuthorName
-          done()
-    .catch undesiredErr(done)
-
-    return
-
-  it 'should be updated when its local author entity title changes (work entity)', (done)->
-    createWorkWithAuthor()
-    .then (workEntity)->
-      authReq 'post', '/api/items', { entity: workEntity.uri, lang: 'en' }
-      .then (item)->
-        updateAuthorName = humanName()
-        uri = workEntity.claims['wdt:P50'][0]
-        updateLabel uri, 'en', updateAuthorName
-        .delay 100
-        .then -> getItem item
-        .then (item)->
-          item.snapshot['entity:authors'].should.equal updateAuthorName
-          done()
-    .catch undesiredErr(done)
-
-    return
-
-  it 'should be updated when its local work entity is merged (work entity)', (done)->
-    Promise.all [
-      getUserId()
-      createWork()
-      createWork()
-    ]
-    .spread (userId, workEntityA, workEntityB)->
-      authReq 'post', '/api/items', { entity: workEntityA.uri, lang: 'en' }
-      .tap -> merge workEntityA.uri, workEntityB.uri
-      .then getItem
-      .then (updatedItem)->
-        updatedTitle = workEntityB.labels.en
-        updatedItem.snapshot['entity:title'].should.equal updatedTitle
-        done()
-    .catch undesiredErr(done)
-
-    return
-
-  it 'should be updated when its local work entity is merged (edition entity)', (done)->
-    Promise.all [
-      getUserId()
-      createWork()
-      createWork()
-    ]
-    .spread (userId, workEntityA, workEntityB)->
-      createEditionFromWorks workEntityA
-      .then (editionEntity)->
-        Promise.all [
-          authReq 'post', '/api/items', { entity: editionEntity.uri }
-          addAuthor workEntityB
-        ]
-        .delay 200
-        .tap -> merge workEntityA.uri, workEntityB.uri
-        .delay 200
-        .spread (item, addedAuthor)->
-          getItem item
-          .then (updatedItem)->
-            authorName = _.values(addedAuthor.labels)[0]
-            updatedItem.snapshot['entity:authors'].should.equal authorName
-            done()
-    .catch undesiredErr(done)
-
-    return
-
-  it 'should be updated when its local author entity is merged', (done)->
-    Promise.all [
-      getUserId()
-      createHuman()
-      createHuman()
-    ]
-    .spread (userId, authorEntityA, authorEntityB)->
-      createWorkWithAuthor authorEntityA
-      .then (workEntity)->
-        authReq 'post', '/api/items', { entity: workEntity.uri, lang: 'en' }
-      .delay 200
-      .tap -> merge authorEntityA.uri, authorEntityB.uri
-      .delay 200
-      .then getItem
-      .then (updatedItem)->
-        updatedAuthors = authorEntityB.labels.en
-        updatedItem.snapshot['entity:authors'].should.equal updatedAuthors
-        done()
-    .catch undesiredErr(done)
-
-    return
-
-  it 'should be updated when its local author entity is merged and reverted', (done)->
-    Promise.all [
-      getUserId()
-      createHuman()
-      createHuman()
-    ]
-    .spread (userId, authorEntityA, authorEntityB)->
-      createWorkWithAuthor authorEntityA
-      .then (workEntity)->
-        authReq 'post', '/api/items', { entity: workEntity.uri, lang: 'en' }
-      .delay 200
-      .tap -> merge authorEntityA.uri, authorEntityB.uri
-      .delay 200
-      .then getItem
-      .then (updatedItem)->
-        updatedAuthors = authorEntityB.labels.en
-        updatedItem.snapshot['entity:authors'].should.equal updatedAuthors
-        revertMerge authorEntityA.uri
-        .delay 200
-        .then -> getItem updatedItem
-        .then (reupdatedItem)->
-          oldAuthors = authorEntityA.labels.en
-          reupdatedItem.snapshot['entity:authors'].should.equal oldAuthors
-          done()
     .catch undesiredErr(done)
 
     return
@@ -278,30 +78,231 @@ describe 'items:snapshot', ->
 
     return
 
-  it 'should be updated when its entity changes', (done)->
-    Promise.all [
-      getUserId()
+  describe 'update', ->
+    it 'should be updated when its local edition entity title changes', (done)->
       createWork()
-    ]
-    .spread (userId, workEntityA)->
-      Promise.all [
-        createEditionFromWorks workEntityA
-        authReq 'post', '/api/items', { entity: workEntityA.uri, lang: 'en' }
-      ]
-      .delay 100
-      .spread (editionEntity, item)->
-        getByIds item._id
-        .then (res)->
-          item = res.items[0]
-          item.entity = editionEntity.uri
-          return authReq 'put', '/api/items', item
-        .then (updatedItem)->
-          editionTitle = editionEntity.claims['wdt:P1476'][0]
-          updatedItem.snapshot['entity:title'].should.equal editionTitle
-          done()
-    .catch undesiredErr(done)
+      .then createEditionFromWorks
+      .then (res)->
+        { _id:entityId, uri } = res
+        authReq 'post', '/api/items', { entity: uri }
+        .then (item)->
+          currentTitle = item.snapshot['entity:title']
+          updatedTitle = currentTitle.split('$$')[0] + '$$' + new Date().toISOString()
 
-    return
+          updateClaim entityId, 'wdt:P1476', currentTitle, updatedTitle
+          .delay 100
+          .then -> getItem item
+          .then (updatedItem)->
+            updatedItem.snapshot['entity:title'].should.equal updatedTitle
+            done()
+      .catch undesiredErr(done)
+
+      return
+
+    it 'should be updated when its local work entity title changes', (done)->
+      createWork()
+      .then (res)->
+        { _id:entityId, uri } = res
+        authReq 'post', '/api/items', { entity: uri, lang: 'en' }
+        .then (item)->
+          currentTitle = item.snapshot['entity:title']
+          updatedTitle = currentTitle + ' ' + new Date().toISOString()
+          updateLabel entityId, 'en', updatedTitle
+          .delay 100
+          .then -> getItem item
+          .then (updatedItem)->
+            updatedItem.snapshot['entity:title'].should.equal updatedTitle
+            done()
+      .catch undesiredErr(done)
+
+      return
+
+    it 'should be updated when its local serie entity title changes', (done)->
+      createWork()
+      .then (workEntity)->
+        authReq 'post', '/api/items', { entity: workEntity.uri, lang: 'en' }
+        .delay 200
+        .then (item)->
+          addSerie workEntity
+          .delay 200
+          .then (serieEntity)->
+            title = _.values(serieEntity.labels)[0]
+            getItem item
+            .then (updatedItem)->
+              updatedItem.snapshot['entity:series'].should.equal title
+              updatedTitle = title + '-updated'
+              updateLabel serieEntity._id, 'en', updatedTitle
+              .delay 200
+              .then -> getItem item
+              .then (reupdatedItem)->
+                reupdatedItem.snapshot['entity:series'].should.equal updatedTitle
+                done()
+      .catch undesiredErr(done)
+
+      return
+
+    it 'should be updated when its local author entity title changes (edition entity)', (done)->
+      ensureEditionExists 'isbn:9788389920935', null,
+        labels: {}
+        claims:
+          'wdt:P31': [ 'wd:Q3331189' ]
+          'wdt:P212': [ '978-83-89920-93-5' ]
+          'wdt:P1476': [ 'some title' ]
+      .then (editionDoc)->
+        workUri = editionDoc.claims['wdt:P629'][0]
+        getByUris workUri
+      .then (res)->
+        workEntity = _.values(res.entities)[0]
+        trueAuthorUri = workEntity.claims['wdt:P50'][0]
+        authReq 'post', '/api/items', { entity: 'isbn:9788389920935' }
+        .delay 200
+        .then (item)->
+          updateAuthorName = humanName()
+          updateLabel trueAuthorUri, 'en', updateAuthorName
+          .delay 200
+          .then -> getItem item
+          .then (updatedItem)->
+            updatedItem.snapshot['entity:authors'].should.equal updateAuthorName
+            done()
+      .catch undesiredErr(done)
+
+      return
+
+    it 'should be updated when its local author entity title changes (work entity)', (done)->
+      createWorkWithAuthor()
+      .then (workEntity)->
+        authReq 'post', '/api/items', { entity: workEntity.uri, lang: 'en' }
+        .then (item)->
+          updateAuthorName = humanName()
+          uri = workEntity.claims['wdt:P50'][0]
+          updateLabel uri, 'en', updateAuthorName
+          .delay 100
+          .then -> getItem item
+          .then (item)->
+            item.snapshot['entity:authors'].should.equal updateAuthorName
+            done()
+      .catch undesiredErr(done)
+
+      return
+
+    it 'should be updated when its local work entity is merged (work entity)', (done)->
+      Promise.all [
+        getUserId()
+        createWork()
+        createWork()
+      ]
+      .spread (userId, workEntityA, workEntityB)->
+        authReq 'post', '/api/items', { entity: workEntityA.uri, lang: 'en' }
+        .tap -> merge workEntityA.uri, workEntityB.uri
+        .then getItem
+        .then (updatedItem)->
+          updatedTitle = workEntityB.labels.en
+          updatedItem.snapshot['entity:title'].should.equal updatedTitle
+          done()
+      .catch undesiredErr(done)
+
+      return
+
+    it 'should be updated when its local work entity is merged (edition entity)', (done)->
+      Promise.all [
+        getUserId()
+        createWork()
+        createWork()
+      ]
+      .spread (userId, workEntityA, workEntityB)->
+        createEditionFromWorks workEntityA
+        .then (editionEntity)->
+          Promise.all [
+            authReq 'post', '/api/items', { entity: editionEntity.uri }
+            addAuthor workEntityB
+          ]
+          .delay 200
+          .tap -> merge workEntityA.uri, workEntityB.uri
+          .delay 200
+          .spread (item, addedAuthor)->
+            getItem item
+            .then (updatedItem)->
+              authorName = _.values(addedAuthor.labels)[0]
+              updatedItem.snapshot['entity:authors'].should.equal authorName
+              done()
+      .catch undesiredErr(done)
+
+      return
+
+    it 'should be updated when its local author entity is merged', (done)->
+      Promise.all [
+        getUserId()
+        createHuman()
+        createHuman()
+      ]
+      .spread (userId, authorEntityA, authorEntityB)->
+        createWorkWithAuthor authorEntityA
+        .then (workEntity)->
+          authReq 'post', '/api/items', { entity: workEntity.uri, lang: 'en' }
+        .delay 200
+        .tap -> merge authorEntityA.uri, authorEntityB.uri
+        .delay 200
+        .then getItem
+        .then (updatedItem)->
+          updatedAuthors = authorEntityB.labels.en
+          updatedItem.snapshot['entity:authors'].should.equal updatedAuthors
+          done()
+      .catch undesiredErr(done)
+
+      return
+
+    it 'should be updated when its local author entity is merged and reverted', (done)->
+      Promise.all [
+        getUserId()
+        createHuman()
+        createHuman()
+      ]
+      .spread (userId, authorEntityA, authorEntityB)->
+        createWorkWithAuthor authorEntityA
+        .then (workEntity)->
+          authReq 'post', '/api/items', { entity: workEntity.uri, lang: 'en' }
+        .delay 200
+        .tap -> merge authorEntityA.uri, authorEntityB.uri
+        .delay 200
+        .then getItem
+        .then (updatedItem)->
+          updatedAuthors = authorEntityB.labels.en
+          updatedItem.snapshot['entity:authors'].should.equal updatedAuthors
+          revertMerge authorEntityA.uri
+          .delay 200
+          .then -> getItem updatedItem
+          .then (reupdatedItem)->
+            oldAuthors = authorEntityA.labels.en
+            reupdatedItem.snapshot['entity:authors'].should.equal oldAuthors
+            done()
+      .catch undesiredErr(done)
+
+      return
+
+    it 'should be updated when its entity changes', (done)->
+      Promise.all [
+        getUserId()
+        createWork()
+      ]
+      .spread (userId, workEntityA)->
+        Promise.all [
+          createEditionFromWorks workEntityA
+          authReq 'post', '/api/items', { entity: workEntityA.uri, lang: 'en' }
+        ]
+        .delay 100
+        .spread (editionEntity, item)->
+          getByIds item._id
+          .then (res)->
+            item = res.items[0]
+            item.entity = editionEntity.uri
+            return authReq 'put', '/api/items', item
+          .then (updatedItem)->
+            editionTitle = editionEntity.claims['wdt:P1476'][0]
+            updatedItem.snapshot['entity:title'].should.equal editionTitle
+            done()
+      .catch undesiredErr(done)
+
+      return
 
   # TODO:
   # it 'should be updated when its remote author entity changes', (done)->

--- a/tests/api/utils/items.coffee
+++ b/tests/api/utils/items.coffee
@@ -3,7 +3,11 @@ __ = CONFIG.universalPath
 _ = __.require 'builders', 'utils'
 { authReq } = require './utils'
 
-module.exports =
+module.exports = utils =
   getByIds: (ids)->
     if _.isArray(ids) then ids = ids.join('|')
     authReq 'get', "/api/items?action=by-ids&ids=#{ids}"
+
+  getById: (item)->
+    utils.getByIds item._id
+    .then (res)-> res.items[0]


### PR DESCRIPTION
well, that was ugly

the issue was that [non-formatted edition docs (that is, without .image.url attribute) were used when refreshing snapshot following an event on the work](https://github.com/inventaire/inventaire/blob/a9fecad/server/controllers/items/lib/snapshot/refresh_snapshot.coffee#L67), creating this weird situation were snapshot refresh triggered by the edition returned with images but not when triggered from the work...