### PR TITLE
add entities timestamps

### DIFF
--- a/server/models/entity.coffee
+++ b/server/models/entity.coffee
@@ -38,6 +38,7 @@ module.exports = Entity =
     type: 'entity'
     labels: {}
     claims: {}
+    created: Date.now()
 
   setLabel: (doc, lang, value)->
     assert_.types [ 'object', 'string', 'string' ], arguments
@@ -53,6 +54,9 @@ module.exports = Entity =
       throw error_.new 'already up-to-date', 400, { doc, lang, value }
 
     doc.labels[lang] = value
+
+    doc.updated = Date.now()
+
     return doc
 
   setLabels: (doc, labels)->
@@ -84,6 +88,9 @@ module.exports = Entity =
         doc = Entity.createClaim doc, property, value
 
     delete doc._allClaimsProps
+
+    doc.updated = Date.now()
+
     return doc
 
   createClaim: (doc, property, value)->
@@ -127,6 +134,8 @@ module.exports = Entity =
       # if the old value is null, it plays the role of a createClaim
       doc.claims[property] or= []
       doc.claims[property].push newVal
+
+    doc.updated = Date.now()
 
     return updateInferredProperties doc, property, oldVal, newVal
 

--- a/server/models/entity.coffee
+++ b/server/models/entity.coffee
@@ -39,6 +39,7 @@ module.exports = Entity =
     labels: {}
     claims: {}
     created: Date.now()
+    updated: Date.now()
 
   setLabel: (doc, lang, value)->
     assert_.types [ 'object', 'string', 'string' ], arguments

--- a/server/models/entity.coffee
+++ b/server/models/entity.coffee
@@ -145,10 +145,23 @@ module.exports = Entity =
   mergeDocs: (fromEntityDoc, toEntityDoc)->
     Entity.preventRedirectionEdit fromEntityDoc, 'mergeDocs (from)'
     Entity.preventRedirectionEdit toEntityDoc, 'mergeDocs (to)'
-    # Giving priority to the toEntityDoc labels and claims
-    toEntityDoc.labels = _.extend {}, fromEntityDoc.labels, toEntityDoc.labels
-    toEntityDoc.claims = _.extend {}, fromEntityDoc.claims, toEntityDoc.claims
-    toEntityDoc.updated = Date.now()
+
+    dataTransfered = false
+
+    for lang, value of fromEntityDoc.labels
+      unless toEntityDoc.labels[lang]?
+        toEntityDoc.labels[lang] = value
+        dataTransfered = true
+
+    for property, values of fromEntityDoc.claims
+      toEntityDoc.claims[property] ?= []
+      for value in values
+        unless value in toEntityDoc.claims[property]
+          toEntityDoc.claims[property].push value
+          dataTransfered = true
+
+    if dataTransfered then toEntityDoc.updated = Date.now()
+
     return toEntityDoc
 
   turnIntoRedirection: (fromEntityDoc, toUri, removedPlaceholdersIds)->

--- a/server/models/entity.coffee
+++ b/server/models/entity.coffee
@@ -173,14 +173,16 @@ module.exports = Entity =
     if prefix is 'inv' and id is fromEntityDoc._id
       throw error_.new 'circular redirection', 500, arguments
 
-    return {
-      _id: fromEntityDoc._id
-      _rev: fromEntityDoc._rev
-      type: 'entity'
-      redirect: toUri
-      # the list of placeholders entities to recover if the merge as to be reverted
-      removedPlaceholdersIds: removedPlaceholdersIds
-    }
+    redirection = _.cloneDeep fromEntityDoc
+
+    redirection.redirect = toUri
+    delete redirection.labels
+    delete redirection.claims
+    redirection.updated = Date.now()
+    # the list of placeholders entities to recover if the merge as to be reverted
+    redirection.removedPlaceholdersIds = removedPlaceholdersIds
+
+    return redirection
 
   removePlaceholder: (entityDoc)->
     if entityDoc.redirect?

--- a/server/models/entity.coffee
+++ b/server/models/entity.coffee
@@ -148,6 +148,7 @@ module.exports = Entity =
     # Giving priority to the toEntityDoc labels and claims
     toEntityDoc.labels = _.extend {}, fromEntityDoc.labels, toEntityDoc.labels
     toEntityDoc.claims = _.extend {}, fromEntityDoc.claims, toEntityDoc.claims
+    toEntityDoc.updated = Date.now()
     return toEntityDoc
 
   turnIntoRedirection: (fromEntityDoc, toUri, removedPlaceholdersIds)->

--- a/server/models/entity.coffee
+++ b/server/models/entity.coffee
@@ -158,6 +158,9 @@ module.exports = Entity =
       for value in values
         unless value in toEntityDoc.claims[property]
           toEntityDoc.claims[property].push value
+          if properties[property].uniqueValue and toEntityDoc.claims[property].length > 1
+            context = { toEntityDoc, property, values: toEntityDoc.claims[property] }
+            throw error_.new "merge would create mutliples #{property} values", 400, context
           dataTransfered = true
 
     if dataTransfered then toEntityDoc.updated = Date.now()

--- a/server/models/entity.coffee
+++ b/server/models/entity.coffee
@@ -191,6 +191,7 @@ module.exports = Entity =
 
     removedDoc = _.cloneDeep entityDoc
     removedDoc.type = 'removed:placeholder'
+    removedDoc.updated = Date.now()
     return removedDoc
 
   recoverPlaceholder: (entityDoc)->

--- a/tests/unit/models/024-entity.coffee
+++ b/tests/unit/models/024-entity.coffee
@@ -45,7 +45,7 @@ describe 'entity model', ->
       entityDoc.created.should.be.a.Number()
       entityDoc.created.should.be.aboveOrEqual now
       entityDoc.created.should.be.below now + 10
-      should(entityDoc.updated).not.be.ok()
+      entityDoc.updated.should.be.ok()
       done()
 
   describe 'create claim', ->

--- a/tests/unit/models/024-entity.coffee
+++ b/tests/unit/models/024-entity.coffee
@@ -279,3 +279,38 @@ describe 'entity model', ->
           updatedDoc.updated.should.be.below now + 10
           done()
         setTimeout update, 1
+
+    describe 'merge', ->
+      it 'should transfer labels', (done)->
+        entityA = workDoc()
+        entityB = workDoc()
+        Entity.setLabel entityA, 'da', 'foo'
+        Entity.mergeDocs entityA, entityB
+        entityB.labels.da.should.equal 'foo'
+        done()
+
+      it 'should not override existing labels', (done)->
+        entityA = workDoc()
+        entityB = workDoc()
+        Entity.setLabel entityA, 'da', 'foo'
+        Entity.setLabel entityB, 'da', 'bar'
+        Entity.mergeDocs entityA, entityB
+        entityB.labels.da.should.equal 'bar'
+        done()
+
+      it 'should transfer claims', (done)->
+        entityA = workDoc()
+        entityB = workDoc()
+        Entity.createClaim entityA, 'wdt:P921', 'wd:Q3'
+        Entity.mergeDocs entityA, entityB
+        entityB.claims['wdt:P921'].should.deepEqual [ 'wd:Q3' ]
+        done()
+
+      it 'should not override existing claims', (done)->
+        entityA = workDoc()
+        entityB = workDoc()
+        Entity.createClaim entityA, 'wdt:P921', 'wd:Q3'
+        Entity.createClaim entityB, 'wdt:P921', 'wd:Q1'
+        Entity.mergeDocs entityA, entityB
+        entityB.claims['wdt:P921'].should.deepEqual [ 'wd:Q1' ]
+        done()

--- a/tests/unit/models/024-entity.coffee
+++ b/tests/unit/models/024-entity.coffee
@@ -302,13 +302,22 @@ describe 'entity model', ->
         entityB.claims['wdt:P921'].should.deepEqual [ 'wd:Q3' ]
         done()
 
-      it 'should not override existing claims', (done)->
+      it 'should add new claims on already used property', (done)->
         entityA = workDoc()
         entityB = workDoc()
         Entity.createClaim entityA, 'wdt:P921', 'wd:Q3'
         Entity.createClaim entityB, 'wdt:P921', 'wd:Q1'
         Entity.mergeDocs entityA, entityB
-        entityB.claims['wdt:P921'].should.deepEqual [ 'wd:Q1' ]
+        entityB.claims['wdt:P921'].should.deepEqual [ 'wd:Q1', 'wd:Q3' ]
+        done()
+
+      it 'should not create duplicated claims', (done)->
+        entityA = workDoc()
+        entityB = workDoc()
+        Entity.createClaim entityA, 'wdt:P921', 'wd:Q3'
+        Entity.createClaim entityB, 'wdt:P921', 'wd:Q3'
+        Entity.mergeDocs entityA, entityB
+        entityB.claims['wdt:P921'].should.deepEqual [ 'wd:Q3' ]
         done()
 
       it 'should update the timestamp', (done)->
@@ -323,3 +332,15 @@ describe 'entity model', ->
           entityB.updated.should.be.below now + 10
           done()
         setTimeout update, 1
+
+      it 'should not update the timestamp if no data was transfered', (done)->
+        entityA = workDoc()
+        entityB = workDoc()
+        initialTimestamp = entityB.updated
+        Entity.createClaim entityA, 'wdt:P921', 'wd:Q3'
+        Entity.createClaim entityB, 'wdt:P921', 'wd:Q3'
+        update = ->
+          Entity.mergeDocs entityA, entityB
+          entityB.updated.should.equal initialTimestamp
+          done()
+        setTimeout update, 10

--- a/tests/unit/models/024-entity.coffee
+++ b/tests/unit/models/024-entity.coffee
@@ -337,9 +337,9 @@ describe 'entity model', ->
       it 'should not update the timestamp if no data was transfered', (done)->
         entityA = workDoc()
         entityB = workDoc()
-        initialTimestamp = entityB.updated
         Entity.createClaim entityA, 'wdt:P921', 'wd:Q3'
         Entity.createClaim entityB, 'wdt:P921', 'wd:Q3'
+        initialTimestamp = entityB.updated
         update = ->
           Entity.mergeDocs entityA, entityB
           entityB.updated.should.equal initialTimestamp

--- a/tests/unit/models/024-entity.coffee
+++ b/tests/unit/models/024-entity.coffee
@@ -344,3 +344,11 @@ describe 'entity model', ->
           entityB.updated.should.equal initialTimestamp
           done()
         setTimeout update, 10
+
+      it 'should reject merge implying to break claim uniqueness restrictions', (done)->
+        entityA = workDoc()
+        entityB = workDoc()
+        Entity.createClaim entityA, 'wdt:P648', 'OL123456W'
+        Entity.createClaim entityB, 'wdt:P648', 'OL123457W'
+        (-> Entity.mergeDocs entityA, entityB).should.throw 'merge would create mutliples wdt:P648 values'
+        done()

--- a/tests/unit/models/024-entity.coffee
+++ b/tests/unit/models/024-entity.coffee
@@ -211,9 +211,7 @@ describe 'entity model', ->
       it 'should throw if a critical property got zero claims', (done)->
         doc = editionDoc()
         updater = -> Entity.updateClaim doc, 'wdt:P629', 'wd:Q53592', null
-        updater.should.throw()
-        try updater()
-        catch err then err.message.should.equal 'this property should at least have one value'
+        updater.should.throw('this property should at least have one value')
         done()
 
       it 'should update the timestamp', (done)->

--- a/tests/unit/models/024-entity.coffee
+++ b/tests/unit/models/024-entity.coffee
@@ -390,3 +390,26 @@ describe 'entity model', ->
           done()
 
         setTimeout redirect, 5
+
+    describe 'removePlaceholder', ->
+      it 'should return a removed placeholder doc', (done)->
+        entity = workDoc()
+        removedPlaceholder = Entity.removePlaceholder entity
+        removedPlaceholder.should.be.an.Object()
+        removedPlaceholder.labels.should.deepEqual entity.labels
+        removedPlaceholder.claims.should.deepEqual entity.claims
+        done()
+
+      it 'should be a different object', (done)->
+        entity = workDoc()
+        removedPlaceholder = Entity.removePlaceholder entity
+        should(removedPlaceholder is entity).not.be.true()
+        done()
+
+      it 'should update the timestamp', (done)->
+        entity = workDoc()
+        remove = ->
+          removedPlaceholder = Entity.removePlaceholder entity
+          removedPlaceholder.updated.should.be.above entity.updated
+          done()
+        setTimeout remove, 5

--- a/tests/unit/models/024-entity.coffee
+++ b/tests/unit/models/024-entity.coffee
@@ -265,16 +265,14 @@ describe 'entity model', ->
         done()
 
       it 'should update the timestamp', (done)->
-        now = Date.now()
         entityDoc = workDoc()
+        initialTimestamp = entityDoc.updated
         entityDoc.updated.should.be.a.Number()
-        entityDoc.updated.should.be.aboveOrEqual entityDoc.updated
-        entityDoc.updated.should.be.below entityDoc.updated + 10
         update = ->
           updatedDoc = Entity.setLabel entityDoc, 'fr', 'hello'
           updatedDoc.updated.should.be.a.Number()
-          updatedDoc.updated.should.be.above now
-          updatedDoc.updated.should.be.below now + 10
+          updatedDoc.updated.should.be.above initialTimestamp
+          updatedDoc.updated.should.be.below initialTimestamp + 10
           done()
         setTimeout update, 1
 
@@ -312,3 +310,16 @@ describe 'entity model', ->
         Entity.mergeDocs entityA, entityB
         entityB.claims['wdt:P921'].should.deepEqual [ 'wd:Q1' ]
         done()
+
+      it 'should update the timestamp', (done)->
+        entityA = workDoc()
+        entityB = workDoc()
+        Entity.createClaim entityA, 'wdt:P921', 'wd:Q3'
+        now = Date.now()
+        update = ->
+          Entity.mergeDocs entityA, entityB
+          entityB.updated.should.be.a.Number()
+          entityB.updated.should.be.above now
+          entityB.updated.should.be.below now + 10
+          done()
+        setTimeout update, 1


### PR DESCRIPTION
to easily be able to access creation and last update dates for data cleaners, or from query.inventaire.io