### PR TITLE
improve serie parts query

### DIFF
--- a/server/controllers/entities/lib/get_serie_parts.coffee
+++ b/server/controllers/entities/lib/get_serie_parts.coffee
@@ -29,6 +29,7 @@ getWdSerieParts = (qid, refresh, dry)->
     date: getSimpleDayDate result.date
     ordinal: result.ordinal
     subparts: result.subparts
+    superpart: prefixifyWd result.superpart
 
 getInvSerieParts = (uri)->
   # Querying only for 'serie' (wdt:P179) and not 'part of' (wdt:P361)

--- a/server/controllers/entities/lib/get_serie_parts.coffee
+++ b/server/controllers/entities/lib/get_serie_parts.coffee
@@ -28,6 +28,7 @@ getWdSerieParts = (qid, refresh, dry)->
     uri: prefixifyWd result.part
     date: getSimpleDayDate result.date
     ordinal: result.ordinal
+    subparts: result.subparts
 
 getInvSerieParts = (uri)->
   # Querying only for 'serie' (wdt:P179) and not 'part of' (wdt:P361)
@@ -40,3 +41,4 @@ parseRow = (row)->
   uri: "inv:#{row.id}"
   date: row.doc.claims['wdt:P577']?[0]
   ordinal: row.doc.claims['wdt:P1545']?[0]
+  subparts: 0

--- a/server/controllers/entities/lib/queries_utils.coffee
+++ b/server/controllers/entities/lib/queries_utils.coffee
@@ -6,26 +6,23 @@ module.exports =
     # its a year-precision date
     .replace '-01-01', ''
 
-  # sortByDate: (a, b)-> formatDate(a) - formatDate(b)
-  sortByOrdinalOrDate: (a, b)-> formatDate(a, true) - formatDate(b, true)
+  sortByOrdinalOrDate: (a, b)-> getPartScore(a) - getPartScore(b)
   sortByScore: (a, b)-> b.score - a.score
 
 earliestDate = -10000
-formatDate = (obj, preferOrdinal)->
-  { date, ordinal } = obj
+getPartScore = (obj)->
+  { date, ordinal, subparts } = obj
+  # Push parts with subparts up if they don't have a date or ordinal of their own
+  if subparts > 0 and not date? and not ordinal? then return earliestDate - subparts
   # Fake a very early date to be ranked before any entity
   # with a date but no ordinal
-  if preferOrdinal and ordinal? then return earliestDate + ordinalNum(ordinal)
+  if ordinal? then return earliestDate + ordinalNum(ordinal)
   if date? then return new Date(date).getTime()
-  return fakeLastYearTime ordinal
+  return lastYearTime
 
 # If no date is available, make it appear last by providing a date in the future
-# Add the ordinal so that items without a date are still prioritized by ordinal
-# lastYearBase to update once we will have passed the year 2100
-lastYearBase = 2100
-fakeLastYearTime = (ordinal)->
-  fakeDateYearString = (lastYearBase + ordinalNum(ordinal)).toString()
-  return new Date(fakeDateYearString).getTime()
+# Update once we passed the year 2100
+lastYearTime = new Date('2100').getTime()
 
 lastOrdinal = 1000
 ordinalNum = (ordinal)->

--- a/server/data/wikidata/queries/serie_parts.coffee
+++ b/server/data/wikidata/queries/serie_parts.coffee
@@ -9,11 +9,13 @@ module.exports =
 
     """
     SELECT ?part ?date ?ordinal WHERE {
-      ?part wdt:P179|wdt:P361 wd:#{serieQid} .
+      ?part p:P179|p:P361 ?serie_statement .
+      ?serie_statement ps:P179|ps:P361 wd:#{serieQid} .
       FILTER NOT EXISTS { wd:#{serieQid} wdt:P179|wdt:P361 ?part }
       FILTER NOT EXISTS { ?part wdt:P31 wd:Q3331189 }
       FILTER NOT EXISTS { ?part wdt:P629 ?work }
       OPTIONAL { ?part wdt:P577 ?date . }
       OPTIONAL { ?part wdt:P1545 ?ordinal . }
+      OPTIONAL { ?serie_statement pq:P1545 ?ordinal . }
     }
     """

--- a/server/data/wikidata/queries/serie_parts.coffee
+++ b/server/data/wikidata/queries/serie_parts.coffee
@@ -8,12 +8,21 @@ module.exports =
       ?part p:P179|p:P361 ?serie_statement .
       ?serie_statement ps:P179|ps:P361 wd:#{serieQid} .
 
-      # reject circular series/parts relations
+      # Reject circular series/parts relations
       FILTER NOT EXISTS { wd:#{serieQid} wdt:P179|wdt:P361 ?part }
 
-      # reject editions
-      FILTER NOT EXISTS { ?part wdt:P31 wd:Q3331189 }
+      # Reject parts that have an associated work (duck-typing editions)
       FILTER NOT EXISTS { ?part wdt:P629 ?work }
+
+      # Reject parts that are instance of editions
+      FILTER NOT EXISTS {
+        ?part wdt:P31 wd:Q3331189
+        # but recover parts that are also instances of work
+        FILTER NOT EXISTS {
+          VALUES (?work_type) { (wd:Q571) (wd:Q47461344) (wd:Q2831984) (wd:Q1760610) (wd:Q8274) } .
+          ?part wdt:P31 ?work_type .
+        }
+      }
 
       OPTIONAL { ?part wdt:P577 ?date . }
       OPTIONAL { ?part wdt:P1545 ?ordinal . }

--- a/server/data/wikidata/queries/serie_parts.coffee
+++ b/server/data/wikidata/queries/serie_parts.coffee
@@ -3,24 +3,28 @@ module.exports =
   query: (params)->
     { qid:serieQid } = params
 
-    # FILTERS:
-    # - reject circular series/parts relations
-    # - reject parts that are also subparts of another part of the serie
-    # - reject editions
-
     """
-    SELECT ?part ?date ?ordinal WHERE {
+    SELECT ?part ?date ?ordinal (COUNT(?subpart) AS ?subparts) WHERE {
       ?part p:P179|p:P361 ?serie_statement .
       ?serie_statement ps:P179|ps:P361 wd:#{serieQid} .
+
+      # reject circular series/parts relations
       FILTER NOT EXISTS { wd:#{serieQid} wdt:P179|wdt:P361 ?part }
+
+      # reject parts that are also subparts of another part of the serie
       FILTER NOT EXISTS {
-        ?part wdt:P179|wdt:P361 ?part_b
+        ?part wdt:P179|wdt:P361 ?part_b .
         ?part_b wdt:P179|wdt:P361 wd:#{serieQid} .
       }
+
+      # reject editions
       FILTER NOT EXISTS { ?part wdt:P31 wd:Q3331189 }
       FILTER NOT EXISTS { ?part wdt:P629 ?work }
+
       OPTIONAL { ?part wdt:P577 ?date . }
       OPTIONAL { ?part wdt:P1545 ?ordinal . }
       OPTIONAL { ?serie_statement pq:P1545 ?ordinal . }
+      OPTIONAL { ?subpart wdt:P179|wdt:P361 ?part . }
     }
+    GROUP BY ?part ?date ?ordinal
     """

--- a/server/data/wikidata/queries/serie_parts.coffee
+++ b/server/data/wikidata/queries/serie_parts.coffee
@@ -3,12 +3,16 @@ module.exports =
   query: (params)->
     { qid:serieQid } = params
 
-    # FILTER: reject circular series/parts relations
+    # FILTERS:
+    # - reject circular series/parts relations
+    # - reject editions
 
     """
     SELECT ?part ?date ?ordinal WHERE {
       ?part wdt:P179|wdt:P361 wd:#{serieQid} .
       FILTER NOT EXISTS { wd:#{serieQid} wdt:P179|wdt:P361 ?part }
+      FILTER NOT EXISTS { ?part wdt:P31 wd:Q3331189 }
+      FILTER NOT EXISTS { ?part wdt:P629 ?work }
       OPTIONAL { ?part wdt:P577 ?date . }
       OPTIONAL { ?part wdt:P1545 ?ordinal . }
     }

--- a/server/data/wikidata/queries/serie_parts.coffee
+++ b/server/data/wikidata/queries/serie_parts.coffee
@@ -5,6 +5,7 @@ module.exports =
 
     # FILTERS:
     # - reject circular series/parts relations
+    # - reject parts that are also subparts of another part of the serie
     # - reject editions
 
     """
@@ -12,6 +13,10 @@ module.exports =
       ?part p:P179|p:P361 ?serie_statement .
       ?serie_statement ps:P179|ps:P361 wd:#{serieQid} .
       FILTER NOT EXISTS { wd:#{serieQid} wdt:P179|wdt:P361 ?part }
+      FILTER NOT EXISTS {
+        ?part wdt:P179|wdt:P361 ?part_b
+        ?part_b wdt:P179|wdt:P361 wd:#{serieQid} .
+      }
       FILTER NOT EXISTS { ?part wdt:P31 wd:Q3331189 }
       FILTER NOT EXISTS { ?part wdt:P629 ?work }
       OPTIONAL { ?part wdt:P577 ?date . }

--- a/server/data/wikidata/queries/serie_parts.coffee
+++ b/server/data/wikidata/queries/serie_parts.coffee
@@ -4,18 +4,12 @@ module.exports =
     { qid:serieQid } = params
 
     """
-    SELECT ?part ?date ?ordinal (COUNT(?subpart) AS ?subparts) WHERE {
+    SELECT ?part ?date ?ordinal (COUNT(?subpart) AS ?subparts) ?superpart WHERE {
       ?part p:P179|p:P361 ?serie_statement .
       ?serie_statement ps:P179|ps:P361 wd:#{serieQid} .
 
       # reject circular series/parts relations
       FILTER NOT EXISTS { wd:#{serieQid} wdt:P179|wdt:P361 ?part }
-
-      # reject parts that are also subparts of another part of the serie
-      FILTER NOT EXISTS {
-        ?part wdt:P179|wdt:P361 ?part_b .
-        ?part_b wdt:P179|wdt:P361 wd:#{serieQid} .
-      }
 
       # reject editions
       FILTER NOT EXISTS { ?part wdt:P31 wd:Q3331189 }
@@ -24,7 +18,14 @@ module.exports =
       OPTIONAL { ?part wdt:P577 ?date . }
       OPTIONAL { ?part wdt:P1545 ?ordinal . }
       OPTIONAL { ?serie_statement pq:P1545 ?ordinal . }
+
       OPTIONAL { ?subpart wdt:P179|wdt:P361 ?part . }
+
+      OPTIONAL {
+        ?part wdt:P179|wdt:P361 ?superpart .
+        ?superpart wdt:P179|wdt:P361 wd:#{serieQid} .
+      }
+
     }
-    GROUP BY ?part ?date ?ordinal
+    GROUP BY ?part ?date ?ordinal ?superpart
     """


### PR DESCRIPTION
* filter-out editions
* take ordinal data from serie claim qualifiers too
* push parts with subparts up the list
* keep a reference to superparts in subparts to let the client choose if they should be displayed or not
