### PR TITLE
prevent popularity infinite loop

### DIFF
--- a/server/data/wikidata/queries/serie_parts.coffee
+++ b/server/data/wikidata/queries/serie_parts.coffee
@@ -2,11 +2,13 @@ module.exports =
   parameters: ['qid']
   query: (params)->
     { qid:serieQid } = params
+
+    # FILTER: reject circular series/parts relations
+
     """
     SELECT ?part ?date ?ordinal WHERE {
-      { ?part wdt:P179 wd:#{serieQid} . }
-      UNION
-      { ?part wdt:P361 wd:#{serieQid} . }
+      ?part wdt:P179|wdt:P361 #{serieQid} .
+      FILTER NOT EXISTS { #{serieQid} wdt:P179|wdt:P361 ?part }
       OPTIONAL { ?part wdt:P577 ?date . }
       OPTIONAL { ?part wdt:P1545 ?ordinal . }
     }

--- a/server/lib/cache.coffee
+++ b/server/lib/cache.coffee
@@ -25,6 +25,7 @@ module.exports =
     if refresh
       timespan = 0
       dry = false
+      dryAndCache = false
     timespan ?= oneMonth
     dry ?= false
     dryAndCache ?= false

--- a/tests/api/entities/popularity.test.coffee
+++ b/tests/api/entities/popularity.test.coffee
@@ -11,7 +11,7 @@ describe 'entities:popularity', ->
   describe 'edition', ->
     it 'should reject invalid uri', (done)->
       invalidUri = 'inv:aliduri'
-      getPopularity invalidUri
+      getRefreshedPopularityByUri invalidUri
       .then undesiredRes(done)
       .catch (err)->
         err.body.status_verbose.should.startWith 'invalid '

--- a/tests/unit/libs/037-cache.coffee
+++ b/tests/unit/libs/037-cache.coffee
@@ -195,6 +195,17 @@ describe 'cache', ->
         .catch done
         return
 
+      it 'should be overriden by refresh', (done)->
+        key = randomString 4
+        fn = workingFn.bind null, 'foo'
+        cache_.get { key, fn, refresh:true, dryAndCache: true }
+        .delay 10
+        .then (res1)->
+          should(res1).be.ok()
+          done()
+        .catch done
+        return
+
   describe 'put', ->
     it 'should return a promise', (done)->
       p = cache_.put 'whatever', 'somevalue'


### PR DESCRIPTION
a loop was created by requesting the popularity of a serie having itself as part ([example](https://www.wikidata.org/w/index.php?title=Q56064945&oldid=726704275)), this is fixing it by filtering-out series' parts that are either the serie itself or which has the serie for part (f254da4)

Other commits are just fixing an undesired behavior of the cache (5795d5c) and fixing a test (10f3e24)