### PR TITLE
build_task_docs: refactor

### DIFF
--- a/server/controllers/entities/lib/find_author_from_works_labels.coffee
+++ b/server/controllers/entities/lib/find_author_from_works_labels.coffee
@@ -6,7 +6,7 @@ __ = CONFIG.universalPath
 _ = __.require 'builders', 'utils'
 typeSearch = __.require 'controllers', 'search/lib/type_search'
 { prefixifyWd } = __.require 'controllers', 'entities/lib/prefix'
-hasWorksLabelsOccurrence = require './has_works_labels_occurrence'
+getWorksLabelsOccurrence = require './get_works_labels_occurrence'
 
 # Returns a URI if an single author was identified
 # returns undefined otherwise
@@ -34,5 +34,7 @@ getWdAuthorUris = (res)->
   .map (hit)-> prefixifyWd hit._id
 
 getAuthorOccurrenceData = (worksLabels, worksLabelsLangs)-> (wdAuthorUri)->
-  hasWorksLabelsOccurrence wdAuthorUri, worksLabels, worksLabelsLangs
-  .then (hasOccurrence)-> { uri: wdAuthorUri, hasOccurrence }
+  getWorksLabelsOccurrence wdAuthorUri, worksLabels, worksLabelsLangs
+  .then (occurrence)->
+    hasOccurrence = occurrence.length > 0
+    return { uri: wdAuthorUri, hasOccurrence }

--- a/server/controllers/tasks/lib/automerge.coffee
+++ b/server/controllers/tasks/lib/automerge.coffee
@@ -4,25 +4,27 @@ mergeEntities = __.require 'controllers', 'entities/lib/merge_entities'
 { _id: reconcilerUserId } = __.require('couch', 'hard_coded_documents').users.reconciler
 { prefixifyInv } = __.require 'controllers', 'entities/lib/prefix'
 
-module.exports = (suggestions, authorWorksData)-> (occurrences)->
-  unless occurrences.length > 0 then return occurrences
-  { labels, authorId } = authorWorksData
-  matchedTitles = getMatchedTitles occurrences
-  # TODO : check every labels to merge entity
-  unless canBeAutomerged suggestions, matchedTitles then return occurrences
-  # Assume first occurrence is the right one to merge into
-  # since only one suggestion necessary to merge
-  # occurrences of first suggestion picked
-  mergeEntities reconcilerUserId, prefixifyInv(authorId), occurrences[0].uri
-  return []
+module.exports = (suspectUri)-> (suggestions)->
+  suggestionsWithOccurrences = suggestions.filter hasOccurrences
+  _.log suggestionsWithOccurrences, 'suggestionsWithOccurrences'
+  # No suggestion has occurrences, all should get a task
+  if suggestionsWithOccurrences.length is 0 then return suggestions
+  # Some suggestions have occurrences, those only should get a task
+  if suggestionsWithOccurrences.length > 1 then return suggestionsWithOccurrences
+  # Else, only the one that has occurrences should either be automerged or get a task
+  suggestionWithOccurrences = suggestionsWithOccurrences[0]
+  unless canBeAutomerged suggestionWithOccurrences then return suggestionsWithOccurrences
 
-getMatchedTitles = (occurrences)->
-  matchedTitles = occurrences.map (occ)-> _.map(occ.occurrences, 'matchedTitles')
-  return _.flattenDeep matchedTitles
+  foundUri = suggestionWithOccurrences.uri
+  _.log { suspectUri, foundUri }, 'automerging'
+  mergeEntities reconcilerUserId, suspectUri, foundUri
+  # No task should be created
+  .then -> return []
 
-canBeAutomerged = (suggestions, matchedTitles)->
-  # Several suggestions == has homonym => cannot be merged
-  unless suggestions.length is 1 then return false
+hasOccurrences = (suggestion)-> suggestion.occurrences.length > 0
+
+canBeAutomerged = (suggestion)->
+  matchedTitles =  _.flatten _.map(suggestion.occurrences, 'matchedTitles')
   longTitles = matchedTitles.filter isLongTitle
   return longTitles.length > 0
 

--- a/server/controllers/tasks/lib/build_task_docs.coffee
+++ b/server/controllers/tasks/lib/build_task_docs.coffee
@@ -4,55 +4,40 @@ _ = __.require 'builders', 'utils'
 searchEntityDuplicatesSuggestions = require './search_entity_duplicates_suggestions'
 { calculateRelationScore } = require './relation_score'
 getAuthorWorksData = require './get_author_works_data'
-hasWorksLabelsOccurrence = __.require 'controllers', 'entities/lib/has_works_labels_occurrence'
+getWorksLabelsOccurrence = __.require 'controllers', 'entities/lib/get_works_labels_occurrence'
 { prefixifyInv } = __.require 'controllers', 'entities/lib/prefix'
 automerge = require './automerge'
 
 module.exports = (entity)->
+  { uri: suspectUri } = entity
   Promise.all [
     searchEntityDuplicatesSuggestions entity
     getAuthorWorksData entity._id
   ]
   .spread (suggestions, authorWorksData)->
     unless suggestions.length > 0 then return []
-    Promise.all suggestions.map(getOccurrences authorWorksData)
-    .then _.compact
-    .then automerge(suggestions, authorWorksData)
-    .then (occurrences)->
-      Promise.all filterSuggestions(occurrences, suggestions)
-      .then createTasksDocs(authorWorksData, occurrences)
+    Promise.all suggestions.map(addOccurrences(authorWorksData))
+    .then automerge(suspectUri)
+    # build tasks from remaining suggestions, if any
+    .then buildTasksDocs(suspectUri)
 
-filterSuggestions = (occurrences, suggestions)->
-  # Create a task for every suggestions
-  unless occurrences.length > 0 then return suggestions
-  # Create tasks only for suggestions with occurrences
-  occurrencesUris = _.map occurrences, 'uri'
-  return suggestions.filter (suggestion)-> suggestion.uri in occurrencesUris
-
-createTasksDocs = (authorWorksData, occurrences)-> (suggestions)->
-  relationScore = calculateRelationScore suggestions
-  return suggestions.map createTaskDoc(authorWorksData, relationScore, occurrences)
-
-getOccurrences = (authorWorksData)-> (suggestion)->
+addOccurrences = (authorWorksData)-> (suggestion)->
   { labels, langs } = authorWorksData
   { uri } = suggestion
-  hasWorksLabelsOccurrence uri, labels, langs
+  getWorksLabelsOccurrence uri, labels, langs
   .then (occurrences)->
-    if occurrences.length is 0 then return false
-    return { uri, occurrences }
+    _.log occurrences, 'occurrences'
+    suggestion.occurrences = occurrences
+    return suggestion
 
-createTaskDoc = (authorWorksData, relationScore, suggestionsOccurrences)->
-  occurrencesBySuggestionUri = _.keyBy suggestionsOccurrences, 'uri'
-  return (suggestion)->
-    { authorId } = authorWorksData
-    occurrencesObj = occurrencesBySuggestionUri[suggestion.uri]
-    unless _.isEmpty occurrencesObj
-      occurrences = occurrencesObj['occurrences']
-    return {
-      type: 'deduplicate'
-      suspectUri: prefixifyInv authorId
-      suggestionUri: suggestion.uri
-      lexicalScore: suggestion._score
-      relationScore: relationScore
-      externalSourcesOccurrences: occurrences or []
-    }
+buildTasksDocs = (suspectUri)-> (suggestions)->
+  relationScore = calculateRelationScore suggestions
+  return suggestions.map createTaskDoc(suspectUri, relationScore)
+
+createTaskDoc = (suspectUri, relationScore)-> (suggestion)->
+  type: 'deduplicate'
+  suspectUri: suspectUri
+  suggestionUri: suggestion.uri
+  lexicalScore: suggestion._score
+  relationScore: relationScore
+  externalSourcesOccurrences: suggestion.occurrences

--- a/tests/api/tasks/external_sources_occurrences.test.coffee
+++ b/tests/api/tasks/external_sources_occurrences.test.coffee
@@ -39,7 +39,7 @@ describe 'tasks:externalSourcesOccurrences', ->
 
     return
 
-  it 'should create tasks if author has homonyms and occurrences', (done)->
+  it 'should automerge if author has homonyms but only one has occurrences', (done)->
     humanLabel = 'Alan Moore' # homonyms Q205739, Q1748845
     workLabel = 'Voice of the Fire' # wd:Q3825051
     createHuman { labels: { en: humanLabel } }
@@ -47,9 +47,7 @@ describe 'tasks:externalSourcesOccurrences', ->
       createWorkWithAuthor human, workLabel
       .then (work)-> checkEntities human.uri
       .then (tasks)->
-        tasks.length.should.aboveOrEqual 1
-        task = tasks.find (task)-> task.suggestionUri.match /wd:/
-        task.externalSourcesOccurrences.should.not.be.empty()
+        tasks.length.should.equal 0
         done()
     .catch undesiredErr(done)
 


### PR DESCRIPTION
- rename `has_works_labels_occurrence` into `get_works_labels_occurrence` as
  it doesn't return a simple boolean anymore but a collection of occurrences
- attach occurrences on suggestions objects to keep their context at hand
  without having to handle those 2 parallel collections of objects
- change behavior when there are several suggestions but only one has occurrences: now automerges
