### PR TITLE
entities delete by uris: fix issue with items not detected

### DIFF
--- a/server/controllers/entities/lib/get_entities_by_uris.coffee
+++ b/server/controllers/entities/lib/get_entities_by_uris.coffee
@@ -16,6 +16,7 @@ prefixes = Object.keys getters
 
 module.exports = (params)->
   { uris } = params
+  assert_.array uris
   domains = {}
 
   # validate per URI to be able to return a precise error message

--- a/server/controllers/entities/lib/verify_that_entities_can_be_removed.coffee
+++ b/server/controllers/entities/lib/verify_that_entities_can_be_removed.coffee
@@ -4,6 +4,7 @@ error_ = __.require 'lib', 'error/error'
 { Promise } = __.require 'lib', 'promises'
 entities_ = require './entities'
 items_ = __.require 'controllers', 'items/lib/items'
+getEntitiesByUris = require './get_entities_by_uris'
 
 criticalClaimProperties = [
   # No edition should end up without an associated work because of a removed work
@@ -28,7 +29,16 @@ entityIsntUsedMuch = (uri)->
       if claim.property in criticalClaimProperties
         throw error_.new 'this entity is used in a critical claim', 400, uri, claim
 
-entitiesItemsChecks = (uris)-> Promise.all uris.map(entityIsntUsedByAnyItem)
+entitiesItemsChecks = (uris)->
+  getAllUris uris
+  .map entityIsntUsedByAnyItem
+
+getAllUris = (uris)->
+  getEntitiesByUris { uris }
+  .then (res)->
+    unless res.redirects? then return uris
+    missingCanonicalUris = _.values res.redirects
+    return uris.concat missingCanonicalUris
 
 entityIsntUsedByAnyItem = (uri)->
   items_.byEntity uri

--- a/server/controllers/entities/lib/verify_that_entities_can_be_removed.coffee
+++ b/server/controllers/entities/lib/verify_that_entities_can_be_removed.coffee
@@ -16,9 +16,9 @@ module.exports = (uris)->
     entitiesItemsChecks uris
   ]
 
-entitiesRelationsChecks = (uris)-> Promise.all uris.map entityIsntMuchUsed
+entitiesRelationsChecks = (uris)-> Promise.all uris.map(entityIsntUsedMuch)
 
-entityIsntMuchUsed = (uri)->
+entityIsntUsedMuch = (uri)->
   entities_.byClaimsValue uri
   .then (claims)->
     if claims.length > 1
@@ -28,7 +28,8 @@ entityIsntMuchUsed = (uri)->
       if claim.property in criticalClaimProperties
         throw error_.new 'this entity is used in a critical claim', 400, uri, claim
 
-entitiesItemsChecks = (uris)-> Promise.all uris.map entityIsntUsedByAnyItem
+entitiesItemsChecks = (uris)-> Promise.all uris.map(entityIsntUsedByAnyItem)
+
 entityIsntUsedByAnyItem = (uri)->
   items_.byEntity uri
   .then (items)->

--- a/tests/api/entities/delete.test.coffee
+++ b/tests/api/entities/delete.test.coffee
@@ -106,7 +106,7 @@ describe 'entities:delete:by-uris', ->
     uri = 'isbn:9782298063264'
     ensureEditionExists uri
     .then (edition)->
-      # Using the inv URI, as the isbn one would be rejected earlier
+      # Using the inv URI, as the isbn one would be rejected
       invUri = 'inv:' + edition._id
       deleteByUris invUri
     .then -> done()
@@ -172,5 +172,22 @@ describe 'entities:delete:by-uris', ->
         err.body.status_verbose.should.equal "entities that are used by an item can't be removed"
         err.statusCode.should.equal 400
         done()
+    .catch undesiredErr(done)
+    return
+
+  it 'should not remove editions with an ISBN and an item', (done)->
+    uri = 'isbn:9782298063264'
+    ensureEditionExists uri
+    .then (edition)->
+      authReq 'post', '/api/items', { entity: uri, lang: 'en' }
+      .then ->
+        # Using the inv URI, as the isbn one would be rejected
+        invUri = 'inv:' + edition._id
+        deleteByUris invUri
+    .then undesiredRes(done)
+    .catch (err)->
+      err.body.status_verbose.should.equal "entities that are used by an item can't be removed"
+      err.statusCode.should.equal 400
+      done()
     .catch undesiredErr(done)
     return


### PR DESCRIPTION
due to a different URI being used by item.entity, typically an ISBN, while the `inv:` URI was passed