### PR TITLE
entities: revert-merge: fix and test placeholder recovery

### DIFF
--- a/server/controllers/entities/lib/revert_merge.coffee
+++ b/server/controllers/entities/lib/revert_merge.coffee
@@ -25,7 +25,7 @@ module.exports = (userId, fromId)->
         currentDoc: currentVersion
         updatedDoc: targetVersion
       .tap -> updateItemEntity.afterRevert fromUri, toUri
-      .tap -> recoverPlaceholders currentVersion.removedPlaceholdersIds
+      .tap -> recoverPlaceholders userId, currentVersion.removedPlaceholdersIds
       .tap -> revertMergePatch userId, fromUri, toUri
       .tap -> revertClaimsRedirections userId, fromUri, toUri
 


### PR DESCRIPTION
the recovery of placeholder after a `revert-merge` was mistakenly implemented from the start (missing argument), and there was no test to help spot it

---

Documenting what I had to do to recover failed placeholder recoveries:

* generate a ttl dump including `removed:placeholder`s by replacing
  * [`serialize_entity_in_turtle.coffee#L9`](https://github.com/inventaire/inventaire/blob/978e338/scripts/dumps/lib/serialize_entity_in_turtle.coffee#L9) with `if type is 'removed:placeholder' then return "inv:#{_id} a wikibase:RemovedPlaceholder ."`
  * [`prepare_entities_dumps#L46`](https://github.com/inventaire/inventaire/blob/978e338/scripts/dumps/prepare_entities_dumps#L46) with `grep '"type":"'`

* load the generated dump to a Blazegraph namespace:
```sh
curl http://localhost:9999/bigdata/namespace/entities/dataloader -H 'Content-Type: application/x-turtle' -d@./entities_with_seeds.ttl
```

* find the non-recovered placeholders with the following query
```sparql
# Find any placeholder with entities linking to it
SELECT DISTINCT ?removedPlaceholder WHERE {
  hint:Query hint:optimizer "None".
  ?removedPlaceholder a wikibase:RemovedPlaceholder .
  ?entity ?property ?removedPlaceholder .
}
```
