### PR TITLE
update node to v12 (latest LTS)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -288,6 +288,12 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
+    },
     "async-each": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
@@ -651,6 +657,12 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
+      "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg==",
       "dev": true
     },
     "buildmail": {
@@ -1127,22 +1139,21 @@
       }
     },
     "couch2elastic4sync": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/couch2elastic4sync/-/couch2elastic4sync-7.0.0.tgz",
-      "integrity": "sha512-jfQh2GX5VJjfxEkQh7KHAWjddfQrUel6TZQY5sCajpbWB9HLTQxI7cjY8xhIUkudealv8QyeVCq3MGBl9Xavhg==",
+      "version": "git+https://github.com/inventaire/couch2elastic4sync.git#74b2819cf5f7195a166d665f8dd20a2b36b936fe",
+      "from": "git+https://github.com/inventaire/couch2elastic4sync.git#74b2819",
       "dev": true,
       "requires": {
         "async": "^1.5.2",
         "bunyan": "^1.5.1",
         "follow": "^0.12.1",
-        "hyperquest": "^1.2.0",
+        "hyperquest": "^2.1.3",
         "jsonfilter": "^1.1.2",
-        "jsonist": "^1.3.0",
+        "jsonist": "^3.0.1",
         "lodash": "^4.2.0",
         "md5": "^2.0.0",
         "mkdirp": "^0.5.1",
         "ndjson": "^1.4.2",
-        "ndjson-to-elasticsearch": "^1.0.0",
+        "ndjson-to-elasticsearch": "git+https://github.com/inventaire/ndjson-to-elasticsearch.git#19e1ba7",
         "rc": "^1.1.2",
         "recover-couch-doc": "^1.0.0",
         "request": "^2.69.0",
@@ -1160,12 +1171,6 @@
           "version": "0.1.5",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
           "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
-          "dev": true
-        },
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
         "aws-sign2": {
@@ -1281,12 +1286,6 @@
             "assert-plus": "^0.1.5",
             "ctype": "0.5.3"
           }
-        },
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-          "dev": true
         },
         "mime-db": {
           "version": "1.12.0",
@@ -1445,6 +1444,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true
     },
     "deep-is": {
@@ -1639,22 +1644,13 @@
       "dev": true
     },
     "dtrace-provider": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.7.tgz",
-      "integrity": "sha1-3JObTT4GIM/gwc2APQ0tftBP/QQ=",
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.8.tgz",
+      "integrity": "sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==",
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.10.0"
-      },
-      "dependencies": {
-        "nan": {
-          "version": "2.11.1",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-          "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
-          "dev": true,
-          "optional": true
-        }
+        "nan": "^2.14.0"
       }
     },
     "duplexer": {
@@ -3755,7 +3751,7 @@
     },
     "hawk": {
       "version": "2.3.1",
-      "resolved": "http://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
       "integrity": "sha1-HnMc45RH+h0PbXB/e87r7A/R7B8=",
       "dev": true,
       "requires": {
@@ -3851,11 +3847,12 @@
       }
     },
     "hyperquest": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/hyperquest/-/hyperquest-1.3.0.tgz",
-      "integrity": "sha1-59WYAwo/wCKbYXJXg7ZBssbxeCo=",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/hyperquest/-/hyperquest-2.1.3.tgz",
+      "integrity": "sha512-fUuDOrB47PqNK/BAMOS13v41UoaqIxqSLHX6CAbOD7OfT+/GCWO1/vPLfTNutOeXrv1ikuaZ3yux+33Z9vh+rw==",
       "dev": true,
       "requires": {
+        "buffer-from": "^0.1.1",
         "duplexer2": "~0.0.2",
         "through2": "~0.6.3"
       },
@@ -3948,9 +3945,9 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
     "inquirer": {
@@ -4079,6 +4076,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+    },
+    "ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+      "dev": true
     },
     "ipaddr.js": {
       "version": "1.6.0",
@@ -4463,84 +4466,49 @@
       }
     },
     "jsonist": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/jsonist/-/jsonist-1.3.0.tgz",
-      "integrity": "sha1-wMdLle8clSA4YZsp76UgscyYdVY=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jsonist/-/jsonist-3.0.1.tgz",
+      "integrity": "sha512-+lrAqdk5BO36j5RG7MSY2M8XqBqBwJRt/+iSfLmpelBBsi0kFflqhtlROeioDA5MlHNhZxm0Doslr7QSRzCqTQ==",
       "dev": true,
       "requires": {
-        "bl": "~1.0.0",
-        "hyperquest": "~1.2.0",
-        "json-stringify-safe": "~5.0.0",
-        "xtend": "~4.0.0"
+        "bl": "~4.0.0",
+        "hyperquest": "~2.1.3",
+        "json-stringify-safe": "~5.0.1"
       },
       "dependencies": {
         "bl": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
-          "integrity": "sha1-/FQhoo/UImA2w7OJGmaiW8ZNIm4=",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.0.tgz",
+          "integrity": "sha512-QwQvAZZA1Bw1FWnhNj2X5lu+sPxxB2ITH3mqEqYyahN6JZR13ONjk+XiTnBaGEzMPUrAgOkaD68pBH1rvPRPsw==",
           "dev": true,
           "requires": {
-            "readable-stream": "~2.0.5"
-          }
-        },
-        "hyperquest": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/hyperquest/-/hyperquest-1.2.0.tgz",
-          "integrity": "sha1-OeH+9miI3Hzg3sbA3YFPb8iUStU=",
-          "dev": true,
-          "requires": {
-            "duplexer2": "~0.0.2",
-            "through2": "~0.6.3"
+            "readable-stream": "^3.4.0"
           }
         },
         "readable-stream": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
           "dev": true
         },
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
           "dev": true,
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-              "dev": true
-            },
-            "readable-stream": {
-              "version": "1.0.34",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
-                "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
-              }
-            }
+            "safe-buffer": "~5.2.0"
           }
         }
       }
@@ -5832,6 +5800,13 @@
       "resolved": "http://registry.npmjs.org/n3/-/n3-0.11.3.tgz",
       "integrity": "sha512-Hk5GSXBeAZrYoqi+NeS/U0H47Hx0Lzj7K6nLWCZpC9E04iUwEwBcrlMb/5foAli7QF4newPNQQQGgM6IAxTxGg=="
     },
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+      "dev": true,
+      "optional": true
+    },
     "nano": {
       "version": "6.4.4",
       "resolved": "https://registry.npmjs.org/nano/-/nano-6.4.4.tgz",
@@ -5942,13 +5917,12 @@
       }
     },
     "ndjson-to-elasticsearch": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/ndjson-to-elasticsearch/-/ndjson-to-elasticsearch-1.0.3.tgz",
-      "integrity": "sha1-rbkTYQsYiT73RqKAwOC5WL1+pz8=",
+      "version": "git+https://github.com/inventaire/ndjson-to-elasticsearch.git#19e1ba7af0c1660089898a35d13eb4dce65a4471",
+      "from": "git+https://github.com/inventaire/ndjson-to-elasticsearch.git#19e1ba7",
       "dev": true,
       "requires": {
         "async": "^2.0.0-rc.1",
-        "jsonist": "^1.3.0",
+        "jsonist": "^3.0.1",
         "lodash.template": "^4.2.0",
         "ndjson": "^1.3.0",
         "rc": "^1.0.3",
@@ -5957,19 +5931,13 @@
       },
       "dependencies": {
         "async": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
           "dev": true,
           "requires": {
-            "lodash": "^4.17.10"
+            "lodash": "^4.17.14"
           }
-        },
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-          "dev": true
         }
       }
     },
@@ -6604,9 +6572,9 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
-      "version": "1.1.27",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.27.tgz",
-      "integrity": "sha512-J8tJX5tAeEp9tQTI2w2aMZ6V1INuU4JmNaNPRuHAqjjVq3ZJ+jV3+tcT3ncgTnBxvwJy740IB/WZrxFus2VdMA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
+      "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ==",
       "dev": true
     },
     "pull-core": {
@@ -6686,12 +6654,6 @@
         "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
-        "deep-extend": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-          "dev": true
-        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -7947,14 +7909,14 @@
       },
       "dependencies": {
         "process-nextick-args": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
           "dev": true
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -8032,13 +7994,22 @@
       "integrity": "sha1-0Xrqcv8vujm55DYBvns/9y4ImFI="
     },
     "tough-cookie": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+      "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
       "dev": true,
       "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
+        "ip-regex": "^2.1.0",
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
+        }
       }
     },
     "traverse": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "xml2js": "^0.4.13"
   },
   "devDependencies": {
-    "couch2elastic4sync": "^7.0.0",
+    "couch2elastic4sync": "git+https://github.com/inventaire/couch2elastic4sync.git#74b2819",
     "couchdb-backup": "^1.0.0",
     "diff": "^2.2.1",
     "doctoc": "^1.2.0",


### PR DESCRIPTION
Now that level-party got updated (#349), there wasn't much blocking us from updating to the latest Node LTS.

The only (minor) issue, was those `TimeoutOverflowWarning` warnings, due to old versions of `hyperquest` (see https://github.com/substack/hyperquest/issues/62) being depended on by `couch2elastic4sync` at various degrees. Using a custom version of `couch2elastic4sync` allows to depend on updated packages, until there is an official release with updated dependencies.

The `engine` in `package.json` being advisory, this PR is mostly a call to other contributors to udpate their version of Node and `rm -rf node_modules && npm install` (and be amazed at how faster it goes :D), and to be coordinated with:
- [`inventaire-client`](https://github.com/inventaire/inventaire-client/pull/190)
- [`docker-inventaire`](https://github.com/inventaire/docker-inventaire/pull/8)
- [`inventaire-deploy`](https://github.com/inventaire/inventaire-deploy/pull/4)