### PR TITLE
reverse_claims: accept string values

### DIFF
--- a/server/controllers/entities/reverse_claims.coffee
+++ b/server/controllers/entities/reverse_claims.coffee
@@ -3,19 +3,18 @@ _ = __.require 'builders', 'utils'
 error_ = __.require 'lib', 'error/error'
 responses_ = __.require 'lib', 'responses'
 reverseClaims = require './lib/reverse_claims'
+sanitize = __.require 'lib', 'sanitize/sanitize'
 
-module.exports = (req, res, next)->
-  { property, uri, refresh, sort } = req.query
+sanitization =
+  property: {}
+  value: {}
+  refresh: { optional: true }
+  sort:
+    generic: 'boolean'
+    default: false
 
-  unless _.isPropertyUri property
-    return error_.bundleInvalid req, res, 'property', property
-
-  unless _.isEntityUri uri
-    return error_.bundleInvalid req, res, 'uri', uri
-
-  refresh = _.parseBooleanString refresh
-  sort = _.parseBooleanString sort
-
-  reverseClaims { property, value: uri, refresh, sort }
+module.exports = (req, res)->
+  sanitize req, res, sanitization
+  .then reverseClaims
   .then responses_.Wrap(res, 'uris')
   .catch error_.Handler(req, res)

--- a/server/lib/sanitize/parameters.coffee
+++ b/server/lib/sanitize/parameters.coffee
@@ -124,6 +124,7 @@ module.exports =
     secret: true
     validate: validations.user.password
   prefix: whitelistedString
+  property: { validate: _.isPropertyUri }
   range: _.extend {}, positiveInteger,
     default: 50
     max: 500

--- a/tests/api/entities/reverse_claims.test.coffee
+++ b/tests/api/entities/reverse_claims.test.coffee
@@ -4,16 +4,33 @@ _ = __.require 'builders', 'utils'
 should = require 'should'
 { nonAuthReq, undesiredErr, undesiredRes } = require '../utils/utils'
 
+buildUrl = (property, value)->
+  url = _.buildPath '/api/entities', { action: 'reverse-claims', property, value }
+
 describe 'entities:reverse-claims', ->
   it 'should reject wdt:P31 requests', (done)->
-    url = _.buildPath '/api/entities',
-      action: 'reverse-claims'
-      property: 'wdt:P31'
-      uri: 'wd:Q571'
-    nonAuthReq 'get', url
+    nonAuthReq 'get', buildUrl('wdt:P31', 'wd:Q571')
     .then undesiredRes(done)
     .catch (err)->
       err.body.status_verbose.should.equal 'blacklisted property'
+      done()
+    .catch undesiredErr(done)
+
+    return
+
+  it 'should accept whitelisted entity value properties', (done)->
+    nonAuthReq 'get', buildUrl('wdt:P921', 'wd:Q456')
+    .then (res)->
+      res.uris.should.be.an.Array()
+      done()
+    .catch undesiredErr(done)
+
+    return
+
+  it 'should accept whitelisted string value properties', (done)->
+    nonAuthReq 'get', buildUrl('wdt:P3035', '978-2-505')
+    .then (res)->
+      res.uris.should.be.an.Array()
       done()
     .catch undesiredErr(done)
 


### PR DESCRIPTION
needed by the client to be able to resolve ids.

Example: find a publisher from an ISBN publisher prefix (`wdt:P3035`): `/api/entities?action=reverse-claims&property=wdt:P3035&value=978-2-505`