### PR TITLE
queries: harmonize work type detection

### DIFF
--- a/server/data/wikidata/queries/author_works.js
+++ b/server/data/wikidata/queries/author_works.js
@@ -2,6 +2,14 @@ module.exports = {
   parameters: [ 'qid' ],
   query: params => {
     const { qid: authorQid } = params
+
+    // P50    author
+    // P58    screenwriter
+    // P110   illustrator
+    // P6338  colorist
+
+    // Filter-out instances of edition (Q3331189)
+
     return `SELECT ?work ?type ?date ?serie WHERE {
   ?work wdt:P50|wdt:P58|wdt:P110|wdt:P6338 wd:${authorQid} .
   ?work wdt:P31 ?type .

--- a/server/data/wikidata/queries/editions_reverse_claims.js
+++ b/server/data/wikidata/queries/editions_reverse_claims.js
@@ -2,10 +2,20 @@ module.exports = {
   parameters: [ 'pid', 'qid' ],
   query: params => {
     const { pid, qid } = params
+    // Filter-out entities tagged as both work and edition (Q3331189)
+
+    // Work types:
+    // Q571       book
+    // Q47461344  written work
+    // Q7725634   literary work
+    // Q2831984   comic book album
+    // Q1004      comic
+    // Q1760610   comic book
+    // Q8274      manga
+
     return `SELECT DISTINCT ?item WHERE {
   ?item wdt:${pid} wd:${qid} .
   ?item wdt:P31 wd:Q3331189 .
-  # Filter-out entities tagged as both work and edition
   FILTER NOT EXISTS {
     VALUES (?work_type) { (wd:Q571) (wd:Q47461344) (wd:Q7725634) (wd:Q2831984) (wd:Q1004) (wd:Q1760610) (wd:Q8274) } .
     ?item wdt:P31 ?work_type

--- a/server/data/wikidata/queries/editions_reverse_claims.js
+++ b/server/data/wikidata/queries/editions_reverse_claims.js
@@ -7,8 +7,8 @@ module.exports = {
   ?item wdt:P31 wd:Q3331189 .
   # Filter-out entities tagged as both work and edition
   FILTER NOT EXISTS {
-    ?item wdt:P31 ?work_type
     VALUES (?work_type) { (wd:Q571) (wd:Q47461344) (wd:Q7725634) (wd:Q2831984) (wd:Q1004) (wd:Q1760610) (wd:Q8274) } .
+    ?item wdt:P31 ?work_type
   }
 }
 LIMIT 1000`

--- a/server/data/wikidata/queries/editions_reverse_claims.js
+++ b/server/data/wikidata/queries/editions_reverse_claims.js
@@ -6,8 +6,10 @@ module.exports = {
   ?item wdt:${pid} wd:${qid} .
   ?item wdt:P31 wd:Q3331189 .
   # Filter-out entities tagged as both work and edition
-  FILTER NOT EXISTS { ?item wdt:P31 wd:Q571 }
-  FILTER NOT EXISTS { ?item wdt:P31 wd:Q47461344 }
+  FILTER NOT EXISTS {
+    ?item wdt:P31 ?work_type
+    VALUES (?work_type) { (wd:Q571) (wd:Q47461344) (wd:Q7725634) (wd:Q2831984) (wd:Q1004) (wd:Q1760610) (wd:Q8274) } .
+  }
 }
 LIMIT 1000`
   }

--- a/server/data/wikidata/queries/humans_reverse_claims.js
+++ b/server/data/wikidata/queries/humans_reverse_claims.js
@@ -8,18 +8,8 @@ module.exports = {
 
   # Keep only humans that are known for at least one work
   ?work wdt:P50 ?item .
-  # book
-  { ?work wdt:P31 wd:Q571 . }
-  # written work
-  UNION { ?item wdt:P31 wd:Q47461344 . }
-  # literary work
-  UNION { ?work wdt:P31 wd:Q7725634 . }
-  # comic book album
-  UNION { ?work wdt:P31 wd:Q2831984 . }
-  # comic book
-  UNION { ?work wdt:P31 wd:Q1004 . }
-  # manga
-  UNION { ?work wdt:P31 wd:Q8274 . }
+  ?work wdt:P31 ?work_type .
+  VALUES (?work_type) { (wd:Q571) (wd:Q47461344) (wd:Q7725634) (wd:Q2831984) (wd:Q1004) (wd:Q1760610) (wd:Q8274) } .
 }
 LIMIT 1000`
   }

--- a/server/data/wikidata/queries/humans_reverse_claims.js
+++ b/server/data/wikidata/queries/humans_reverse_claims.js
@@ -8,8 +8,8 @@ module.exports = {
 
   # Keep only humans that are known for at least one work
   ?work wdt:P50 ?item .
-  ?work wdt:P31 ?work_type .
   VALUES (?work_type) { (wd:Q571) (wd:Q47461344) (wd:Q7725634) (wd:Q2831984) (wd:Q1004) (wd:Q1760610) (wd:Q8274) } .
+  ?work wdt:P31 ?work_type .
 }
 LIMIT 1000`
   }

--- a/server/data/wikidata/queries/humans_reverse_claims.js
+++ b/server/data/wikidata/queries/humans_reverse_claims.js
@@ -2,11 +2,20 @@ module.exports = {
   parameters: [ 'pid', 'qid' ],
   query: params => {
     const { pid, qid } = params
+    // Keep only humans that are known for at least one work
+
+    // Work types:
+    // Q571       book
+    // Q47461344  written work
+    // Q7725634   literary work
+    // Q2831984   comic book album
+    // Q1004      comic
+    // Q1760610   comic book
+    // Q8274      manga
+
     return `SELECT DISTINCT ?item WHERE {
   ?item wdt:${pid} wd:${qid} .
   ?item wdt:P31 wd:Q5 .
-
-  # Keep only humans that are known for at least one work
   ?work wdt:P50 ?item .
   VALUES (?work_type) { (wd:Q571) (wd:Q47461344) (wd:Q7725634) (wd:Q2831984) (wd:Q1004) (wd:Q1760610) (wd:Q8274) } .
   ?work wdt:P31 ?work_type .

--- a/server/data/wikidata/queries/serie_parts.js
+++ b/server/data/wikidata/queries/serie_parts.js
@@ -18,7 +18,7 @@ module.exports = {
     ?part wdt:P31 wd:Q3331189
     # but recover parts that are also instances of work
     FILTER NOT EXISTS {
-      VALUES (?work_type) { (wd:Q571) (wd:Q47461344) (wd:Q2831984) (wd:Q1760610) (wd:Q8274) (wd:Q1760610) (wd:Q8274) } .
+      VALUES (?work_type) { (wd:Q571) (wd:Q47461344) (wd:Q7725634) (wd:Q2831984) (wd:Q1004) (wd:Q1760610) (wd:Q8274) } .
       ?part wdt:P31 ?work_type .
     }
   }

--- a/server/data/wikidata/queries/serie_parts.js
+++ b/server/data/wikidata/queries/serie_parts.js
@@ -18,7 +18,7 @@ module.exports = {
     ?part wdt:P31 wd:Q3331189
     # but recover parts that are also instances of work
     FILTER NOT EXISTS {
-      VALUES (?work_type) { (wd:Q571) (wd:Q47461344) (wd:Q2831984) (wd:Q1760610) (wd:Q8274) } .
+      VALUES (?work_type) { (wd:Q571) (wd:Q47461344) (wd:Q2831984) (wd:Q1760610) (wd:Q8274) (wd:Q1760610) (wd:Q8274) } .
       ?part wdt:P31 ?work_type .
     }
   }

--- a/server/data/wikidata/queries/serie_parts.js
+++ b/server/data/wikidata/queries/serie_parts.js
@@ -2,21 +2,30 @@ module.exports = {
   parameters: [ 'qid' ],
   query: params => {
     const { qid: serieQid } = params
+    // Reject circular series/parts relations
+    // Reject parts that have an associated work (duck-typing editions)
+    // Reject parts that are instance of editions (Q3331189)
+    // but recover parts that are also instances of work
+
+    // Work types:
+    // Q571       book
+    // Q47461344  written work
+    // Q7725634   literary work
+    // Q2831984   comic book album
+    // Q1004      comic
+    // Q1760610   comic book
+    // Q8274      manga
 
     return `SELECT ?part ?date ?ordinal (COUNT(?subpart) AS ?subparts) ?superpart WHERE {
   ?part p:P179|p:P361 ?serie_statement .
   ?serie_statement ps:P179|ps:P361 wd:${serieQid} .
 
-  # Reject circular series/parts relations
   FILTER NOT EXISTS { wd:${serieQid} wdt:P179|wdt:P361 ?part }
 
-  # Reject parts that have an associated work (duck-typing editions)
   FILTER NOT EXISTS { ?part wdt:P629 ?work }
 
-  # Reject parts that are instance of editions
   FILTER NOT EXISTS {
     ?part wdt:P31 wd:Q3331189
-    # but recover parts that are also instances of work
     FILTER NOT EXISTS {
       VALUES (?work_type) { (wd:Q571) (wd:Q47461344) (wd:Q7725634) (wd:Q2831984) (wd:Q1004) (wd:Q1760610) (wd:Q8274) } .
       ?part wdt:P31 ?work_type .

--- a/server/data/wikidata/queries/works_reverse_claims.js
+++ b/server/data/wikidata/queries/works_reverse_claims.js
@@ -2,6 +2,16 @@ module.exports = {
   parameters: [ 'pid', 'qid' ],
   query: params => {
     const { pid, qid } = params
+
+    // Work types:
+    // Q571       book
+    // Q47461344  written work
+    // Q7725634   literary work
+    // Q2831984   comic book album
+    // Q1004      comic
+    // Q1760610   comic book
+    // Q8274      manga
+
     return `SELECT DISTINCT ?item WHERE {
   ?item wdt:${pid} wd:${qid} .
   VALUES (?work_type) { (wd:Q571) (wd:Q47461344) (wd:Q7725634) (wd:Q2831984) (wd:Q1004) (wd:Q1760610) (wd:Q8274) } .

--- a/server/data/wikidata/queries/works_reverse_claims.js
+++ b/server/data/wikidata/queries/works_reverse_claims.js
@@ -4,28 +4,8 @@ module.exports = {
     const { pid, qid } = params
     return `SELECT DISTINCT ?item WHERE {
   ?item wdt:${pid} wd:${qid} .
-  # book
-  { ?item wdt:P31 wd:Q571 . }
-  # written work
-  UNION { ?item wdt:P31 wd:Q47461344 . }
-  # literary work
-  UNION { ?item wdt:P31 wd:Q7725634 . }
-  # comic book album
-  UNION { ?item wdt:P31 wd:Q2831984 . }
-  # comic book
-  UNION { ?item wdt:P31 wd:Q1004 . }
-  # manga
-  UNION { ?item wdt:P31 wd:Q8274 . }
-  # book series
-  UNION { ?item wdt:P31 wd:Q277759 . }
-  # comic book series
-  UNION { ?item wdt:P31 wd:Q14406742 . }
-  # manga series
-  UNION { ?item wdt:P31 wd:Q21198342 . }
-  # novel series
-  UNION { ?item wdt:P31 wd:Q1667921 . }
-  # Filter-out entities tagged as both work and edition
-  FILTER NOT EXISTS { ?item wdt:P31 wd:Q3331189 }
+  ?item wdt:P31 ?work_type .
+  VALUES (?work_type) { (wd:Q571) (wd:Q47461344) (wd:Q7725634) (wd:Q2831984) (wd:Q1004) (wd:Q1760610) (wd:Q8274) } .
 }
 LIMIT 1000`
   }

--- a/server/data/wikidata/queries/works_reverse_claims.js
+++ b/server/data/wikidata/queries/works_reverse_claims.js
@@ -4,8 +4,8 @@ module.exports = {
     const { pid, qid } = params
     return `SELECT DISTINCT ?item WHERE {
   ?item wdt:${pid} wd:${qid} .
-  ?item wdt:P31 ?work_type .
   VALUES (?work_type) { (wd:Q571) (wd:Q47461344) (wd:Q7725634) (wd:Q2831984) (wd:Q1004) (wd:Q1760610) (wd:Q8274) } .
+  ?item wdt:P31 ?work_type .
 }
 LIMIT 1000`
   }


### PR DESCRIPTION
hypothesis of this PR: using `VALUES` allows to more easily see the pattern than making those lenghtly `UNION`s