### PR TITLE
items:update-bulk update one attribute on many items

### DIFF
--- a/server/controllers/items/bulk_update.coffee
+++ b/server/controllers/items/bulk_update.coffee
@@ -1,0 +1,21 @@
+__ = require('config').universalPath
+_ = __.require 'builders', 'utils'
+sanitize = __.require 'lib', 'sanitize/sanitize'
+items_ = __.require 'controllers', 'items/lib/items'
+error_ = __.require 'lib', 'error/error'
+responses_ = __.require 'lib', 'responses'
+
+sanitization =
+  ids: {}
+  attribute: {}
+  value: {}
+
+module.exports = (req, res, next)->
+  reqUserId = req.user._id
+
+  sanitize req, res, sanitization
+  .then (params)->
+    { ids, attribute, value } = params
+    items_.bulkUpdate(reqUserId, ids, attribute, value)
+    .then responses_.Ok(res)
+  .catch error_.Handler(req, res)

--- a/server/controllers/items/items.coffee
+++ b/server/controllers/items/items.coffee
@@ -20,7 +20,10 @@ module.exports =
     admin:
       'refresh-snapshot': require './refresh_snapshot'
 
-  put: require './update'
+  put: ActionsControllers
+    authentified:
+      default: require './update'
+      'bulk-update': require './bulk_update'
 
   delete: require './delete'
 

--- a/server/controllers/items/lib/items.coffee
+++ b/server/controllers/items/lib/items.coffee
@@ -78,17 +78,18 @@ module.exports = items_ =
       db.fetch itemsIds
       .tap -> radio.emit 'user:inventory:update', userId
 
-  bulkUpdate: (userId, ids, attribute, newValue)->
-    items_.byIds ids
-    .map (item)-> Item.bulkUpdate(userId, item, attribute, newValue)
-    .then db.bulk
-
   update: (userId, itemUpdateData)->
     db.get itemUpdateData._id
     .then (currentItem)->
       updatedItem = Item.update userId, itemUpdateData, currentItem
       return updatedItem
     .then db.putAndReturn
+    .tap -> radio.emit 'user:inventory:update', userId
+
+  bulkUpdate: (userId, ids, attribute, newValue)->
+    items_.byIds ids
+    .map (item)-> Item.updateAttr(userId, item, attribute, newValue)
+    .then db.bulk
     .tap -> radio.emit 'user:inventory:update', userId
 
   verifyOwnership: (itemId, userId)->

--- a/server/controllers/items/lib/items.coffee
+++ b/server/controllers/items/lib/items.coffee
@@ -80,15 +80,15 @@ module.exports = items_ =
 
   update: (userId, itemUpdateData)->
     db.get itemUpdateData._id
-    .then (currentItem)->
-      updatedItem = Item.update userId, itemUpdateData, currentItem
-      return updatedItem
+    .then (currentItem)-> Item.update(userId, itemUpdateData, currentItem)
     .then db.putAndReturn
     .tap -> radio.emit 'user:inventory:update', userId
 
   bulkUpdate: (userId, ids, attribute, newValue)->
+    itemUpdateData = {}
+    itemUpdateData[attribute] = newValue
     items_.byIds ids
-    .map (item)-> Item.updateAttr(userId, item, attribute, newValue)
+    .map (currentItem)-> Item.update(userId, itemUpdateData, currentItem)
     .then db.bulk
     .tap -> radio.emit 'user:inventory:update', userId
 

--- a/server/controllers/items/lib/items.coffee
+++ b/server/controllers/items/lib/items.coffee
@@ -78,6 +78,11 @@ module.exports = items_ =
       db.fetch itemsIds
       .tap -> radio.emit 'user:inventory:update', userId
 
+  bulkUpdate: (userId, ids, attribute, newValue)->
+    items_.byIds ids
+    .map (item)-> Item.bulkUpdate(userId, item, attribute, newValue)
+    .then db.bulk
+
   update: (userId, itemUpdateData)->
     db.get itemUpdateData._id
     .then (currentItem)->

--- a/server/lib/sanitize/parameters.coffee
+++ b/server/lib/sanitize/parameters.coffee
@@ -97,6 +97,7 @@ generics =
 
 module.exports =
   authors: arrayOfStrings
+  attribute: nonEmptyString
   email: { validate: validations.common.email }
   generics: generics
   refresh: generics.boolean
@@ -130,3 +131,4 @@ module.exports =
   users: couchUuids
   username: { validate: validations.common.username }
   relatives: whitelistedStrings
+  value: nonEmptyString

--- a/server/models/item.coffee
+++ b/server/models/item.coffee
@@ -41,10 +41,13 @@ Item.update = (userId, newAttributes, oldItem)->
   unless oldItem.owner is userId
     throw error_.new "user isnt item.owner: #{userId}", 400, oldItem.owner
 
-  updatableAttributes = Object.keys(newAttributes).filter (attr)-> attr in attributes.updatable
   newItem = _.clone oldItem
 
-  for attr in updatableAttributes
+  passedAttributes = Object.keys newAttributes
+
+  for attr in passedAttributes
+    unless attr in attributes.updatable
+      throw error_.new "invalid attribute: #{attr}", 400, arguments
     newVal = newAttributes[attr]
     validations.pass attr, newVal
     newItem[attr] = newVal

--- a/server/models/item.coffee
+++ b/server/models/item.coffee
@@ -55,7 +55,7 @@ Item.update = (userId, updateAttributesData, doc)->
   updatedDoc.updated = Date.now()
   return updatedDoc
 
-Item.bulkUpdate = (userId, item, attribute, value)->
+Item.updateAttr = (userId, item, attribute, value)->
   assert_.types [ 'string', 'object', 'string', 'string|number' ], arguments
   unless item.owner is userId
     throw error_.new "user isnt item.owner: #{userId}", 400, item.owner

--- a/server/models/item.coffee
+++ b/server/models/item.coffee
@@ -57,6 +57,8 @@ Item.update = (userId, updateAttributesData, doc)->
 
 Item.bulkUpdate = (userId, item, attribute, value)->
   assert_.types [ 'string', 'object', 'string', 'string|number' ], arguments
+  unless item.owner is userId
+    throw error_.new "user isnt item.owner: #{userId}", 400, item.owner
 
   validations.pass 'attribute', attribute
   validations.pass attribute, value

--- a/server/models/item.coffee
+++ b/server/models/item.coffee
@@ -55,6 +55,18 @@ Item.update = (userId, updateAttributesData, doc)->
   updatedDoc.updated = Date.now()
   return updatedDoc
 
+Item.bulkUpdate = (userId, item, attribute, value)->
+  assert_.types [ 'string', 'object', 'string', 'string|number' ], arguments
+
+  validations.pass 'attribute', attribute
+  validations.pass attribute, value
+
+  now = Date.now()
+
+  item[attribute] = value
+  item.updated = now
+  return item
+
 Item.changeOwner = (transacDoc, item)->
   assert_.objects [ transacDoc, item ]
   _.log arguments, 'changeOwner'

--- a/server/models/validations/item.coffee
+++ b/server/models/validations/item.coffee
@@ -11,6 +11,7 @@ module.exports = validations =
   entity: entityUri
   lang: (lang)-> if lang then _.isLang(lang) else true
   pictures: (pictures)-> _.isArray(pictures) and _.every(pictures, imgUrl)
+  attribute: (attribute)-> attribute in _.keys(constrained)
   transaction: (transaction)->
     transaction in constrained.transaction.possibilities
   listing: (listing)->

--- a/server/models/validations/task.coffee
+++ b/server/models/validations/task.coffee
@@ -9,7 +9,7 @@ module.exports =
   pass: pass
   # in attributes/task.coffee, attributes keys should match
   # db keys to verify if attribute is updatable
-  attribute: (attribute)-> attribute in _.keys attributes
+  attribute: (attribute)-> attribute in _.keys(attributes)
   type: (taskType)-> taskType in attributes.type
   state: (taskState)-> taskState in attributes.state
   suspectUri: entityUri

--- a/tests/api/items/bulk-details.test.coffee
+++ b/tests/api/items/bulk-details.test.coffee
@@ -1,8 +1,8 @@
 should = require 'should'
-{ authReq, undesiredErr } = require '../utils/utils'
+{ authReq, authReqB, undesiredErr } = require '../utils/utils'
 { newItemBase } = require './helpers'
 
-describe 'items:update-details', ->
+describe 'items:bulk-update', ->
   it 'should update an item details', (done)->
     authReq 'post', '/api/items', newItemBase()
     .then (item)->
@@ -20,6 +20,22 @@ describe 'items:update-details', ->
         .then (updatedItems)->
           updatedItems[0].transaction.should.equal newTransaction
           done()
+    .catch undesiredErr(done)
+
+    return
+
+  it 'should not update an item from another owner', (done)->
+    authReq 'post', '/api/items', newItemBase()
+    .then (item)->
+      ids = [ item._id ]
+      authReqB 'put', '/api/items?action=bulk-update',
+        ids: ids
+        attribute: 'transaction'
+        value: 'lending'
+      .catch (err)->
+        err.statusCode.should.equal 400
+        err.body.status_verbose.should.startWith 'user isnt item.owner'
+        done()
     .catch undesiredErr(done)
 
     return

--- a/tests/api/items/bulk-details.test.coffee
+++ b/tests/api/items/bulk-details.test.coffee
@@ -1,0 +1,25 @@
+should = require 'should'
+{ authReq, undesiredErr } = require '../utils/utils'
+{ newItemBase } = require './helpers'
+
+describe 'items:update-details', ->
+  it 'should update an item details', (done)->
+    authReq 'post', '/api/items', newItemBase()
+    .then (item)->
+      newTransaction = 'lending'
+      item.transaction.should.not.equal newTransaction
+      ids = [ item._id ]
+      authReq 'put', '/api/items?action=bulk-update',
+        ids: ids
+        attribute: 'transaction'
+        value: newTransaction
+      .then (res)->
+        res.ok.should.be.true
+        authReq 'get', "/api/items?action=by-ids&ids=#{ids.join('|')}"
+        .get 'items'
+        .then (updatedItems)->
+          updatedItems[0].transaction.should.equal newTransaction
+          done()
+    .catch undesiredErr(done)
+
+    return

--- a/tests/api/items/bulk-update.test.coffee
+++ b/tests/api/items/bulk-update.test.coffee
@@ -14,7 +14,7 @@ describe 'items:bulk-update', ->
         attribute: 'transaction'
         value: newTransaction
       .then (res)->
-        res.ok.should.be.true
+        res.ok.should.be.true()
         authReq 'get', "/api/items?action=by-ids&ids=#{ids.join('|')}"
         .get 'items'
         .then (updatedItems)->

--- a/tests/unit/models/023-item.coffee
+++ b/tests/unit/models/023-item.coffee
@@ -108,6 +108,12 @@ describe 'item model', ->
 
     it 'should throw when updated with an invalid attribute', (done)->
       doc = create validItem
+      updateAttributesData = { foo: '123' }
+      (-> update(updateAttributesData, doc)).should.throw()
+      done()
+
+    it 'should throw when updated with an invalid attribute value', (done)->
+      doc = create validItem
       updateAttributesData = { listing: 'chocolat' }
       (-> update(updateAttributesData, doc)).should.throw()
       done()

--- a/tests/unit/models/023-item.coffee
+++ b/tests/unit/models/023-item.coffee
@@ -109,7 +109,7 @@ describe 'item model', ->
     it 'should throw when updated with an invalid attribute', (done)->
       doc = create validItem
       updateAttributesData = { foo: '123' }
-      (-> update(updateAttributesData, doc)).should.throw()
+      (-> update(updateAttributesData, doc)).should.throw('invalid attribute: foo')
       done()
 
     it 'should throw when updated with an invalid attribute value', (done)->


### PR DESCRIPTION
open endpoint `bulk-update` for smoothing transition out of `update` and not breaking the api
import controller and model logic from [tasks](server/server/models/task.coffee)
