### PR TITLE
Automerge when same work label

### DIFF
--- a/server/controllers/entities/lib/find_author_from_works_labels.coffee
+++ b/server/controllers/entities/lib/find_author_from_works_labels.coffee
@@ -6,7 +6,7 @@ __ = CONFIG.universalPath
 _ = __.require 'builders', 'utils'
 typeSearch = __.require 'controllers', 'search/lib/type_search'
 { prefixifyWd } = __.require 'controllers', 'entities/lib/prefix'
-getWorksLabelsOccurrence = require './get_works_labels_occurrence'
+getOccurrencesFromExternalSources = require './get_occurrences_from_external_sources'
 
 # Returns a URI if an single author was identified
 # returns undefined otherwise
@@ -34,7 +34,7 @@ getWdAuthorUris = (res)->
   .map (hit)-> prefixifyWd hit._id
 
 getAuthorOccurrenceData = (worksLabels, worksLabelsLangs)-> (wdAuthorUri)->
-  getWorksLabelsOccurrence wdAuthorUri, worksLabels, worksLabelsLangs
-  .then (occurrence)->
-    hasOccurrence = occurrence.length > 0
+  getOccurrencesFromExternalSources wdAuthorUri, worksLabels, worksLabelsLangs
+  .then (occurrences)->
+    hasOccurrence = occurrences.length > 0
     return { uri: wdAuthorUri, hasOccurrence }

--- a/server/controllers/entities/lib/get_occurences_from_entities.coffee
+++ b/server/controllers/entities/lib/get_occurences_from_entities.coffee
@@ -1,24 +1,9 @@
 __ = require('config').universalPath
 _ = __.require 'builders', 'utils'
 getAuthorWorks = __.require 'controllers', 'entities/lib/get_author_works'
-getWorksLabelsOccurrence = __.require 'controllers', 'entities/lib/get_works_labels_occurrence'
 getEntitiesByUris = __.require 'controllers', 'entities/lib/get_entities_by_uris'
-{ Promise } = __.require 'lib', 'promises'
 
-module.exports = (suspectWorksData)-> (suggestion)->
-  unless suggestion? then return []
-  { labels, langs } = suspectWorksData
-  { uri } = suggestion
-
-  Promise.all [
-    getWorksLabelsOccurrence uri, labels, langs
-    getInventaireWorkOccurence uri, labels
-  ]
-  .spread (externalOccurrences, inventaireOccurences)->
-    suggestion.occurrences = externalOccurrences.concat inventaireOccurences
-    return suggestion
-
-getInventaireWorkOccurence = (uri, suspectWorksLabels) ->
+module.exports = (uri, suspectWorksLabels) ->
   getAuthorWorks { uri, dry: true }
   .then getSuggestionWorks
   .then (suggestionWorksData)->

--- a/server/controllers/entities/lib/get_occurrences_from_external_sources.coffee
+++ b/server/controllers/entities/lib/get_occurrences_from_external_sources.coffee
@@ -18,13 +18,6 @@ module.exports = (wdAuthorUri, worksLabels, worksLabelsLangs)->
   assert_.strings worksLabels
   assert_.strings worksLabelsLangs
 
-  unless _.isWdEntityUri wdAuthorUri then return promises_.resolve []
-
-  # Filter-out labels that are too short, as it could generate false positives
-  worksLabels = worksLabels.filter (label)-> label.length > 5
-
-  if worksLabels.length is 0 then return promises_.resolve []
-
   # get Wikipedia article title from URI
   getEntityByUri { uri: wdAuthorUri }
   .then (authorEntity)->

--- a/server/controllers/tasks/lib/add_occurrences_to_suggestion.coffee
+++ b/server/controllers/tasks/lib/add_occurrences_to_suggestion.coffee
@@ -1,0 +1,25 @@
+__ = require('config').universalPath
+_ = __.require 'builders', 'utils'
+getOccurrencesFromExternalSources = __.require 'controllers', 'entities/lib/get_occurrences_from_external_sources'
+getOccurencesFromEntities = __.require 'controllers', 'entities/lib/get_occurences_from_entities'
+{ Promise } = __.require 'lib', 'promises'
+
+module.exports = (suspectWorksData)-> (suggestion)->
+  unless suggestion? then return []
+  { labels, langs } = suspectWorksData
+  { uri } = suggestion
+
+  # Filter-out labels that are too short, as it could generate false positives
+  labels = labels.filter (label)-> label.length > 5
+
+  if labels.length is 0
+    suggestion.occurrences = []
+    return promises_.resolve suggestion
+
+  Promise.all [
+    getOccurrencesFromExternalSources uri, labels, langs
+    getOccurencesFromEntities uri, labels
+  ]
+  .spread (externalOccurrences, entitiesOccurences)->
+    suggestion.occurrences = externalOccurrences.concat entitiesOccurences
+    return suggestion

--- a/server/controllers/tasks/lib/add_occurrences_to_suggestions.coffee
+++ b/server/controllers/tasks/lib/add_occurrences_to_suggestions.coffee
@@ -1,0 +1,39 @@
+__ = require('config').universalPath
+_ = __.require 'builders', 'utils'
+getAuthorWorks = __.require 'controllers', 'entities/lib/get_author_works'
+getWorksLabelsOccurrence = __.require 'controllers', 'entities/lib/get_works_labels_occurrence'
+getEntitiesByUris = __.require 'controllers', 'entities/lib/get_entities_by_uris'
+{ Promise } = __.require 'lib', 'promises'
+
+module.exports = (suspectWorksData)-> (suggestion)->
+  unless suggestion? then return []
+  { labels, langs } = suspectWorksData
+  { uri } = suggestion
+
+  Promise.all [
+    getWorksLabelsOccurrence uri, labels, langs
+    getAuthorWorks({ uri, dry: true }).get('works')
+  ]
+  .spread (occurrences, sugggestionWorks)->
+    suggestion.occurrences = occurrences
+    addIdenticalLabel(sugggestionWorks, labels, suggestion)
+
+addIdenticalLabel = (sugggestionWorks, suspectWorksLabels, suggestion)->
+  uris = sugggestionWorks.map _.property('uri')
+
+  getEntitiesByUris { uris }
+  .get 'entities'
+  .then _.values
+  .then (suggestionWorksData)->
+    for sugWork in suggestionWorksData
+      sugWorkLabels = _.values sugWork.labels
+      matchedTitles = []
+      for sugWorkLabel in sugWorkLabels
+        if sugWorkLabel in suspectWorksLabels
+          matchedTitles.push sugWorkLabel
+    suggestion.occurrences ?= []
+    if matchedTitles?
+      suggestion.occurrences.push
+        uri: sugWork.uri
+        matchedTitles: matchedTitles
+    suggestion

--- a/server/controllers/tasks/lib/get_new_tasks.coffee
+++ b/server/controllers/tasks/lib/get_new_tasks.coffee
@@ -2,29 +2,22 @@ __ = require('config').universalPath
 _ = __.require 'builders', 'utils'
 { Promise } = __.require 'lib', 'promises'
 searchEntityDuplicatesSuggestions = require './search_entity_duplicates_suggestions'
+addOccurrencesToSuggestions = require './add_occurrences_to_suggestions'
 getAuthorWorksData = require './get_author_works_data'
-getWorksLabelsOccurrence = __.require 'controllers', 'entities/lib/get_works_labels_occurrence'
 automerge = require './automerge'
 
 module.exports = (entity)-> (existingTasks)->
-  { uri: suspectUri } = entity
+  { uri:suspectUri } = entity
   Promise.all [
     searchEntityDuplicatesSuggestions entity, existingTasks
     getAuthorWorksData entity._id
   ]
-  .spread (newSuggestions, authorWorksData)->
+  .spread (newSuggestions, suspectWorksData)->
     unless newSuggestions.length > 0 then return []
-    Promise.all newSuggestions.map(addOccurrences(authorWorksData))
-    .then automerge(entity, authorWorksData.labels)
+    suspectWorksLabels = suspectWorksData.labels
+    Promise.all newSuggestions.map(addOccurrencesToSuggestions(suspectWorksData))
+    .then automerge(entity, suspectWorksData.labels)
     .then buildTaskObject(suspectUri)
-
-addOccurrences = (authorWorksData)-> (suggestion)->
-  { labels, langs } = authorWorksData
-  { uri } = suggestion
-  getWorksLabelsOccurrence uri, labels, langs
-  .then (occurrences)->
-    suggestion.occurrences = occurrences
-    return suggestion
 
 buildTaskObject = (suspectUri)-> (suggestions)->
   return suggestions.map (suggestion)->

--- a/server/controllers/tasks/lib/get_new_tasks.coffee
+++ b/server/controllers/tasks/lib/get_new_tasks.coffee
@@ -2,7 +2,7 @@ __ = require('config').universalPath
 _ = __.require 'builders', 'utils'
 { Promise } = __.require 'lib', 'promises'
 searchEntityDuplicatesSuggestions = require './search_entity_duplicates_suggestions'
-addOccurrencesToSuggestions = require './add_occurrences_to_suggestions'
+addOccurrencesToSuggestion = require './add_occurrences_to_suggestion'
 getAuthorWorksData = require './get_author_works_data'
 automerge = require './automerge'
 
@@ -15,7 +15,7 @@ module.exports = (entity)-> (existingTasks)->
   .spread (newSuggestions, suspectWorksData)->
     unless newSuggestions.length > 0 then return []
     suspectWorksLabels = suspectWorksData.labels
-    Promise.all newSuggestions.map(addOccurrencesToSuggestions(suspectWorksData))
+    Promise.all newSuggestions.map(addOccurrencesToSuggestion(suspectWorksData))
     .then automerge(entity, suspectWorksData.labels)
     .then buildTaskObject(suspectUri)
 

--- a/tests/api/tasks/automerge.test.coffee
+++ b/tests/api/tasks/automerge.test.coffee
@@ -1,37 +1,49 @@
 should = require 'should'
 { undesiredErr } = require '../utils/utils'
 { checkEntities } = require '../utils/tasks'
+{ getByUris } = require '../utils/entities'
 { createHuman, createWorkWithAuthor, randomWorkLabel } = require '../fixtures/entities'
+
 
 # Tests dependency: having a populated ElasticSearch wikidata index
 describe 'tasks:automerge', ->
   it 'should automerge if author has homonyms but only one has occurrences', (done)->
     humanLabel = 'Alan Moore' # homonyms Q205739, Q1748845
+    WdUri = 'wd:Q205739'
     workLabel = 'Voice of the Fire' # wd:Q3825051
     createHuman { labels: { en: humanLabel } }
     .then (human)->
       createWorkWithAuthor human, workLabel
       .then -> checkEntities human.uri
-      .then (tasks)->
-        tasks.length.should.equal 0
-        done()
+      .then (tasks)-> tasks.length.should.equal 0
+      .then ->
+        getByUris human.uri
+        .get 'entities'
+        .then (entities)->
+          # entity should have merged, thus URI is now a a WD uri
+          entities[WdUri].should.be.ok()
+          done()
     .catch undesiredErr(done)
 
     return
 
   it 'should automerge if suspect and suggestion workLabel are similar', (done)->
     humanLabel = 'Alain Damasio' # wdId Q2829704
+    wikidataUri = 'wd:Q2829704'
     workLabel = randomWorkLabel()
     createHuman { labels: { en: humanLabel } }
     .then (human)->
       Promise.all [
-        createWorkWithAuthor { uri: "wd:Q2829704" }, workLabel
+        createWorkWithAuthor { uri: wikidataUri }, workLabel
         createWorkWithAuthor human, workLabel
       ]
       .then -> checkEntities human.uri
-      .then (tasks)->
-        tasks.length.should.equal 0
-        done()
+      .then ->
+        getByUris human.uri
+        .get 'entities'
+        .then (entities)->
+          entities[wikidataUri].should.be.ok()
+          done()
     .catch undesiredErr(done)
 
     return
@@ -45,6 +57,8 @@ describe 'tasks:automerge', ->
       .then -> checkEntities human.uri
       .then (tasks)->
         tasks.length.should.aboveOrEqual 1
+        firstOccurenceMatch = tasks[0].externalSourcesOccurrences[0].matchedTitles[0]
+        firstOccurenceMatch.should.equal humanLabel
         done()
     .catch undesiredErr(done)
 

--- a/tests/api/tasks/automerge.test.coffee
+++ b/tests/api/tasks/automerge.test.coffee
@@ -1,7 +1,7 @@
 should = require 'should'
 { undesiredErr } = require '../utils/utils'
 { checkEntities } = require '../utils/tasks'
-{ createHuman, createWorkWithAuthor } = require '../fixtures/entities'
+{ createHuman, createWorkWithAuthor, randomWorkLabel } = require '../fixtures/entities'
 
 # Tests dependency: having a populated ElasticSearch wikidata index
 describe 'tasks:automerge', ->
@@ -11,7 +11,24 @@ describe 'tasks:automerge', ->
     createHuman { labels: { en: humanLabel } }
     .then (human)->
       createWorkWithAuthor human, workLabel
-      .then (work)-> checkEntities human.uri
+      .then -> checkEntities human.uri
+      .then (tasks)->
+        tasks.length.should.equal 0
+        done()
+    .catch undesiredErr(done)
+
+    return
+
+  it 'should automerge if suspect and suggestion workLabel are similar', (done)->
+    humanLabel = 'Alain Damasio' # wdId Q2829704
+    workLabel = randomWorkLabel()
+    createHuman { labels: { en: humanLabel } }
+    .then (human)->
+      Promise.all [
+        createWorkWithAuthor { uri: "wd:Q2829704" }, workLabel
+        createWorkWithAuthor human, workLabel
+      ]
+      .then -> checkEntities human.uri
       .then (tasks)->
         tasks.length.should.equal 0
         done()
@@ -25,7 +42,7 @@ describe 'tasks:automerge', ->
     createHuman { labels: { en: humanLabel } }
     .then (human)->
       createWorkWithAuthor human, workLabel
-      .then (work)-> checkEntities human.uri
+      .then -> checkEntities human.uri
       .then (tasks)->
         tasks.length.should.aboveOrEqual 1
         done()


### PR DESCRIPTION
this PR corrects some past decisions : 
 - do not merge authors that have their names in their work (ie. an autobiography) since occurences found on external source page are the name of the author in question.

and add a couple a new way of finding occurences/clues
 - to find potential suspect, it now checks if the suggestion ("wd:Q42") has inventaire works entity with the same label as the suspect works.