### PR TITLE
search filter: accept an entity prefix as filter parameter

### DIFF
--- a/server/controllers/search/lib/type_search.js
+++ b/server/controllers/search/lib/type_search.js
@@ -2,20 +2,33 @@ const CONFIG = require('config')
 const __ = CONFIG.universalPath
 const requests_ = __.require('lib', 'requests')
 const assert_ = __.require('utils', 'assert_types')
+const error_ = __.require('lib', 'error/error')
+const { Promise } = __.require('lib', 'promises')
 const { host: elasticHost } = CONFIG.elasticsearch
 const { formatError } = __.require('lib', 'elasticsearch')
 const getIndexesAndTypes = require('./get_indexes_and_types')
 const queryBodyBuilder = require('./query_body_builder')
 
 // types should be a subset of ./types possibleTypes
-module.exports = (types, search, limit = 20) => {
-  let indexes
+module.exports = (types, search, limit = 20, filter) => {
   assert_.array(types)
-  assert_.string(search);
+  assert_.string(search)
 
-  ({ indexes, types } = getIndexesAndTypes(types))
+  let { indexes, types: indexesTypes } = getIndexesAndTypes(types)
 
-  const url = `${elasticHost}/${indexes.join(',')}/${types.join(',')}/_search`
+  if (filter) {
+    if (filter === 'wd') {
+      indexes = indexes.includes('wikidata') ? [ 'wikidata' ] : []
+    } else if (filter === 'inv') {
+      indexes = indexes.filter(indexName => indexName !== 'wikidata')
+    } else {
+      throw error_.new('invalid filter', 500, { types, search, filter })
+    }
+  }
+
+  if (indexes.length === 0) return Promise.resolve([])
+
+  const url = `${elasticHost}/${indexes.join(',')}/${indexesTypes.join(',')}/_search`
 
   const body = queryBodyBuilder(search, limit)
 

--- a/server/controllers/search/search.js
+++ b/server/controllers/search/search.js
@@ -13,18 +13,27 @@ const Group = __.require('models', 'group')
 const sanitization = {
   search: {},
   lang: {},
-  types: { allowlist: possibleTypes },
-  limit: { default: 10, max: 100 }
+  types: {
+    allowlist: possibleTypes
+  },
+  limit: {
+    default: 10,
+    max: 100
+  },
+  filter: {
+    optional: true,
+    allowlist: [ 'inv', 'wd' ]
+  }
 }
 
 module.exports = {
   get: (req, res) => {
     sanitize(req, res, sanitization)
     .then(params => {
-      const { types, search, lang, limit, reqUserId } = params
+      const { types, search, lang, limit, filter: index, reqUserId } = params
       // Extend the search to the next 10 results, so that the popularity boost
       // can save some good results a bit further down the limit
-      return typeSearch(types, search, limit + 10)
+      return typeSearch(types, search, limit + 10, index)
       .then(parseResults(types))
       .then(results => {
         return results

--- a/tests/api/utils/search.js
+++ b/tests/api/utils/search.js
@@ -8,10 +8,12 @@ const { rawRequest } = require('./request')
 const endpoint = '/api/search'
 
 module.exports = {
-  search: async (types, input, lang = 'en') => {
+  search: async (types, input, filter) => {
     if (_.isArray(types)) types = types.join('|')
     input = encodeURIComponent(input)
-    const { results } = await nonAuthReq('get', `${endpoint}?types=${types}&lang=${lang}&search=${input}`)
+    let url = `${endpoint}?types=${types}&lang=en&search=${input}`
+    if (filter) url += `&filter=${filter}`
+    const { results } = await nonAuthReq('get', url)
     return results
   },
 


### PR DESCRIPTION
this would make [query.inventaire.io](https://query.inventaire.io) prefix autocompletion more efficient: it currently needs to request a lot of results to then filter-out those that aren't of the `inv` prefix