### PR TITLE
entities: move_to_wikidata: fix case where moved entity has concurrent property claims

### DIFF
--- a/server/controllers/entities/lib/create_wd_entity.coffee
+++ b/server/controllers/entities/lib/create_wd_entity.coffee
@@ -18,7 +18,7 @@ createWdEntity = (params)->
   wdOauth.validate user
   oauth = wdOauth.getFullCredentials user
 
-  entity = { labels, claims }
+  entity = { labels, claims, isWdEntity: true }
 
   _.log entity, 'wd entity creation'
 

--- a/server/controllers/entities/lib/create_wd_entity.coffee
+++ b/server/controllers/entities/lib/create_wd_entity.coffee
@@ -14,15 +14,15 @@ whitelistedEntityTypes = [ 'work', 'serie', 'human' ]
 module.exports = (params)-> Promise.try -> createWdEntity params
 
 createWdEntity = (params)->
-  { labels, claims, user } = params
+  { labels, claims, user, isAlreadyValidated } = params
   wdOauth.validate user
   oauth = wdOauth.getFullCredentials user
 
-  entity = { labels, claims, isWdEntity: true }
+  entity = { labels, claims }
 
   _.log entity, 'wd entity creation'
 
-  validateEntity entity
+  validate entity, isAlreadyValidated
   .then ->
     validateWikidataCompliance entity
     return format entity
@@ -34,6 +34,10 @@ createWdEntity = (params)->
 
     entity.uri = prefixifyWd entity.id
     return entity
+
+validate = (entity, isAlreadyValidated)->
+  if isAlreadyValidated then Promise.resolve()
+  else validateEntity entity
 
 validateWikidataCompliance = (entity)->
   { claims } = entity

--- a/server/controllers/entities/lib/move_to_wikidata.coffee
+++ b/server/controllers/entities/lib/move_to_wikidata.coffee
@@ -13,7 +13,7 @@ module.exports = (user, invEntityUri)->
   entities_.byId entityId
   .then (entity)->
     { labels, claims } = entity
-    createWdEntity { labels, claims, user }
+    createWdEntity { labels, claims, user, isAlreadyValidated: true }
   .then (createdEntity)->
     { uri: wdEntityUri } = createdEntity
     mergeEntities reqUserId, invEntityUri, wdEntityUri

--- a/server/controllers/entities/lib/validate_claim_value.coffee
+++ b/server/controllers/entities/lib/validate_claim_value.coffee
@@ -20,7 +20,7 @@ module.exports = (params)->
   promises_.try -> validateClaimValue params
 
 validateClaimValue = (params)->
-  { type, currentClaims, property, oldVal, newVal, letEmptyValuePass, isWdEntity, userIsAdmin } = params
+  { type, currentClaims, property, oldVal, newVal, letEmptyValuePass, userIsAdmin } = params
   # letEmptyValuePass to let it be interpreted as a claim deletion
   if letEmptyValuePass and not newVal? then return null
 
@@ -45,12 +45,6 @@ validateClaimValue = (params)->
   formattedValue = if prop.format? then prop.format(newVal) else newVal
 
   { concurrency, restrictedType } = prop
-
-  # Disable concurrency checks for claims being made on Wikidata entities
-  # as the only current case is when we move an Inventaire entity to Wikidata
-  # in which case the concurrency check will fail as the property value
-  # is already used by the entity currently in Inventaire itself
-  if isWdEntity then concurrency = false
 
   # Resolve only if all async tests pass
   return promises_.all [

--- a/server/controllers/entities/lib/validate_claims.coffee
+++ b/server/controllers/entities/lib/validate_claims.coffee
@@ -27,7 +27,7 @@ validatePropertiesClaims = (params)->
   .map validatePropertyClaims(params)
 
 validatePropertyClaims = (params)-> (property)->
-  { newClaims, currentClaims, type, isWdEntity } = params
+  { newClaims, currentClaims, type } = params
   validateClaimProperty type, property
   values = newClaims[property]
 
@@ -43,8 +43,7 @@ validatePropertyClaims = (params)-> (property)->
       property,
       oldVal: null,
       newVal,
-      letEmptyValuePass: false,
-      isWdEntity
+      letEmptyValuePass: false
     }
 
 perTypeClaimsTests =

--- a/server/controllers/entities/lib/validate_claims.coffee
+++ b/server/controllers/entities/lib/validate_claims.coffee
@@ -9,7 +9,7 @@ validateClaimProperty = require './validate_claim_property'
 module.exports = (params)->
   { newClaims, currentClaims, creating } = params
   wdtP31 = currentClaims['wdt:P31'] or newClaims['wdt:P31']
-  type = getEntityType wdtP31
+  params.type = type = getEntityType wdtP31
 
   unless _.isNonEmptyPlainObject newClaims
     throw error_.new 'invalid claims', 400, { newClaims }
@@ -20,19 +20,22 @@ module.exports = (params)->
   typeTestFn = perTypeClaimsTests[type] or _.noop
   typeTestFn newClaims, creating
 
-  propertiesClaimsValidation = validatePropertiesClaims newClaims, currentClaims, type
-  promises_.all _.flatten(propertiesClaimsValidation)
+  promises_.all _.flatten(validatePropertiesClaims(params))
 
-validatePropertiesClaims = (newClaims, currentClaims, type)->
-  Object.keys newClaims
-  .map validatePropertyClaims(newClaims, currentClaims, type)
+validatePropertiesClaims = (params)->
+  Object.keys params.newClaims
+  .map validatePropertyClaims(params)
 
-validatePropertyClaims = (newClaims, currentClaims, type)-> (property)->
+validatePropertyClaims = (params)-> (property)->
+  { newClaims, currentClaims, type, isWdEntity } = params
   validateClaimProperty type, property
   values = newClaims[property]
+
   unless _.isArray values
     throw error_.new 'invalid property values', 400, { property, values }
+
   newClaims[property] = values = _.uniq values
+
   values.map (newVal)->
     validateClaim {
       type,
@@ -40,7 +43,8 @@ validatePropertyClaims = (newClaims, currentClaims, type)-> (property)->
       property,
       oldVal: null,
       newVal,
-      letEmptyValuePass: false
+      letEmptyValuePass: false,
+      isWdEntity
     }
 
 perTypeClaimsTests =

--- a/server/controllers/entities/lib/validate_entity.coffee
+++ b/server/controllers/entities/lib/validate_entity.coffee
@@ -14,14 +14,19 @@ module.exports = (entity)->
   .catch addErrorContext(entity)
 
 validate = (entity)->
-  { labels, claims } = entity
+  { labels, claims, isWdEntity } = entity
   assert_.object labels
   assert_.object claims
 
   type = getValueType claims
   validateValueType type, claims['wdt:P31']
   validateLabels labels, type
-  return validateClaims { newClaims: claims, currentClaims: {}, creating: true }
+  return validateClaims {
+    newClaims: claims,
+    currentClaims: {},
+    creating: true,
+    isWdEntity
+  }
 
 getValueType = (claims)->
   wdtP31 = claims['wdt:P31']

--- a/server/controllers/entities/lib/validate_entity.coffee
+++ b/server/controllers/entities/lib/validate_entity.coffee
@@ -14,7 +14,7 @@ module.exports = (entity)->
   .catch addErrorContext(entity)
 
 validate = (entity)->
-  { labels, claims, isWdEntity } = entity
+  { labels, claims } = entity
   assert_.object labels
   assert_.object claims
 
@@ -24,8 +24,7 @@ validate = (entity)->
   return validateClaims {
     newClaims: claims,
     currentClaims: {},
-    creating: true,
-    isWdEntity
+    creating: true
   }
 
 getValueType = (claims)->


### PR DESCRIPTION
those moves were rejected as the concurrency checks were finding the moved entity itself

This is for instance [preventing this entity to be moved to Wikidata](https://inventaire.io/entity/inv:60905d992c09c12f92b0a8a78ed0a41f/edit) has it has a [`wdt:P3035`](https://www.wikidata.org/entity/P3035) claim value already used by... itself, so concurrency tests fail at creating a new entity with that claim value. The patch is thus to pass a flag disabling the concurrency check when the validated entity is a (soon to be) Wikidata entity.