### PR TITLE
follow: prevent crash when CouchDB isn't yet available

### DIFF
--- a/server/db/couch/init.js
+++ b/server/db/couch/init.js
@@ -21,7 +21,7 @@ for (const dbName in dbsList) {
 
 const designDocFolder = __.path('couchdb', 'design_docs')
 
-module.exports = () => {
+const init = () => {
   return couchInit(dbBaseUrl, formattedList, designDocFolder)
   .tap(initHardCodedDocuments)
   .tap(initDesignDocSync)
@@ -34,4 +34,12 @@ module.exports = () => {
     console.error(err.message, context)
     return process.exit(1)
   })
+}
+
+let waitForCouchInit
+
+module.exports = () => {
+  // Return the same promises to all consumers
+  waitForCouchInit = waitForCouchInit || init()
+  return waitForCouchInit
 }

--- a/server/server.js
+++ b/server/server.js
@@ -10,13 +10,13 @@ const _ = __.require('builders', 'utils')
 __.require('lib', 'startup/before')()
 
 // Starting to make CouchDB initialization checks
-const couchInit = __.require('couch', 'init')()
+const waitForCouchInit = __.require('couch', 'init')
 // Meanwhile, start setting up the server.
 // Startup time is mostly due to the time needed to require
 // all files from controllers, middlewares, libs, etc
 const initExpress = require('./init_express')
 
-couchInit
+waitForCouchInit()
 .then(_.Log('couch init'))
 .then(initExpress)
 .tap(() => console.timeEnd('startup'))


### PR DESCRIPTION
In this age of Docker containers, it now happens that a service is started and not another: making every code depending on it wait for CouchDB to be available, instead of assuming it is, allows to gracefully recover from a situation where the server was started before CouchDB.
