### PR TITLE
[WIP] Constrain editions without isbn

### DIFF
--- a/tests/api/entities/create_editions.test.coffee
+++ b/tests/api/entities/create_editions.test.coffee
@@ -2,8 +2,8 @@ CONFIG = require 'config'
 __ = CONFIG.universalPath
 _ = __.require 'builders', 'utils'
 should = require 'should'
-{ nonAuthReq, authReq, undesiredErr, undesiredRes } = require '../../utils/utils'
-{ createWork, createSerie, randomLabel } = require '../../fixtures/entities'
+{ nonAuthReq, authReq, undesiredErr, undesiredRes } = require '../utils/utils'
+{ createWork, createSerie, randomLabel } = require '../fixtures/entities'
 workEntityPromise = createWork()
 
 describe 'entities:editions:create', ->

--- a/tests/api/entities/create_publishers.test.coffee
+++ b/tests/api/entities/create_publishers.test.coffee
@@ -22,7 +22,7 @@ describe 'entities:publishers:create', ->
       editionUri = "inv:#{edition._id}"
       createPublisher()
       .then (publisher)->
-        oldVal = null
+        oldVal = edition.claims['wdt:P123'][0]
         newVal = "inv:#{publisher._id}"
         property = 'wdt:P123'
         updateClaim(editionUri, property, oldVal, newVal)

--- a/tests/api/entities/create_publishers.test.coffee
+++ b/tests/api/entities/create_publishers.test.coffee
@@ -2,12 +2,12 @@ CONFIG = require 'config'
 __ = CONFIG.universalPath
 _ = __.require 'builders', 'utils'
 should = require 'should'
-{ createEdition, createPublisher } = require '../../fixtures/entities'
-{ updateClaim } = require '../../utils/entities'
-{ undesiredErr } = require '../../utils/utils'
+{ randomLabel, createEdition, createPublisher } = require '../fixtures/entities'
+{ updateClaim } = require '../utils/entities'
+{ authReq, undesiredErr } = require '../utils/utils'
 
 describe 'entities:publishers:create', ->
-  it 'should create a local publisher entity', (done)->
+  it 'should create an inventaire publisher entity', (done)->
     createPublisher()
     .then (publisherDoc) ->
       publisherDoc.type.should.equal 'publisher'
@@ -16,7 +16,7 @@ describe 'entities:publishers:create', ->
 
     return
 
-  it 'should update an edition claim with a local publisher entity', (done)->
+  it 'should update an edition claim with an inventaire publisher entity', (done)->
     createEdition()
     .then (edition)->
       editionUri = "inv:#{edition._id}"
@@ -25,7 +25,7 @@ describe 'entities:publishers:create', ->
         oldVal = null
         newVal = "inv:#{publisher._id}"
         property = 'wdt:P123'
-        updateClaim editionUri, property, oldVal, newVal
+        updateClaim(editionUri, property, oldVal, newVal)
         .then (res)-> done()
     .catch undesiredErr(done)
 

--- a/tests/api/entities/update_editions_labels.test.coffee
+++ b/tests/api/entities/update_editions_labels.test.coffee
@@ -2,9 +2,9 @@ CONFIG = require 'config'
 __ = CONFIG.universalPath
 _ = __.require 'builders', 'utils'
 should = require 'should'
-{ undesiredRes, undesiredErr } = require '../../utils/utils'
-{ updateLabel } = require '../../utils/entities'
-{ createEdition, randomLabel } = require '../../fixtures/entities'
+{ undesiredRes, undesiredErr } = require '../utils/utils'
+{ updateLabel } = require '../utils/entities'
+{ createEdition, randomLabel } = require '../fixtures/entities'
 
 describe 'entities:editions:update-labels', ->
   it 'should reject labels update', (done)->

--- a/tests/api/fixtures/entities.coffee
+++ b/tests/api/fixtures/entities.coffee
@@ -61,6 +61,8 @@ module.exports = API =
           'wdt:P1476': [ _.values(works[0].labels)[0] ]
           'wdt:P1680': [ randomWords() ]
           'wdt:P407': [ 'wd:' + wdLang.byCode[lang].wd ]
+          'wdt:P123': [ 'wd:Q3213930' ]
+          'wdt:P577': [ '2019' ]
           'invp:P2': [ someImageHash ]
 
   createEditionFromWorks: (works...)->

--- a/tests/api/utils/entities.coffee
+++ b/tests/api/utils/entities.coffee
@@ -45,6 +45,9 @@ module.exports = entitiesUtils =
   addClaim: (uri, property, value)-> entitiesUtils.updateClaim uri, property, null, value
   removeClaim: (uri, property, value)-> entitiesUtils.updateClaim uri, property, value, null
 
+  removeClaim: (uri, property, value)->
+    entitiesUtils.updateClaim uri, property, value, null
+
   getRefreshedPopularityByUris: (uris)->
     if _.isArray(uris) then uris = uris.join('|')
     nonAuthReq 'get', "/api/entities?action=popularity&uris=#{uris}&refresh=true"


### PR DESCRIPTION
Editions without publisher and publication date are unmergeable has we can't know for sure which edition a user meant. Now that publishers can be created locally, adding this kind of restriction should be possible without too much disruption for the users