### PR TITLE
Restrict checked entities types

### DIFF
--- a/server/controllers/tasks/lib/check_entity.coffee
+++ b/server/controllers/tasks/lib/check_entity.coffee
@@ -8,14 +8,21 @@ tasks_ = require './tasks'
 getNewTasks = require './get_new_tasks'
 error_ = __.require 'lib', 'error/error'
 updateRelationScore = require './relation_score'
+supportedTypes = [ 'human' ]
 
 module.exports = (uri)->
+  if uri.split(':')[0] isnt 'inv'
+    return error_.reject 'invalid uri domain', 400, { uri }
+
   getEntityByUri { uri }
   .then (entity)->
     unless entity? then throw error_.notFound { uri }
 
     if entity.uri.split(':')[0] is 'wd'
       throw error_.new 'entity is already a redirection', 400, { uri }
+
+    if entity.type not in supportedTypes
+      throw error_.new "unsupported type: #{entity.type}", 400, { uri, supportedTypes }
 
     getExistingTasks uri
     .then getNewTasks(entity)


### PR DESCRIPTION
the logic behind the endpoint is coupled to humans entry points.
    
This doesn't mean that this endpoint shouldn't support other types in the future, just that it currently doesn't do it well and should thus refuse to do it and return informative feedback to the requester.