### PR TITLE
items snapshot: snapshot editions' title

### DIFF
--- a/server/controllers/items/lib/snapshot/build_snapshot.coffee
+++ b/server/controllers/items/lib/snapshot/build_snapshot.coffee
@@ -11,6 +11,7 @@ module.exports =
   edition: (edition, works, authors, series)->
     lang = edition.originalLang or 'en'
     title = edition.claims['wdt:P1476']?[0]
+    subtitle = edition.claims['wdt:P1680']?[0]
     # Wikidata editions might not have a wdt:P1476 value
     title or= getBestLangValue(lang, null, edition.labels).value
     image = edition.image?.url
@@ -19,6 +20,7 @@ module.exports =
       entity: edition,
       works,
       title,
+      subtitle,
       lang,
       image,
       authors,
@@ -42,7 +44,7 @@ module.exports =
     }
 
 buildOperation = (params)->
-  { type, entity, works, title, lang, image, authors, series } = params
+  { type, entity, works, title, subtitle, lang, image, authors, series } = params
   assert_.array works
   unless _.isNonEmptyString title
     throw error_.new 'no title found', 400, entity
@@ -62,6 +64,9 @@ buildOperation = (params)->
   # Filtering out Wikimedia File names, keeping only images hashes or URLs
   if snapshotValidations['entity:image'](image)
     snapshot['entity:image'] = image
+
+  if _.isNonEmptyString subtitle
+    snapshot['entity:subtitle'] = subtitle
 
   { uri } = entity
   assert_.string uri

--- a/tests/api/fixtures/entities.coffee
+++ b/tests/api/fixtures/entities.coffee
@@ -65,6 +65,7 @@ module.exports = API =
           'wdt:P31': [ 'wd:Q3331189' ]
           'wdt:P629': worksUris
           'wdt:P1476': [ _.values(works[0].labels)[0] ]
+          'wdt:P1680': [ randomWords() ]
           'wdt:P407': [ 'wd:' + wdLang.byCode[lang].wd ]
           'invp:P2': [ someImageHash ]
 

--- a/tests/api/items/snapshot.test.coffee
+++ b/tests/api/items/snapshot.test.coffee
@@ -90,6 +90,19 @@ describe 'items:snapshot', ->
 
     return
 
+  it 'should snapshot the subtitle of an edition', (done)->
+    createEdition()
+    .then (edition)->
+      subtitle = edition.claims['wdt:P1680'][0]
+      subtitle.should.a.String()
+      authReq 'post', '/api/items', { entity: edition.uri }
+      .then (item)->
+        item.snapshot['entity:subtitle'].should.equal subtitle
+        done()
+    .catch done
+
+    return
+
   it 'should snapshot the image of an edition after a work-related refresh', (done)->
     createEdition()
     .then (edition)->


### PR DESCRIPTION
to be able to display subtitles without having to fetch the entity
typically in items lists