### PR TITLE
task automerge: dont merge suspect when authorName is in WorkTitle

### DIFF
--- a/server/controllers/tasks/lib/automerge.coffee
+++ b/server/controllers/tasks/lib/automerge.coffee
@@ -4,22 +4,43 @@ mergeEntities = __.require 'controllers', 'entities/lib/merge_entities'
 { _id: reconcilerUserId } = __.require('couch', 'hard_coded_documents').users.reconciler
 { prefixifyInv } = __.require 'controllers', 'entities/lib/prefix'
 
-module.exports = (suspectUri)-> (suggestions)->
-  suggestionsWithOccurrences = suggestions.filter hasOccurrences
-  _.log suggestionsWithOccurrences, 'suggestionsWithOccurrences'
-  # No suggestion has occurrences, all should get a task
-  if suggestionsWithOccurrences.length is 0 then return suggestions
-  # Some suggestions have occurrences, those only should get a task
-  if suggestionsWithOccurrences.length > 1 then return suggestionsWithOccurrences
-  # Else, only the one that has occurrences should either be automerged or get a task
-  suggestionWithOccurrences = suggestionsWithOccurrences[0]
-  unless canBeAutomerged suggestionWithOccurrences then return suggestionsWithOccurrences
+# Merge automatically if enough confidence between suspect and suggestion
+# If confidence is too low, return best suggestions for task creation
 
-  foundUri = suggestionWithOccurrences.uri
-  _.log { suspectUri, foundUri }, 'automerging'
-  mergeEntities reconcilerUserId, suspectUri, foundUri
-  # No task should be created
+module.exports = (suspect, workLabels)-> (suggestions)->
+  # unable to define if occurences are relevant
+  # since author name will be found on external
+  # source pages
+  if authorNameInWorkTitles(suspect.labels, workLabels) then return suggestions
+
+  sourcedSuggestions = suggestions.filter hasOccurrences
+
+  if noSuggestion sourcedSuggestions
+    return suggestions
+  else if manySuggestions sourcedSuggestions
+    return sourcedSuggestions
+  else
+    # Only one suggestion, automerge possible
+    uniqSuggestion = sourcedSuggestions[0]
+    unless canBeAutomerged uniqSuggestion
+      return sourcedSuggestions
+
+
+  mergeEntities reconcilerUserId, suspect.uri, uniqSuggestion.uri
+  # No suggestions since merged suspect
   .then -> return []
+
+noSuggestion = (sug)->  sug.length is 0
+
+manySuggestions = (sug)-> sug.length > 1
+
+authorNameInWorkTitles = (authorLabels, workLabels)->
+  works = _.values workLabels
+  authors = _.values authorLabels
+  for author in authors
+    for work in works
+      if work.indexOf(author) > -1
+        return true
 
 hasOccurrences = (suggestion)-> suggestion.occurrences.length > 0
 

--- a/server/controllers/tasks/lib/get_new_tasks.coffee
+++ b/server/controllers/tasks/lib/get_new_tasks.coffee
@@ -15,7 +15,7 @@ module.exports = (entity)-> (existingTasks)->
   .spread (newSuggestions, authorWorksData)->
     unless newSuggestions.length > 0 then return []
     Promise.all newSuggestions.map(addOccurrences(authorWorksData))
-    .then automerge(suspectUri)
+    .then automerge(entity, authorWorksData.labels)
     .then buildTaskObject(suspectUri)
 
 addOccurrences = (authorWorksData)-> (suggestion)->

--- a/tests/api/tasks/automerge.test.coffee
+++ b/tests/api/tasks/automerge.test.coffee
@@ -1,0 +1,34 @@
+should = require 'should'
+{ undesiredErr } = require '../utils/utils'
+{ checkEntities } = require '../utils/tasks'
+{ createHuman, createWorkWithAuthor } = require '../fixtures/entities'
+
+# Tests dependency: having a populated ElasticSearch wikidata index
+describe 'tasks:automerge', ->
+  it 'should automerge if author has homonyms but only one has occurrences', (done)->
+    humanLabel = 'Alan Moore' # homonyms Q205739, Q1748845
+    workLabel = 'Voice of the Fire' # wd:Q3825051
+    createHuman { labels: { en: humanLabel } }
+    .then (human)->
+      createWorkWithAuthor human, workLabel
+      .then (work)-> checkEntities human.uri
+      .then (tasks)->
+        tasks.length.should.equal 0
+        done()
+    .catch undesiredErr(done)
+
+    return
+
+  it 'should not automerge if author name is in work title', (done)->
+    humanLabel = 'Frédéric Lordon'
+    workLabel = humanLabel
+    createHuman { labels: { en: humanLabel } }
+    .then (human)->
+      createWorkWithAuthor human, workLabel
+      .then (work)-> checkEntities human.uri
+      .then (tasks)->
+        tasks.length.should.aboveOrEqual 1
+        done()
+    .catch undesiredErr(done)
+
+    return

--- a/tests/api/tasks/external_sources_occurrences.test.coffee
+++ b/tests/api/tasks/external_sources_occurrences.test.coffee
@@ -39,20 +39,6 @@ describe 'tasks:externalSourcesOccurrences', ->
 
     return
 
-  it 'should automerge if author has homonyms but only one has occurrences', (done)->
-    humanLabel = 'Alan Moore' # homonyms Q205739, Q1748845
-    workLabel = 'Voice of the Fire' # wd:Q3825051
-    createHuman { labels: { en: humanLabel } }
-    .then (human)->
-      createWorkWithAuthor human, workLabel
-      .then (work)-> checkEntities human.uri
-      .then (tasks)->
-        tasks.length.should.equal 0
-        done()
-    .catch undesiredErr(done)
-
-    return
-
   it 'should return an object of occurrences uris when author has work sourced in their wikipedia page', (done)->
     humanLabel = 'Stanislas Lem' # has no homonyms
     workLabel = 'Solaris' # too short label to be automerged


### PR DESCRIPTION
as occurences are not relevant since author name will mostly be
mentionned on source pages
renaming automerge variables
move tests to automerge test file