### PR TITLE
More permissive resolver

### DIFF
--- a/server/controllers/entities/lib/resolver/resolve_on_labels.coffee
+++ b/server/controllers/entities/lib/resolver/resolve_on_labels.coffee
@@ -24,7 +24,7 @@ searchAuthorAndResolve = (works)-> (author)->
 
 # TODO: extend search to aliases
 searchUrisByAuthorLabels = (labels)->
-  labels = getLabels(labels)
+  labels = getLabels labels
   Promise.all labels.map(searchUrisByAuthorLabel)
   .then _.flatten
   .then _.uniq
@@ -50,6 +50,7 @@ getWorkAndResolve = (authorSeed, authorsUris)-> (work)->
   .then resolveWorkAndAuthor(authorsUris, authorSeed, work, workLabels)
 
 resolveWorkAndAuthor = (authorsUris, authorSeed, workSeed, workLabels)-> (searchedWorks)->
+  lowerSeedLabels = workLabels.map _.toLower
   # Several searchedWorks could match authors homonyms/duplicates
   unless searchedWorks.length is 1 then return
   searchedWork = searchedWorks[0]
@@ -57,7 +58,8 @@ resolveWorkAndAuthor = (authorsUris, authorSeed, workSeed, workLabels)-> (search
   # If unique author to avoid assigning a work to a duplicated author
   unless matchedAuthorsUris.length is 1 then return
   searchedWorkLabels = getLabels searchedWork.labels
-  matchedWorkLabels = _.intersection workLabels, searchedWorkLabels
+  lowerSearchedWorkLabels = searchedWorkLabels.map _.toLower
+  matchedWorkLabels = _.intersection lowerSeedLabels, lowerSearchedWorkLabels
   if matchedWorkLabels.length is 0 then return
 
   authorSeed.uri = matchedAuthorsUris[0]

--- a/server/controllers/entities/lib/resolver/resolve_on_labels.coffee
+++ b/server/controllers/entities/lib/resolver/resolve_on_labels.coffee
@@ -6,9 +6,9 @@ getWorksFromAuthorsUris = require './get_works_from_authors_uris'
 typeSearch = __.require 'controllers', 'search/lib/type_search'
 parseResults = __.require 'controllers', 'search/lib/parse_results'
 
-# If some works and authors have not been resolved yet,
-# resolve if seeds labels match entities labels
-# and if no other entities are in the search result (only one entity found)
+# resolve :
+# - if seeds labels match entities labels
+# - if no other entities are in the search result (only one entity found)
 
 module.exports = (entry)->
   { authors, works } = entry
@@ -22,36 +22,9 @@ searchAuthorAndResolve = (works)-> (author)->
   searchUrisByAuthorLabels author.labels
   .then resolveWorksAndAuthor(works, author)
 
-resolveWorksAndAuthor = (works, author)-> (authorsUris)->
-  Promise.all works.map(resolveWorkAndAuthor(author, authorsUris))
-
-resolveWorkAndAuthor = (author, authorsUris)-> (work)->
-  if work.uri? or not work? then return
-  workLabels = _.uniq _.values(work.labels)
-  Promise.all getWorksFromAuthorsUris(authorsUris)
-  .then _.flatten
-  .then getMatchedUris(authorsUris, author, work)
-
-getMatchedUris = (authorsUris, authorSeed, workSeed)-> (searchedWorks)->
-  # Several searchedWorks could match authors homonyms/duplicates
-  unless searchedWorks.length is 1 then return
-  searchedWork = searchedWorks[0]
-  matchedAuthorsUris = _.intersection getAuthorsUris(searchedWork), authorsUris
-  # If unique author to avoid assigning a work to a duplicated author
-  unless matchedAuthorsUris.length is 1 then return
-  searchedWorkLabels = getLabels searchedWork.labels
-  matchedWorkLabels = _.intersection workLabels, searchedWorkLabels
-  if matchedWorkLabels.length is 0 then return
-
-  authorSeed.uri = matchedAuthorsUris[0]
-  workSeed.uri = searchedWork.uri
-
-getAuthorsUris = (work)-> work.claims['wdt:P50']
-
-# Check every author labels, in every lang
 # TODO: extend search to aliases
 searchUrisByAuthorLabels = (labels)->
-  labels = _.uniq _.values(labels)
+  labels = getLabels(labels)
   Promise.all labels.map(searchUrisByAuthorLabel)
   .then _.flatten
   .then _.uniq
@@ -65,3 +38,31 @@ searchUrisByAuthorLabel = (label)->
   .filter (hit)-> label in _.values(hit._source.labels)
   .map (hit)-> hit._source.uri
   .then _.compact
+
+resolveWorksAndAuthor = (works, author)-> (authorsUris)->
+  Promise.all works.map(getWorkAndResolve(author, authorsUris))
+
+getWorkAndResolve = (authorSeed, authorsUris)-> (work)->
+  if work.uri? or not work? then return
+  workLabels = getLabels work.labels
+  Promise.all getWorksFromAuthorsUris(authorsUris)
+  .then _.flatten
+  .then resolveWorkAndAuthor(authorsUris, authorSeed, work, workLabels)
+
+resolveWorkAndAuthor = (authorsUris, authorSeed, workSeed, workLabels)-> (searchedWorks)->
+  # Several searchedWorks could match authors homonyms/duplicates
+  unless searchedWorks.length is 1 then return
+  searchedWork = searchedWorks[0]
+  matchedAuthorsUris = _.intersection getAuthorsUris(searchedWork), authorsUris
+  # If unique author to avoid assigning a work to a duplicated author
+  unless matchedAuthorsUris.length is 1 then return
+  searchedWorkLabels = getLabels searchedWork.labels
+  matchedWorkLabels = _.intersection workLabels, searchedWorkLabels
+  if matchedWorkLabels.length is 0 then return
+
+  authorSeed.uri = matchedAuthorsUris[0]
+  workSeed.uri = searchedWork.uri
+
+getLabels = (labels)-> _.uniq _.values labels
+
+getAuthorsUris = (work)-> work.claims['wdt:P50']

--- a/server/controllers/entities/lib/resolver/resolve_on_labels.coffee
+++ b/server/controllers/entities/lib/resolver/resolve_on_labels.coffee
@@ -28,20 +28,23 @@ resolveWorksAndAuthor = (works, author)-> (authorsUris)->
 resolveWorkAndAuthor = (author, authorsUris)-> (work)->
   if work.uri? or not work? then return
   workLabels = _.uniq _.values(work.labels)
-  Promise.all getWorksFromAuthorsUris(authorsUris, workLabels)
+  Promise.all getWorksFromAuthorsUris(authorsUris)
   .then _.flatten
   .then getMatchedUris(authorsUris, author, work)
 
 getMatchedUris = (authorsUris, authorSeed, workSeed)-> (searchedWorks)->
   # Several searchedWorks could match authors homonyms/duplicates
   unless searchedWorks.length is 1 then return
-  work = searchedWorks[0]
-  matchedAuthorsUris = _.intersection getAuthorsUris(work), authorsUris
+  searchedWork = searchedWorks[0]
+  matchedAuthorsUris = _.intersection getAuthorsUris(searchedWork), authorsUris
   # If unique author to avoid assigning a work to a duplicated author
   unless matchedAuthorsUris.length is 1 then return
+  searchedWorkLabels = getLabels searchedWork.labels
+  matchedWorkLabels = _.intersection workLabels, searchedWorkLabels
+  if matchedWorkLabels.length is 0 then return
 
   authorSeed.uri = matchedAuthorsUris[0]
-  workSeed.uri = work.uri
+  workSeed.uri = searchedWork.uri
 
 getAuthorsUris = (work)-> work.claims['wdt:P50']
 
@@ -54,6 +57,7 @@ searchUrisByAuthorLabels = (labels)->
   .then _.uniq
 
 types = [ 'humans' ]
+
 searchUrisByAuthorLabel = (label)->
   typeSearch types, label
   .then parseResults(types)

--- a/tests/api/entities/resolver/resolve.test.coffee
+++ b/tests/api/entities/resolver/resolve.test.coffee
@@ -384,13 +384,31 @@ describe 'entities:resolve:in-context', ->
     return
 
 describe 'entities:resolve:on-labels', ->
+  it 'should not resolve work pair if no labels match', (done)->
+    createHuman()
+    .then (author)->
+      workLabel = randomLabel()
+      seedLabel = randomLabel()
+      authorLabel = author.labels.en
+      createWorkWithAuthor author, workLabel
+      .delay elasticsearchUpdateDelay
+      .then (work)->
+        resolve basicEntry(seedLabel, authorLabel)
+        .get 'entries'
+        .then (entries)->
+          should(entries[0].works[0].uri).not.be.ok()
+          done()
+    .catch done
+
+    return
+
   it 'should resolve author and work pair by searching for exact labels', (done)->
     createHuman()
     .then (author)->
       workLabel = randomLabel()
       authorLabel = author.labels.en
       createWorkWithAuthor author, workLabel
-      .delay elasticsearchUpdateDelay # update elasticSearch
+      .delay elasticsearchUpdateDelay
       .then (work)->
         resolve basicEntry(workLabel, authorLabel)
         .get 'entries'
@@ -412,7 +430,7 @@ describe 'entities:resolve:on-labels', ->
           createWorkWithAuthor author, workLabel
           createWorkWithAuthor sameLabelAuthor, workLabel
         ]
-        .delay elasticsearchUpdateDelay # update elasticSearch
+        .delay elasticsearchUpdateDelay
         .then (works)->
           resolve basicEntry(workLabel, author.labels.en)
           .get 'entries'

--- a/tests/api/entities/resolver/resolve.test.coffee
+++ b/tests/api/entities/resolver/resolve.test.coffee
@@ -420,6 +420,25 @@ describe 'entities:resolve:on-labels', ->
 
     return
 
+  it 'should resolve work pair with case insentive labels', (done)->
+    createHuman()
+    .then (author)->
+      workLabel = randomLabel()
+      seedLabel = workLabel.toUpperCase()
+      authorLabel = author.labels.en
+      createWorkWithAuthor author, workLabel
+      .delay elasticsearchUpdateDelay
+      .then (work)->
+        resolve basicEntry(seedLabel, authorLabel)
+        .get 'entries'
+        .then (entries)->
+          entries[0].works[0].uri.should.equal work.uri
+          entries[0].authors[0].uri.should.equal author.uri
+          done()
+    .catch done
+
+    return
+
   it 'should not resolve when several works exist', (done)->
     createHuman()
     .then (author)->


### PR DESCRIPTION
More permissive resolver, by resolving work labels that match even if case is different. (`case-insensitive-work-resolver` could have been the other name of this branch.)
And on the way to get there a bug was found and fixed : before, every works resolved on labels no matter if the label matched or not. Every work resolved on every work...