### PR TITLE
promises: add map function, wrapping Promise.all and array.map

### DIFF
--- a/server/lib/promises.coffee
+++ b/server/lib/promises.coffee
@@ -15,6 +15,7 @@ module.exports = promisesHandlers =
   reject: Promise.reject
   try: Promise.try
   all: Promise.all
+  map: (array, fn)-> Promise.all array.map(fn)
   props: Promise.props
 
   # skip throws in a standard way to be catched later

--- a/tests/api/entities/update_claims.test.coffee
+++ b/tests/api/entities/update_claims.test.coffee
@@ -2,7 +2,8 @@ CONFIG = require 'config'
 __ = CONFIG.universalPath
 _ = __.require 'builders', 'utils'
 should = require 'should'
-{ Promise } = __.require 'lib', 'promises'
+promises_ = __.require 'lib', 'promises'
+{ Promise } = promises_
 { undesiredRes, undesiredErr } = require '../utils/utils'
 { createWork, createEdition, createHuman, someOpenLibraryId } = require '../fixtures/entities'
 { getByUri, addClaim, updateClaim, removeClaim, merge } = require '../utils/entities'
@@ -110,7 +111,7 @@ describe 'entities:update-claims', ->
     createWork()
     .then (work)->
       { uri: workUri } = work
-      Promise.all authorsUris.map((uri)-> addClaim work.uri, 'wdt:P50', uri)
+      promises_.map authorsUris, (uri)-> addClaim work.uri, 'wdt:P50', uri
       .then (responses)->
         responses.forEach (res)-> should(res.ok).be.true()
         getByUri work.uri

--- a/tests/api/entities/update_labels.test.coffee
+++ b/tests/api/entities/update_labels.test.coffee
@@ -1,6 +1,7 @@
 CONFIG = require 'config'
 __ = CONFIG.universalPath
 _ = __.require 'builders', 'utils'
+promises_ = __.require 'lib', 'promises'
 should = require 'should'
 { undesiredRes, undesiredErr } = require '../utils/utils'
 { createHuman } = require '../fixtures/entities'
@@ -67,7 +68,7 @@ describe 'entities:update-labels', ->
     humanPromise
     .then (human)->
       { _id: humanId, uri: humanUri } = human
-      Promise.all langs.map((lang)-> updateLabel humanId, lang, name)
+      promises_.map langs, (lang)-> updateLabel humanId, lang, name
       .then (responses)->
         responses.forEach (res)-> should(res.ok).be.true()
         getByUri human.uri


### PR DESCRIPTION
proposition to improve readability of this recurring pattern, while making it easier to respect the CoffeeScript convention to only remove the top level parenthesis (ex: `a b(c)` but not `a b c ` despite it being valid CoffeeScript)