### PR TITLE
speedup search

### DIFF
--- a/server/controllers/entities/lib/get_entities_popularity.coffee
+++ b/server/controllers/entities/lib/get_entities_popularity.coffee
@@ -17,4 +17,4 @@ getPopularity = (refresh)-> (uri)->
   key = "popularity:#{uri}"
   fn = getPopularityByUri.bind null, uri
 
-  cache_.get { key, fn, refresh, dry: true, dryFallbackValue: 0, dryPopulate: true }
+  cache_.get { key, fn, refresh, dry: true, dryAndCache: true, dryFallbackValue: 0 }

--- a/server/controllers/entities/lib/get_entities_popularity.coffee
+++ b/server/controllers/entities/lib/get_entities_popularity.coffee
@@ -14,9 +14,7 @@ module.exports = (uris, refresh)->
 getPopularity = (refresh)-> (uri)->
   unless _.isEntityUri(uri) then throw error_.new 'invalid uri', 400, uri
 
-  key = buildKey uri
+  key = "popularity:#{uri}"
   fn = getPopularityByUri.bind null, uri
 
-  cache_.get { key, fn, refresh }
-
-buildKey = (uri)-> "popularity:#{uri}"
+  cache_.get { key, fn, refresh, dry: true, dryFallbackValue: 0, dryPopulate: true }

--- a/tests/api/entities/popularity.test.coffee
+++ b/tests/api/entities/popularity.test.coffee
@@ -4,7 +4,7 @@ _ = __.require 'builders', 'utils'
 should = require 'should'
 { Promise } = __.require 'lib', 'promises'
 { authReq, nonAuthReq, undesiredErr, undesiredRes } = require '../utils/utils'
-{ addClaim } = require '../utils/entities'
+{ addClaim, getRefreshedPopularityByUri } = require '../utils/entities'
 { createEdition, createWork, createItemFromEntityUri, createSerie, createHuman } = require '../fixtures/entities'
 
 describe 'entities:popularity', ->
@@ -91,15 +91,8 @@ describe 'entities:popularity', ->
 
       return
 
-getPopularity = (uri)->
-  nonAuthReq 'get', "/api/entities?action=popularity&uris=#{uri}&refresh=true"
-
-getScore = (uri)->
-  getPopularity uri
-  .then (res)-> res.scores[uri]
-
 scoreShouldEqual = (uri, value, done)->
-  getScore uri
+  getRefreshedPopularityByUri uri
   .then (score)->
     score.should.equal value
     done?()

--- a/tests/api/search/search.test.coffee
+++ b/tests/api/search/search.test.coffee
@@ -6,8 +6,8 @@ faker = require 'faker'
 { Promise } = __.require 'lib', 'promises'
 { nonAuthReq, authReq, undesiredRes, undesiredErr, getUser } = require '../utils/utils'
 randomString = __.require 'lib', './utils/random_string'
-{ createWork, createHuman, createSerie, humanName, randomWorkLabel } = require '../fixtures/entities'
-{ createEditionFromWorks } = require '../fixtures/entities'
+{ createWork, createHuman, createSerie, humanName, randomWorkLabel, createEditionFromWorks } = require '../fixtures/entities'
+{ getRefreshedPopularityByUris } = require '../utils/entities'
 
 describe 'search:global', ->
   it 'should reject empty searches', (done)->
@@ -192,6 +192,9 @@ describe 'search:global', ->
         createEditionFromWorks work
         createWork { labels: { fr: fullMatchLabel } }
       ]
+      # trigger a popularity refresh to avoid getting the default score on
+      # the search hereafter
+      .then -> getRefreshedPopularityByUris work.uri
       .delay 1000
       .then ->
         workWithEditionUri = work.uri
@@ -213,7 +216,10 @@ describe 'search:global', ->
         createEditionFromWorks work
       ]
       Promise.all workEditionsCreation
-      .delay 4000
+      # trigger a popularity refresh to avoid getting the default score on
+      # the search hereafter
+      .then (works)-> getRefreshedPopularityByUris _.map(works, 'uri')
+      .delay 2000
       .then ->
         search 'works', workLabel
         .then (results)->

--- a/tests/api/utils/entities.coffee
+++ b/tests/api/utils/entities.coffee
@@ -47,4 +47,12 @@ module.exports = entitiesUtils =
   addClaim: (uri, property, value)->
     entitiesUtils.updateClaim uri, property, null, value
 
+  getRefreshedPopularityByUris: (uris)->
+    if _.isArray(uris) then uris = uris.join('|')
+    nonAuthReq 'get', "/api/entities?action=popularity&uris=#{uris}&refresh=true"
+
+  getRefreshedPopularityByUri: (uri)->
+    entitiesUtils.getRefreshedPopularityByUris uri
+    .then (res)-> res.scores[uri]
+
 normalizeUri = (uri)-> if _.isInvEntityId(uri) then uri = "inv:#{uri}" else uri

--- a/tests/unit/libs/037-cache.coffee
+++ b/tests/unit/libs/037-cache.coffee
@@ -181,6 +181,20 @@ describe 'cache', ->
         .catch done
         return
 
+      it 'should populate the cache when requested', (done)->
+        key = randomString 4
+        fn = workingFn.bind null, 'foo'
+        cache_.get { key, fn, dry: true, dryPopulate: true }
+        .delay 10
+        .then (res1)->
+          should(res1).not.be.ok()
+          cache_.get { key, dry: true }
+          .then (res2)->
+            should(res2).be.ok()
+          done()
+        .catch done
+        return
+
   describe 'put', ->
     it 'should return a promise', (done)->
       p = cache_.put 'whatever', 'somevalue'

--- a/tests/unit/libs/037-cache.coffee
+++ b/tests/unit/libs/037-cache.coffee
@@ -184,7 +184,7 @@ describe 'cache', ->
       it 'should populate the cache when requested', (done)->
         key = randomString 4
         fn = workingFn.bind null, 'foo'
-        cache_.get { key, fn, dry: true, dryPopulate: true }
+        cache_.get { key, fn, dryAndCache: true }
         .delay 10
         .then (res1)->
           should(res1).not.be.ok()


### PR DESCRIPTION
by making popularity score requests dry too: if a popularity score is in cache it will be used, otherwise, the popularity returns immediately with the default value (0), and a request to populate the score is triggered in the background

![](https://i.kinja-img.com/gawker-media/image/upload/1344998898279631762.jpg)