### PR TITLE
reverse_claims: run requests on local entities only for certain properties

### DIFF
--- a/server/controllers/entities/lib/get_popularity_by_uri.coffee
+++ b/server/controllers/entities/lib/get_popularity_by_uri.coffee
@@ -48,7 +48,7 @@ getItemsCount = (uri)->
 getWorkEditionsScores = (uri)->
   # Limit request to local entities as Wikidata editions entities are currently ignored
   # see https://github.com/inventaire/inventaire/issues/182
-  reverseClaims { property: 'wdt:P629', value: uri, dry: true, localOnly: true }
+  reverseClaims { property: 'wdt:P629', value: uri, dry: true }
   .then (editonsUris)->
     editonsCount = editonsUris.length
     Promise.all editonsUris.map(getItemsCount)

--- a/server/controllers/entities/lib/reverse_claims.coffee
+++ b/server/controllers/entities/lib/reverse_claims.coffee
@@ -23,8 +23,12 @@ blacklistedProperties = [
   'wdt:P407'
 ]
 
+localOnlyProperties = [
+  'wdt:P629'
+]
+
 module.exports = (params)->
-  { property, value, refresh, sort, dry, localOnly } = params
+  { property, value, refresh, sort, dry } = params
   assert_.strings [ property, value ]
 
   if property in blacklistedProperties
@@ -32,7 +36,7 @@ module.exports = (params)->
 
   promises = []
 
-  unless localOnly
+  unless property in localOnlyProperties
     promises.push requestWikidataReverseClaims(property, value, refresh, dry)
 
   promises.push invReverseClaims(property, value)


### PR DESCRIPTION
typically for editions properties, given that editions from Wikidata are still ignored
see #182 