### PR TITLE
cache cleanup

### DIFF
--- a/config/default.coffee
+++ b/config/default.coffee
@@ -86,8 +86,6 @@ module.exports = config =
     ]
   # enable the api/i18n endpoint and its i18nMissingKeys controller
   logMissingI18nKeys: true
-  # reset server/lib/cache.coffee
-  resetCacheAtStartup: false
 
   # parameters for Nodemailer
   mailer:

--- a/server/controllers/entities/lib/get_entities_popularity.coffee
+++ b/server/controllers/entities/lib/get_entities_popularity.coffee
@@ -21,10 +21,9 @@ getPopularity = (refresh)-> (uri)->
   unless _.isEntityUri(uri) then throw error_.new 'invalid uri', 400, uri
 
   key = buildKey uri
-  timespan = if refresh then 0 else null
   fn = getPopularityByUriOrQueue.bind null, uri
 
-  cache_.get { key, fn, timespan }
+  cache_.get { key, fn, refresh }
   .then applyDefaultValue(uri)
 
 buildKey = (uri)-> "popularity:#{uri}"

--- a/server/controllers/entities/lib/get_entities_popularity.coffee
+++ b/server/controllers/entities/lib/get_entities_popularity.coffee
@@ -54,7 +54,7 @@ wdPopularityWorker = (jobId, uri)->
   key = buildKey uri
   _.log uri, 'wdPopularityWorker uri'
   # Check that the score wasn't calculated since this job was queued
-  cache_.dryGet key
+  cache_.get { key, dry: true }
   .then (res)->
     if res? then return
     getPopularityByUri uri

--- a/server/controllers/entities/lib/get_entities_popularity.coffee
+++ b/server/controllers/entities/lib/get_entities_popularity.coffee
@@ -24,7 +24,7 @@ getPopularity = (refresh)-> (uri)->
   timespan = if refresh then 0 else null
   fn = getPopularityByUriOrQueue.bind null, uri
 
-  cache_.get key, fn, timespan
+  cache_.get { key, fn, timespan }
   .then applyDefaultValue(uri)
 
 buildKey = (uri)-> "popularity:#{uri}"

--- a/server/controllers/entities/lib/get_wikidata_enriched_entities.coffee
+++ b/server/controllers/entities/lib/get_wikidata_enriched_entities.coffee
@@ -29,8 +29,7 @@ module.exports = (ids, refresh)->
 getCachedEnrichedEntity = (refresh)-> (wdId)->
   key = "wd:enriched:#{wdId}"
   fn = getEnrichedEntity.bind null, wdId
-  timespan = if refresh then 0 else null
-  cache_.get { key, fn, timespan }
+  cache_.get { key, fn, refresh }
 
 getEnrichedEntity = (wdId)->
   getWdEntity wdId

--- a/server/controllers/entities/lib/get_wikidata_enriched_entities.coffee
+++ b/server/controllers/entities/lib/get_wikidata_enriched_entities.coffee
@@ -28,8 +28,9 @@ module.exports = (ids, refresh)->
 
 getCachedEnrichedEntity = (refresh)-> (wdId)->
   key = "wd:enriched:#{wdId}"
+  fn = getEnrichedEntity.bind null, wdId
   timespan = if refresh then 0 else null
-  cache_.get key, getEnrichedEntity.bind(null, wdId), timespan
+  cache_.get { key, fn, timespan }
 
 getEnrichedEntity = (wdId)->
   getWdEntity wdId

--- a/server/controllers/entities/lib/reverse_claims.coffee
+++ b/server/controllers/entities/lib/reverse_claims.coffee
@@ -62,8 +62,9 @@ wikidataReverseClaims = (property, value, refresh)->
 
 generalWikidataReverseClaims = (property, value, refresh)->
   key = "wd:reverse-claim:#{property}:#{value}"
+  fn = _wikidataReverseClaims.bind null, property, value
   timestamp = if refresh then 0 else null
-  cache_.get key, _wikidataReverseClaims.bind(null, property, value), timestamp
+  cache_.get { key, fn, timestamp }
 
 _wikidataReverseClaims = (property, value)->
   caseInsensitive = property in caseInsensitiveProperties

--- a/server/controllers/entities/lib/reverse_claims.coffee
+++ b/server/controllers/entities/lib/reverse_claims.coffee
@@ -63,8 +63,7 @@ wikidataReverseClaims = (property, value, refresh)->
 generalWikidataReverseClaims = (property, value, refresh)->
   key = "wd:reverse-claim:#{property}:#{value}"
   fn = _wikidataReverseClaims.bind null, property, value
-  timestamp = if refresh then 0 else null
-  cache_.get { key, fn, timestamp }
+  cache_.get { key, fn, refresh }
 
 _wikidataReverseClaims = (property, value)->
   caseInsensitive = property in caseInsensitiveProperties

--- a/server/data/bnf/get_bnf_author_works_titles.coffee
+++ b/server/data/bnf/get_bnf_author_works_titles.coffee
@@ -11,7 +11,7 @@ headers = { accept: '*/*' }
 
 module.exports = (bnfId)->
   key = "bnf:author-works-titles:#{bnfId}"
-  return cache_.get key, getBnfAuthorWorksTitles.bind(null, bnfId)
+  return cache_.get { key, fn: getBnfAuthorWorksTitles.bind(null, bnfId) }
 
 getBnfAuthorWorksTitles = (bnfId)->
   _.info bnfId, 'bnfId'

--- a/server/data/commons/thumb.coffee
+++ b/server/data/commons/thumb.coffee
@@ -13,8 +13,7 @@ fullPublicHost = CONFIG.fullPublicHost()
 # But not too high though so that we don't get super heavy files
 module.exports = (file, width = 2000, refresh)->
   key = "commons:#{file}:#{width}"
-  timespan = if refresh is true then 0 else null
-  cache_.get { key, fn: getThumbData.bind(null, file, width), timespan }
+  cache_.get { key, fn: getThumbData.bind(null, file, width), refresh }
 
 getThumbData = (file, width = 2000)->
   file = qs.escape file

--- a/server/data/commons/thumb.coffee
+++ b/server/data/commons/thumb.coffee
@@ -14,7 +14,7 @@ fullPublicHost = CONFIG.fullPublicHost()
 module.exports = (file, width = 2000, refresh)->
   key = "commons:#{file}:#{width}"
   timespan = if refresh is true then 0 else null
-  cache_.get key, getThumbData.bind(null, file, width), timespan
+  cache_.get { key, fn: getThumbData.bind(null, file, width), timespan }
 
 getThumbData = (file, width = 2000)->
   file = qs.escape file

--- a/server/data/wikidata/run_query.coffee
+++ b/server/data/wikidata/run_query.coffee
@@ -30,17 +30,13 @@ module.exports = (params)->
     unless parametersTests[k](value)
       return error_.rejectInvalid k, params
 
-  # Invalid the cache by passing refresh=true in the query.
-  # Return null if refresh isn't truthy to let the cache set its default value
-  timespan = if refresh is true then 0 else null
-
   # Building the cache key
   key = "wdQuery:#{queryName}"
   for k in parameters
     value = params[k]
     key += ":#{value}"
 
-  cache_.get { key, fn: runQuery.bind(null, params, key), timespan }
+  cache_.get { key, fn: runQuery.bind(null, params, key), refresh }
 
 parametersTests =
   qid: wdk.isItemId

--- a/server/data/wikidata/run_query.coffee
+++ b/server/data/wikidata/run_query.coffee
@@ -40,7 +40,7 @@ module.exports = (params)->
     value = params[k]
     key += ":#{value}"
 
-  cache_.get key, runQuery.bind(null, params, key), timespan
+  cache_.get { key, fn: runQuery.bind(null, params, key), timespan }
 
 parametersTests =
   qid: wdk.isItemId

--- a/server/data/wikidata/search_entities.coffee
+++ b/server/data/wikidata/search_entities.coffee
@@ -10,8 +10,7 @@ module.exports = (query)->
   { search, refresh } = query
   assert_.string search
   key = "wd:search:#{search}"
-  timestamp = if refresh then 0 else null
-  cache_.get { key, fn: searchEntities.bind(null, search), timestamp }
+  cache_.get { key, fn: searchEntities.bind(null, search), refresh }
 
 searchEntities = (search)->
   search = qs.escape search

--- a/server/data/wikidata/search_entities.coffee
+++ b/server/data/wikidata/search_entities.coffee
@@ -11,7 +11,7 @@ module.exports = (query)->
   assert_.string search
   key = "wd:search:#{search}"
   timestamp = if refresh then 0 else null
-  cache_.get key, searchEntities.bind(null, search), timestamp
+  cache_.get { key, fn: searchEntities.bind(null, search), timestamp }
 
 searchEntities = (search)->
   search = qs.escape search

--- a/server/data/wikipedia/get_article.coffee
+++ b/server/data/wikipedia/get_article.coffee
@@ -9,7 +9,7 @@ module.exports = (params)->
   { lang, title, introOnly } = params
   keyBase = if introOnly then 'wpextract' else 'wparticle'
   key = "#{keyBase}:#{lang}:#{title}"
-  return cache_.get key, getArticle.bind(null, lang, title, introOnly)
+  return cache_.get { key, fn: getArticle.bind(null, lang, title, introOnly) }
 
 getArticle = (lang, title, introOnly)->
   requests_.get apiQuery(lang, title, introOnly)

--- a/server/lib/cache.coffee
+++ b/server/lib/cache.coffee
@@ -13,9 +13,12 @@ if CONFIG.resetCacheAtStartup then db.reset()
 
 { oneMinute, oneDay, oneMonth } =  __.require 'lib', 'times'
 
-module.exports = cache_ =
-  # EXPECT function to come with context and arguments .bind'ed
-  # e.g. fn = module.getData.bind(module, arg1, arg2)
+module.exports =
+  # key: the cache key
+  # fn: a function with its context and arguments binded
+  # timespan: maximum acceptable age of the cached value in ms
+  # refresh: alias for timespan=0
+  # dry: return what's in cache or nothing: if the cache is empty, do not call the function
   get: (params)->
     { key, fn, timespan, refresh, dry } = params
     if refresh then timespan = 0

--- a/server/lib/cache.coffee
+++ b/server/lib/cache.coffee
@@ -28,8 +28,9 @@ module.exports = cache_ =
     catch err
       return error_.reject err, 500
 
-    # Try to avoid cache miss when working offline (only useful in development)
-    if offline then timespan = Infinity
+    # Try to avoid cache miss when making a dry get
+    # or when working offline (only useful in development)
+    if dry or offline then timespan = Infinity
 
     # When passed a 0 timespan, it is expected to get a fresh value.
     # Refusing the old value is also a way to invalidate the current cache

--- a/server/lib/cache.coffee
+++ b/server/lib/cache.coffee
@@ -16,7 +16,10 @@ if CONFIG.resetCacheAtStartup then db.reset()
 module.exports = cache_ =
   # EXPECT function to come with context and arguments .bind'ed
   # e.g. function = module.getData.bind(module, arg1, arg2)
-  get: (key, fn, timespan = oneMonth, retry = true)->
+  get: (params)->
+    { key, fn, timespan, retry } = params
+    timespan ?= oneMonth
+    retry ?= true
     types = [ 'string', 'function', 'number', 'boolean' ]
     try  assert_.types types, [ key, fn, timespan, retry ]
     catch err then return error_.reject err, 500
@@ -59,7 +62,7 @@ module.exports = cache_ =
 
   # exemple:
   # timespan = cache_.solveExpirationTime 'commons'
-  # cache_.get key, fn, timespan
+  # cache_.get { key, fn, timespan }
 
   # once the default expiration time is greater than the time since
   # data change, just stop passing a timespan

--- a/server/lib/cache.coffee
+++ b/server/lib/cache.coffee
@@ -8,7 +8,6 @@ levelBase = __.require 'level', 'base'
 
 db = levelBase.simpleSubDb 'cache'
 
-if CONFIG.resetCacheAtStartup then db.reset()
 { offline } = CONFIG
 
 { oneMinute, oneDay, oneMonth } =  __.require 'lib', 'times'

--- a/server/lib/cache.coffee
+++ b/server/lib/cache.coffee
@@ -15,9 +15,10 @@ if CONFIG.resetCacheAtStartup then db.reset()
 
 module.exports = cache_ =
   # EXPECT function to come with context and arguments .bind'ed
-  # e.g. function = module.getData.bind(module, arg1, arg2)
+  # e.g. fn = module.getData.bind(module, arg1, arg2)
   get: (params)->
-    { key, fn, timespan, retry } = params
+    { key, fn, timespan, retry, refresh } = params
+    if refresh then timespan = 0
     timespan ?= oneMonth
     retry ?= true
     types = [ 'string', 'function', 'number', 'boolean' ]

--- a/tests/api/entities/popularity.test.coffee
+++ b/tests/api/entities/popularity.test.coffee
@@ -11,7 +11,7 @@ describe 'entities:popularity', ->
   describe 'edition', ->
     it 'should reject invalid uri', (done)->
       invalidUri = 'inv:aliduri'
-      getPopularity invalidUri, true
+      getPopularity invalidUri
       .then undesiredRes(done)
       .catch (err)->
         err.body.status_verbose.should.startWith 'invalid '
@@ -119,11 +119,11 @@ describe 'entities:popularity', ->
 
       return
 
-getPopularity = (uri, fast=false)->
-  nonAuthReq 'get', "/api/entities?action=popularity&uris=#{uri}&refresh=true&fast=#{fast}"
+getPopularity = (uri)->
+  nonAuthReq 'get', "/api/entities?action=popularity&uris=#{uri}&refresh=true"
 
-getScore = (uri, fast)->
-  getPopularity uri, fast
+getScore = (uri)->
+  getPopularity uri
   .then (res)-> res.scores[uri]
 
 scoreShouldEqual = (uri, value, done)->

--- a/tests/unit/libs/037-cache.coffee
+++ b/tests/unit/libs/037-cache.coffee
@@ -66,22 +66,6 @@ describe 'cache', ->
       .catch done
       return
 
-    it 'should also accept an expiration timespan', (done)->
-      key = 'samekey'
-      cache_.get { key, fn: workingFn.bind(null, 'bla') }
-      .then (res1)->
-        cache_.get { key, fn: workingFn.bind(null, 'different arg'), timespan: 10000 }
-        .delay 100
-        .then (res2)->
-          cache_.get { key, fn: workingFn.bind(null, 'different arg'), timespan: 0 }
-          .delay 100
-          .then (res3)->
-            res1.should.equal res2
-            res2.should.not.equal res3
-            done()
-      .catch done
-      return
-
     it 'should return the outdated version if the new version returns an error', (done)->
       key = 'doden'
       cache_.get { key, fn: workingFn.bind(null, 'Vem är du?'), timespan: 0 }
@@ -95,20 +79,6 @@ describe 'cache', ->
             res1.should.equal res2
             res1.should.equal res3
             done()
-      .catch done
-      return
-
-    it 'should refuse old value when passed a 0 timespan', (done)->
-      key = 'doden'
-      cache_.get { key, fn: workingFn.bind(null, 'Vem är du?'), timespan: 0 }
-      .delay 10
-      .then (res1)->
-        # returns an error: should return old value
-        cache_.get { key, fn: failingFn.bind(null, 'Vem är du?'), timespan: 0 }
-        .then (res2)->
-          res1.should.be.ok()
-          should(res2).not.be.ok()
-          done()
       .catch done
       return
 
@@ -127,6 +97,37 @@ describe 'cache', ->
           should(res2).not.be.ok()
           spy.callCount.should.equal 1
           done()
+      .catch done
+      return
+
+    describe 'timespan', ->
+      it 'should refuse old value when passed a 0 timespan', (done)->
+        key = 'doden'
+        cache_.get { key, fn: workingFn.bind(null, 'Vem är du?'), timespan: 0 }
+        .delay 10
+        .then (res1)->
+          # returns an error: should return old value
+          cache_.get { key, fn: failingFn.bind(null, 'Vem är du?'), timespan: 0 }
+          .then (res2)->
+            res1.should.be.ok()
+            should(res2).not.be.ok()
+            done()
+        .catch done
+        return
+
+    it 'should also accept an expiration timespan', (done)->
+      key = 'samekey'
+      cache_.get { key, fn: workingFn.bind(null, 'bla') }
+      .then (res1)->
+        cache_.get { key, fn: workingFn.bind(null, 'different arg'), timespan: 10000 }
+        .delay 100
+        .then (res2)->
+          cache_.get { key, fn: workingFn.bind(null, 'different arg'), timespan: 0 }
+          .delay 100
+          .then (res3)->
+            res1.should.equal res2
+            res2.should.not.equal res3
+            done()
       .catch done
       return
 

--- a/tests/unit/libs/037-cache.coffee
+++ b/tests/unit/libs/037-cache.coffee
@@ -23,14 +23,14 @@ failingFn = (key)-> promises_.reject 'Jag är Döden'
 describe 'cache', ->
   describe 'get', ->
     it 'should return a promise', (done)->
-      p = cache_.get('whatever', mookPromise.bind(null, 'yo'))
+      p = cache_.get { key: 'whatever', fn: mookPromise.bind(null, 'yo') }
       p.should.have.property 'then'
       p.should.have.property 'catch'
       done()
 
     it 'should accept a key and a promisified function', (done)->
       key = 'whatever'
-      cache_.get(key, mookPromise.bind(null, key))
+      cache_.get { key, fn: mookPromise.bind(null, key) }
       .then -> done()
       .catch done
       return
@@ -44,20 +44,20 @@ describe 'cache', ->
         return hashKey(key)
 
       fn = spiedHash.bind(null, key)
-      cache_.get key, fn
+      cache_.get { key, fn }
       .then (res)->
         res.should.equal hash
-        cache_.get key, spiedHash.bind(null, key)
+        cache_.get { key, fn: spiedHash.bind(null, key) }
         .then (res)->
           res.should.equal hash
-          cache_.get key, spiedHash.bind(null, key)
+          cache_.get { key, fn: spiedHash.bind(null, key) }
           .then (res)->
             res.should.equal hash
             # MOUAHAHA YOU WONT SEE ME (◣_◢)
-            cache_.get '006', spiedHash.bind(null, '006')
+            cache_.get { key: '006', fn: spiedHash.bind(null, '006') }
             .then (res)->
               res.should.equal _.hashCode('006')
-              cache_.get key, spiedHash.bind(null, key)
+              cache_.get { key, fn: spiedHash.bind(null, key) }
               .then (res)->
                 res.should.equal hash
                 # DHO [>.<]
@@ -67,15 +67,15 @@ describe 'cache', ->
       return
 
     it 'should also accept an expiration timespan', (done)->
-      cache_.get 'samekey', workingFn.bind(null, 'bla')
+      key = 'samekey'
+      cache_.get { key, fn: workingFn.bind(null, 'bla') }
       .then (res1)->
-        cache_.get 'samekey', workingFn.bind(null, 'different arg'), 10000
+        cache_.get { key, fn: workingFn.bind(null, 'different arg'), timespan: 10000 }
         .delay 100
         .then (res2)->
-          cache_.get 'samekey', workingFn.bind(null, 'different arg'), 0
+          cache_.get { key, fn: workingFn.bind(null, 'different arg'), timespan: 0 }
           .delay 100
           .then (res3)->
-            _.log [ res1, res2, res3 ], 'results'
             res1.should.equal res2
             res2.should.not.equal res3
             done()
@@ -83,15 +83,15 @@ describe 'cache', ->
       return
 
     it 'should return the outdated version if the new version returns an error', (done)->
-      cache_.get 'doden', workingFn.bind(null, 'Vem är du?'), 0
+      key = 'doden'
+      cache_.get { key, fn: workingFn.bind(null, 'Vem är du?'), timespan: 0 }
       .then (res1)->
         # returns an error: should return old value
-        cache_.get 'doden', failingFn.bind(null, 'Vem är du?'), 1
+        cache_.get { key, fn: failingFn.bind(null, 'Vem är du?'), timespan: 1 }
         .then (res2)->
           # the error shouldnt have overriden the value
-          cache_.get 'doden', workingFn.bind(null, 'Vem är du?'), 5000
+          cache_.get { key, fn: workingFn.bind(null, 'Vem är du?'), timespan: 5000 }
           .then (res3)->
-            _.log [ res1, res2, res3 ], 'results'
             res1.should.equal res2
             res1.should.equal res3
             done()
@@ -99,11 +99,12 @@ describe 'cache', ->
       return
 
     it 'should refuse old value when passed a 0 timespan', (done)->
-      cache_.get 'doden', workingFn.bind(null, 'Vem är du?'), 0
+      key = 'doden'
+      cache_.get { key, fn: workingFn.bind(null, 'Vem är du?'), timespan: 0 }
       .delay 10
       .then (res1)->
         # returns an error: should return old value
-        cache_.get 'doden', failingFn.bind(null, 'Vem är du?'), 0
+        cache_.get { key, fn: failingFn.bind(null, 'Vem är du?'), timespan: 0 }
         .then (res2)->
           res1.should.be.ok()
           should(res2).not.be.ok()
@@ -117,10 +118,11 @@ describe 'cache', ->
         spy()
         return promises_.resolve _.noop(key)
 
-      cache_.get 'gogogo', empty
+      key = 'gogogo'
+      cache_.get { key, fn: empty }
       .then (res1)->
         should(res1).not.be.ok()
-        cache_.get 'gogogo', empty
+        cache_.get { key, fn: empty }
         .then (res2)->
           should(res2).not.be.ok()
           spy.callCount.should.equal 1
@@ -153,7 +155,7 @@ describe 'cache', ->
       .then (cached)->
         should(cached).not.be.ok()
         # with caching
-        cache_.get key, workingFn.bind(null, key)
+        cache_.get { key, fn: workingFn.bind(null, key) }
         .then (cached2)->
           cache_.dryGet key
           .then (cached3)->
@@ -166,7 +168,7 @@ describe 'cache', ->
 
     it "should return a value only if the timestamp isn't expired", (done)->
       key = randomString 8
-      cache_.get key, workingFn.bind(null, key)
+      cache_.get { key, fn: workingFn.bind(null, key) }
       .then (cached)->
         cache_.dryGet key, 10000
         .delay 10

--- a/tests/unit/libs/037-cache.coffee
+++ b/tests/unit/libs/037-cache.coffee
@@ -130,6 +130,23 @@ describe 'cache', ->
       .catch done
       return
 
+    describe 'refresh', ->
+      it 'should accept a refresh parameter', (done)->
+        key = 'samekey'
+        fn = workingFn.bind null, 'foo'
+        cache_.get { key, fn, timespan: 10000 }
+        .delay 100
+        .then (res1)->
+          cache_.get { key, fn }
+          .then (res2)->
+            cache_.get { key, fn, refresh: true }
+            .then (res3)->
+              res1.should.equal res2
+              res1.should.not.equal res3
+              done()
+        .catch done
+        return
+
   describe 'dryGet', ->
     it 'should return a promise', (done)->
       p = cache_.dryGet 'whatever'


### PR DESCRIPTION
Make `cache_.get` use an object interface and integrate `cache_.dryGet` feature

(A [coming PR](https://github.com/inventaire/inventaire/pull/242) builds on those evolutions to cleanup popularity scores, splitting this code exploration in 2 PRs for clarity)