### PR TITLE
create wikidata item

### DIFF
--- a/server/controllers/entities/create.coffee
+++ b/server/controllers/entities/create.coffee
@@ -3,7 +3,6 @@ _ = __.require 'builders', 'utils'
 responses_ = __.require 'lib', 'responses'
 error_ = __.require 'lib', 'error/error'
 { Track } = __.require 'lib', 'track'
-createEntity = require './lib/create_entity'
 getEntityByUri = require './lib/get_entity_by_uri'
 sanitize = __.require 'lib', 'sanitize/sanitize'
 
@@ -13,14 +12,26 @@ sanitization =
     default: {}
   claims:
     generic: 'object'
+  prefix:
+    whitelist: [ 'inv', 'wd' ]
+    default: 'inv'
 
 module.exports = (req, res)->
   sanitize req, res, sanitization
   .then (params)->
-    { labels, claims, reqUserId } = params
-    return createEntity labels, claims, reqUserId
-  # Re-request the entity's data to get it formatted
-  .then (entity)-> getEntityByUri { uri: "inv:#{entity._id}", refresh: true }
+    { prefix, labels, claims, reqUserId } = params
+    createFn = creators[prefix]
+    params = { labels, claims }
+    if prefix is 'wd' then params.user = req.user
+    else params.userId = reqUserId
+    createFn params
+    .then (entity)->
+      # Re-request the entity's data to get it formatted
+      getEntityByUri { uri: entity.uri, refresh: true }
   .then responses_.Send(res)
-  .then Track(req, ['entity', 'creation'])
+  .then Track(req, [ 'entity', 'creation' ])
   .catch error_.Handler(req, res)
+
+creators =
+  inv: require './lib/create_inv_entity'
+  wd: require './lib/create_wd_entity'

--- a/server/controllers/entities/lib/create_inv_entity.coffee
+++ b/server/controllers/entities/lib/create_inv_entity.coffee
@@ -1,0 +1,17 @@
+__ = require('config').universalPath
+_ = __.require 'builders', 'utils'
+entities_ = require './entities'
+validateEntity = require './validate_entity'
+{ unprefixify } = require './prefix'
+{ prefixifyInv, unprefixify } = require './prefix'
+
+module.exports = (params)->
+  { labels, claims, userId } = params
+  _.log params, 'inv entity creation'
+
+  validateEntity { labels, claims }
+  .then -> entities_.create()
+  .then entities_.edit.bind(null, userId, labels, claims)
+  .then (entity)->
+    entity.uri = prefixifyInv entity._id
+    return entity

--- a/server/controllers/entities/lib/create_wd_entity.coffee
+++ b/server/controllers/entities/lib/create_wd_entity.coffee
@@ -1,0 +1,65 @@
+CONFIG = require 'config'
+__ = CONFIG.universalPath
+_ = __.require 'builders', 'utils'
+wdEdit = require 'wikidata-edit'
+wdOauth = require './wikidata_oauth'
+{ Promise } = __.require 'lib', 'promises'
+validateEntity = require './validate_entity'
+getEntityType = require './get_entity_type'
+properties = require './properties/properties_values_constraints'
+{ prefixifyWd, unprefixify } = require './prefix'
+whitelistedEntityTypes = [ 'work', 'serie', 'human' ]
+
+module.exports = (params)-> Promise.try -> createWdEntity params
+
+createWdEntity = (params)->
+  { labels, claims, user } = params
+  wdOauth.validate user
+  oauth = wdOauth.getFullCredentials user
+
+  _.log { labels, claims }, 'wd entity creation'
+
+  validateEntity { labels, claims }
+  .then validateWikidataCompliance
+  .then format
+  .then wdEdit({ oauth }, 'entity/create')
+  .then (res)->
+    { entity } = res
+    unless entity?
+      throw error_.new 'invalid wikidata-edit response', 500, { res }
+
+    entity.uri = prefixifyWd entity.id
+    return entity
+
+validateWikidataCompliance = (entity)->
+  { claims } = entity
+  unless claims? then throw error_.new 'invalid entity', 400, entity
+
+  entityType = getEntityType claims['wdt:P31']
+  unless entityType in whitelistedEntityTypes
+    throw error_.new 'invalid entity type', 400, { entityType, entity }
+
+  for property, values of claims
+    if properties[property].datatype is 'entity'
+      for value in values
+        if value.split(':')[0] is 'inv'
+          throw error_.new 'claim value is an inv uri', 400, { property, value }
+
+  return entity
+
+format = (entity)->
+  { claims } = entity
+  entity.claims = Object.keys(claims)
+    .reduce unprefixifyClaims(claims), {}
+  return entity
+
+unprefixifyClaims = (claims)-> (formattedClaims, property)->
+  unprefixifiedProp = unprefixify property
+  propertyValues = claims[property]
+
+  if properties[property].datatype is 'entity'
+    formattedClaims[unprefixifiedProp] = propertyValues.map unprefixify
+  else
+    # datatype 'string' should not be unprefixified, ex: 'Jules Vernes'
+    formattedClaims[unprefixifiedProp] = propertyValues
+  return formattedClaims

--- a/server/controllers/entities/lib/move_to_wikidata.coffee
+++ b/server/controllers/entities/lib/move_to_wikidata.coffee
@@ -5,65 +5,20 @@ entities_ = require './entities'
 promises_ = __.require 'lib', 'promises'
 getEntityType = require './get_entity_type'
 wdEdit = require 'wikidata-edit'
-{ wikidataOAuth } = require('config')
 mergeEntities = require './merge_entities'
-properties = require './properties/properties_values_constraints'
-{ prefixifyWd, unprefixify } = require './prefix'
-whitelistedEntityTypes = [ 'work', 'serie', 'human' ]
+{ unprefixify } = require './prefix'
+createWdEntity = require './create_wd_entity'
 
 module.exports = (user, invEntityUri)->
-  { oauth, _id: reqUserId } = user
-  userWikidataOAuth = user.oauth?.wikidata
-
-  unless userWikidataOAuth?
-    throw error_.reject 'missing wikidata oauth tokens', 400
-
-  oauth = _.extend userWikidataOAuth, wikidataOAuth
+  { _id: reqUserId } = user
 
   entityId = unprefixify invEntityUri
 
   entities_.byId entityId
-  .then validateWikidataCompliance
-  .then format
-  .then wdEdit({ oauth }, 'entity/create')
-  .then (res)->
-    unless res.entity?
-      throw error_.new 'invalid wikidata-edit response', 500, { invEntityUri, res }
-
-    wdEntityUri = prefixifyWd res.entity.id
-
+  .then (entity)->
+    { labels, claims } = entity
+    createWdEntity { labels, claims, user }
+  .then (createdEntity)->
+    { uri: wdEntityUri } = createdEntity
     mergeEntities reqUserId, invEntityUri, wdEntityUri
     .then -> { uri: wdEntityUri }
-
-validateWikidataCompliance = (entity)->
-  { claims } = entity
-  unless claims? then throw error_.new 'invalid entity', 400, entity
-
-  entityType = getEntityType claims['wdt:P31']
-  unless entityType in whitelistedEntityTypes
-    throw error_.new 'invalid entity type', 400, { entityType, entity }
-
-  for property, values of claims
-    if properties[property].datatype is 'entity'
-      for value in values
-        if value.split(':')[0] is 'inv'
-          throw error_.new 'claim value is an inv uri', 400, { property, value }
-
-  return entity
-
-format = (entity)->
-  { claims } = entity
-  entity.claims = Object.keys(claims)
-    .reduce unprefixifyClaims(claims), {}
-  return entity
-
-unprefixifyClaims = (claims)-> (formattedClaims, property)->
-  unprefixifiedProp = unprefixify property
-  propertyValues = claims[property]
-
-  if properties[property].datatype is 'entity'
-    formattedClaims[unprefixifiedProp] = propertyValues.map unprefixify
-  else
-    # datatype 'string' should not be unprefixified, ex: 'Jules Vernes'
-    formattedClaims[unprefixifiedProp] = propertyValues
-  return formattedClaims

--- a/server/controllers/entities/lib/scaffold_entity_from_seed/edition.coffee
+++ b/server/controllers/entities/lib/scaffold_entity_from_seed/edition.coffee
@@ -10,7 +10,7 @@ _ = __.require 'builders', 'utils'
 error_ = __.require 'lib', 'error/error'
 { parse:parseIsbn } = __.require 'lib', 'isbn/isbn'
 properties = require '../properties/properties_values_constraints'
-createEntity = require '../create_entity'
+createInvEntity = require '../create_inv_entity'
 # It is simpler to use a consistent, recognizable mocked user id
 # than to put exceptions everywhere
 seedUserId = __.require('couch', 'hard_coded_documents').users.seed._id
@@ -74,7 +74,7 @@ createEditionEntity = (seed, workPromise)->
   .then (work)->
     workUri = work.uri or "inv:#{work._id}"
     claims['wdt:P629'] = [ workUri ]
-    return createEntity labels, claims, seedUserId
+    return createInvEntity { labels, claims, userId: seedUserId }
   .then _.Log('created edition entity')
   .catch _.ErrorRethrow('createEditionEntity err')
 

--- a/server/controllers/entities/lib/scaffold_entity_from_seed/work.coffee
+++ b/server/controllers/entities/lib/scaffold_entity_from_seed/work.coffee
@@ -9,7 +9,7 @@ __ = CONFIG.universalPath
 _ = __.require 'builders', 'utils'
 promises_ = __.require 'lib', 'promises'
 error_ = __.require 'lib', 'error/error'
-createEntity = require '../create_entity'
+createInvEntity = require '../create_inv_entity'
 # It is simpler to use a consistent, recognizable mocked user id
 # than to put exceptions everywhere
 seedUserId = __.require('couch', 'hard_coded_documents').users.seed._id
@@ -75,7 +75,7 @@ createAuthorEntity = (authorName, lang)->
   claims =
     'wdt:P31': [ 'wd:Q5' ]
 
-  createEntity labels, claims, seedUserId
+  createInvEntity { labels, claims, userId: seedUserId }
   .then _.Log('created author entity')
   .catch _.ErrorRethrow('createAuthorEntity err')
 
@@ -86,6 +86,6 @@ createWorkEntity = (title, lang, authorsUris)->
     'wdt:P31': [ 'wd:Q571' ]
     'wdt:P50': authorsUris
 
-  return createEntity labels, claims, seedUserId
+  return createInvEntity { labels, claims, userId: seedUserId }
   .then _.Log('created work entity')
   .catch _.ErrorRethrow('createWorkEntity err')

--- a/server/controllers/entities/lib/update_wd_label.coffee
+++ b/server/controllers/entities/lib/update_wd_label.coffee
@@ -4,16 +4,14 @@ _ = __.require 'builders', 'utils'
 error_ = __.require 'lib', 'error/error'
 wdk = require 'wikidata-sdk'
 wdEdit = require 'wikidata-edit'
-{ wikidataOAuth } = CONFIG
+wdOauth = require './wikidata_oauth'
 
-module.exports = (user, id, lang, value)->
-  { oauth } = user
-  userWikidataOAuth = user.oauth?.wikidata
-  unless userWikidataOAuth?
-    return error_.reject 'missing wikidata oauth tokens', 400
+module.exports = (args...)-> Promise.try -> updateWdLabel args...
 
-  unless wdk.isItemId id then return error_.rejectInvalid 'id', id
+updateWdLabel = (user, id, lang, value)->
+  unless wdk.isItemId id then throw error_.newInvalid 'id', id
 
-  oauth = _.extend userWikidataOAuth, wikidataOAuth
+  wdOauth.validate user
+  oauth = wdOauth.getFullCredentials user
 
   return wdEdit({ oauth }, 'label/set')(id, lang, value)

--- a/server/controllers/entities/lib/validate_entity.coffee
+++ b/server/controllers/entities/lib/validate_entity.coffee
@@ -1,24 +1,19 @@
 __ = require('config').universalPath
 _ = __.require 'builders', 'utils'
 error_ = __.require 'lib', 'error/error'
-assert_ = __.require 'utils', 'assert_types'
 entities_ = require './entities'
 { Lang } = __.require 'lib', 'regex'
 promises_ = __.require 'lib', 'promises'
-{ Track } = __.require 'lib', 'track'
 getEntityType = require './get_entity_type'
 validateClaimProperty = require './validate_claim_property'
 typesWithoutLabels = require './types_without_labels'
 
-module.exports = (labels, claims, userId)->
-  assert_.types ['object', 'object', 'string'], arguments
-  _.log arguments, 'entity to create'
-
+module.exports = (entity)->
+  { labels, claims } = entity
   promises_.try -> validateValueType claims['wdt:P31']
   .tap (type)-> validateLabels labels, claims, type
   .then (type)-> validateClaims claims, type
-  .then entities_.create
-  .then entities_.edit.bind(null, userId, labels, claims)
+  .then -> entity
 
 validateValueType = (wdtP31)->
   unless _.isNonEmptyArray wdtP31

--- a/server/controllers/entities/lib/wikidata_oauth.coffee
+++ b/server/controllers/entities/lib/wikidata_oauth.coffee
@@ -1,0 +1,13 @@
+CONFIG = require('config')
+__ = CONFIG.universalPath
+_ = __.require 'builders', 'utils'
+error_ = __.require 'lib', 'error/error'
+{ wikidataOAuth } = CONFIG
+
+module.exports =
+  validate: (user)->
+    userWikidataOAuth = user.oauth?.wikidata
+    unless userWikidataOAuth?
+      throw error_.new 'missing wikidata oauth tokens', 400
+
+  getFullCredentials: (user)-> _.extend {}, wikidataOAuth, user.oauth.wikidata

--- a/server/lib/error/pre_filled.coffee
+++ b/server/lib/error/pre_filled.coffee
@@ -22,8 +22,10 @@ module.exports = (error_)->
     # A standardized way to return a 400 invalid parameter
     newInvalid: (parameter, value)->
       assert_.string parameter
-      context = { parameter, value }
-      err = error_.new "invalid #{parameter}: #{value}", 400, context
+      type = _.typeOf value
+      context = { parameter, value, type }
+      valueStr = if typeof value is 'object' then JSON.stringify(value) else value
+      err = error_.new "invalid #{parameter}: #{valueStr}", 400, context
       err.error_type = 'invalid_parameter'
       err.error_name = "invalid_#{parameter}"
       return err

--- a/server/lib/sanitize/parameters.coffee
+++ b/server/lib/sanitize/parameters.coffee
@@ -123,6 +123,7 @@ module.exports =
   password:
     secret: true
     validate: validations.user.password
+  prefix: whitelistedString
   range: _.extend {}, positiveInteger,
     default: 50
     max: 500

--- a/server/lib/sanitize/parameters.coffee
+++ b/server/lib/sanitize/parameters.coffee
@@ -99,6 +99,8 @@ generics =
       if _.isString value then _.parseBooleanString value, config.default
       else value
     validate: (value)-> _.typeOf(value) is 'boolean'
+  object:
+    validate: (value)-> _.typeOf(value) is 'object'
 
 module.exports =
   authors: arrayOfStrings

--- a/server/lib/sanitize/sanitize.coffee
+++ b/server/lib/sanitize/sanitize.coffee
@@ -70,8 +70,8 @@ format = (input, name, formatFn, config)->
   if formatFn? then input[name] = formatFn input[name], name, config
 
 applyDefaultValue = (input, name, config, parameter)->
-  if config.default? then input[name] = config.default
-  else if parameter.default? then input[name] = parameter.default
+  if config.default? then input[name] = _.cloneDeep config.default
+  else if parameter.default? then input[name] = _.cloneDeep  parameter.default
 
 obfuscateSecret = (parameter, err)->
   if parameter.secret then err.context.value = _.obfuscate err.context.value

--- a/server/lib/sanitize/sanitize.coffee
+++ b/server/lib/sanitize/sanitize.coffee
@@ -30,9 +30,12 @@ sanitizeParameter = (input, name, config, place, res)->
   parameter = if generic? then generics[generic] else parameters[name]
 
   unless parameter?
-    addWarning res, "unexpected config parameter: #{name}"
-    delete input[name]
-    return
+    if generic?
+      throw error_.new 'invalid generic name', 500, { generic }
+    else
+      addWarning res, "unexpected config parameter: #{name}"
+      delete input[name]
+      return
 
   unless input[name]? then applyDefaultValue input, name, config, parameter
   unless input[name]?

--- a/tests/api/entities/create.test.coffee
+++ b/tests/api/entities/create.test.coffee
@@ -66,10 +66,10 @@ describe 'entities:create', ->
   it 'should reject invalid labels object', (done)->
     authReq 'post', '/api/entities?action=create',
       # Invalid labels type: array instead of object
-      labels: [ { fr: humanName() } ]
-      claims: { 'wdt:P31': [ 'wd:Q571' ] }
+      labels: []
+      claims: {}
     .catch (err)->
-      err.body.status_verbose.should.equal 'labels should be an object'
+      err.body.status_verbose.should.equal 'invalid labels: []'
       err.statusCode.should.equal 400
       done()
     .catch undesiredErr(done)
@@ -78,10 +78,10 @@ describe 'entities:create', ->
 
   it 'should reject invalid claims type: array instead of object', (done)->
     authReq 'post', '/api/entities?action=create',
-      labels: { fr: humanName() }
-      claims: [ { 'wdt:P31': [ 'wd:Q571' ] } ]
+      labels: {}
+      claims: []
     .catch (err)->
-      err.body.status_verbose.should.equal 'claims should be an object'
+      err.body.status_verbose.should.equal 'invalid claims: []'
       err.statusCode.should.equal 400
       done()
     .catch undesiredErr(done)

--- a/tests/api/entities/create.test.coffee
+++ b/tests/api/entities/create.test.coffee
@@ -168,4 +168,18 @@ describe 'entities:create', ->
 
     return
 
+  it 'should reject invalid prefixes', (done)->
+    authReq 'post', '/api/entities?action=create',
+      prefix: 'foo'
+      labels: {}
+      claims: {}
+    .then undesiredRes(done)
+    .catch (err)->
+      err.body.status_verbose.should.startWith 'invalid prefix: foo'
+      err.statusCode.should.equal 400
+      done()
+    .catch undesiredErr(done)
+
+    return
+
   # See also: edititons/create.test.coffee

--- a/tests/unit/libs/046-sanitize.coffee
+++ b/tests/unit/libs/046-sanitize.coffee
@@ -117,6 +117,25 @@ describe 'sanitize', ->
 
       return
 
+    it 'should throw when passed an invalid generic name', (done)->
+      req = { query: {} }
+      res = {}
+
+      obj = {}
+
+      configs =
+        foo:
+          generic: 'bar'
+
+      sanitize req, res, configs
+      .then undesiredRes(done)
+      .catch (err)->
+        err.message.should.equal 'invalid generic name'
+        done()
+      .catch done
+
+      return
+
   describe 'strictly positive integer', ->
     it 'should accept string values', (done)->
       req = { query: { limit: '5' } }

--- a/tests/unit/libs/046-sanitize.coffee
+++ b/tests/unit/libs/046-sanitize.coffee
@@ -136,6 +136,26 @@ describe 'sanitize', ->
 
       return
 
+    it 'should clone default values', (done)->
+      req = { query: {} }
+      res = {}
+
+      obj = {}
+
+      configs =
+        foo:
+          generic: 'object'
+          default: obj
+
+      sanitize req, res, configs
+      .then (input)->
+        input.foo.should.deepEqual {}
+        input.foo.should.not.equal obj
+        done()
+      .catch done
+
+      return
+
   describe 'strictly positive integer', ->
     it 'should accept string values', (done)->
       req = { query: { limit: '5' } }
@@ -256,6 +276,23 @@ describe 'sanitize', ->
       .then undesiredRes(done)
       .catch (err)->
         err.message.should.equal 'invalid token length: expected 32, got 3'
+        done()
+      .catch done
+
+      return
+
+  describe 'objects', ->
+    it 'should stringify invalid values', (done)->
+      req = { query: { foo: [ 123 ] } }
+
+      configs =
+        foo:
+          generic: 'object'
+
+      sanitize req, {}, configs
+      .then undesiredRes(done)
+      .catch (err)->
+        err.message.should.equal 'invalid foo: [123]'
         done()
       .catch done
 


### PR DESCRIPTION
having the possibility to create a wikidata item from `/api/entities?action=create` would allow the client to create missing entities when editing Wikidata entities.

Currently, that would fail, as we can only create inv entities, and those can't be added as claim values on Wikidata:
![Sélection_011](https://user-images.githubusercontent.com/1596934/63061974-6c9def00-bef7-11e9-87d8-aa4af08bc026.png)

