### PR TITLE
truncate geographic positions

### DIFF
--- a/server/controllers/entities/reverse_claims.js
+++ b/server/controllers/entities/reverse_claims.js
@@ -6,7 +6,7 @@ const sanitize = __.require('lib', 'sanitize/sanitize')
 
 const sanitization = {
   property: {},
-  value: {},
+  value: { type: 'string' },
   refresh: {
     optional: true
   },

--- a/server/controllers/entities/update_label.js
+++ b/server/controllers/entities/update_label.js
@@ -8,21 +8,23 @@ const sanitization = {
   uri: { optional: true },
   id: { optional: true },
   lang: {},
-  value: {}
+  value: { type: 'string' }
 }
 
 module.exports = (req, res) => {
   sanitize(req, res, sanitization)
   .then(params => {
     let { uri, id, value, lang } = params
+
     const prefix = getPrefix(uri, id)
     const updater = updaters[prefix]
 
-    if (uri) { id = unprefixify(uri) }
+    if (uri) id = unprefixify(uri)
 
     if (updater == null) {
       return error_.bundle(req, res, `unsupported uri prefix: ${prefix}`, 400, uri)
     }
+
     return updater(req.user, id, lang, value)
     .then(responses_.Ok(res))
   })

--- a/server/controllers/groups/lib/update_settings.js
+++ b/server/controllers/groups/lib/update_settings.js
@@ -1,7 +1,7 @@
 const CONFIG = require('config')
 const __ = CONFIG.universalPath
 const _ = __.require('builders', 'utils')
-const { attributes, validations } = __.require('models', 'group')
+const { attributes, validations, formatters } = __.require('models', 'group')
 const { updatable } = attributes
 const promises_ = __.require('lib', 'promises')
 const error_ = __.require('lib', 'error/error')
@@ -10,7 +10,8 @@ const db = __.require('couch', 'base')('groups')
 const { add: addSlug } = require('./slug')
 
 module.exports = (data, userId) => {
-  const { group: groupId, attribute, value } = data
+  const { group: groupId, attribute } = data
+  let { value } = data
 
   if (!updatable.includes(attribute)) {
     throw error_.new(`${attribute} can't be updated`, 400, data)
@@ -19,6 +20,8 @@ module.exports = (data, userId) => {
   if (!validations[attribute](value)) {
     throw error_.newInvalid(attribute, value)
   }
+
+  if (formatters[attribute]) value = formatters[attribute](value)
 
   return db.get(groupId)
   .then(groupDoc => {

--- a/server/controllers/items/bulk_update.js
+++ b/server/controllers/items/bulk_update.js
@@ -7,7 +7,7 @@ const responses_ = __.require('lib', 'responses')
 const sanitization = {
   ids: {},
   attribute: {},
-  value: {}
+  value: { type: 'string' }
 }
 
 module.exports = (req, res) => {

--- a/server/controllers/user/update.js
+++ b/server/controllers/user/update.js
@@ -1,6 +1,6 @@
 const __ = require('config').universalPath
 const _ = __.require('builders', 'utils')
-const { attributes, validations } = __.require('models', 'user')
+const { attributes, validations, formatters } = __.require('models', 'user')
 const { updatable, concurrencial, acceptNullValue } = attributes
 const updateEmail = __.require('controllers', 'user/lib/update_email')
 const db = __.require('couch', 'base')('users')
@@ -12,13 +12,14 @@ const { Track } = __.require('lib', 'track')
 
 module.exports = (req, res) => {
   const { user, body } = req
-  const { attribute, value } = body
+  const { attribute } = body
+  let { value } = body
 
   if (!_.isNonEmptyString(attribute)) {
     return error_.bundleMissingBody(req, res, 'attribute')
   }
 
-  if ((!acceptNullValue.includes(attribute)) && ((value == null))) {
+  if (value == null && !acceptNullValue.includes(attribute)) {
     return error_.bundleMissingBody(req, res, 'value')
   }
 
@@ -38,6 +39,8 @@ module.exports = (req, res) => {
       return error_.bundleInvalid(req, res, 'attribute', attribute)
     }
   }
+
+  if (formatters[attribute]) value = formatters[attribute](value)
 
   if (updatable.includes(rootAttribute)) {
     if (!_.get(validations, rootAttribute)(value)) {

--- a/server/lib/geo.js
+++ b/server/lib/geo.js
@@ -41,5 +41,5 @@ const R = 6378137
 const d2r = Math.PI / 180
 
 // Coordinates are in decimal degrees
-// There is no need to keep more than 4 decimals, cf https://xkcd.com/2170/
-const truncateDecimals = degree => Math.round(degree * 10000) / 10000
+// There is no need to keep more than 5 decimals, cf https://xkcd.com/2170/
+const truncateDecimals = degree => Math.round(degree * 100000) / 100000

--- a/server/lib/geo.js
+++ b/server/lib/geo.js
@@ -15,9 +15,7 @@ module.exports = {
     }
   },
 
-  // Coordinates are in decimal degrees
-  // There is no need to keep more than 4 decimals, cf https://xkcd.com/2170/
-  truncateDecimals: degree => Math.round(degree * 10000) / 10000
+  truncateLatLng: latLng => latLng != null ? latLng.map(truncateDecimals) : null
 }
 
 // Distance between LatLng
@@ -41,3 +39,7 @@ const distanceBetween = (latLngA, latLngB) => {
 const R = 6378137
 // DEG_TO_RAD
 const d2r = Math.PI / 180
+
+// Coordinates are in decimal degrees
+// There is no need to keep more than 4 decimals, cf https://xkcd.com/2170/
+const truncateDecimals = degree => Math.round(degree * 10000) / 10000

--- a/server/lib/geo.js
+++ b/server/lib/geo.js
@@ -13,7 +13,11 @@ module.exports = {
     } else {
       return Math.trunc(meters / 100) / 10
     }
-  }
+  },
+
+  // Coordinates are in decimal degrees
+  // There is no need to keep more than 4 decimals, cf https://xkcd.com/2170/
+  truncateDecimals: degree => Math.round(degree * 10000) / 10000
 }
 
 // Distance between LatLng

--- a/server/lib/sanitize/parameters.js
+++ b/server/lib/sanitize/parameters.js
@@ -224,8 +224,18 @@ module.exports = {
   usernames,
   relatives: whitelistedStrings,
   value: {
-    // Endpoints accepting a 'value' have to do their own validation
+    // Endpoints accepting a 'value' can specify a type
+    // or have to do their own validation
     // as a value can be anything, including null
-    validate: () => true
+    validate: (value, name, config) => {
+      const { type: expectedType } = config
+      if (expectedType) {
+        const valueType = _.typeOf(value)
+        if (valueType !== expectedType) {
+          throw error_.new(`invalid value type: ${valueType} (expected ${expectedType})`, 400, { value })
+        }
+      }
+      return true
+    }
   }
 }

--- a/server/lib/sanitize/parameters.js
+++ b/server/lib/sanitize/parameters.js
@@ -223,5 +223,9 @@ module.exports = {
   username: { validate: validations.common.username },
   usernames,
   relatives: whitelistedStrings,
-  value: nonEmptyString
+  value: {
+    // Endpoints accepting a 'value' have to do their own validation
+    // as a value can be anything, including null
+    validate: () => true
+  }
 }

--- a/server/lib/sanitize/parameters.js
+++ b/server/lib/sanitize/parameters.js
@@ -4,6 +4,7 @@ const _ = __.require('builders', 'utils')
 const host = CONFIG.fullPublicHost()
 const error_ = __.require('lib', 'error/error')
 const isbn_ = __.require('lib', 'isbn/isbn')
+const { truncateLatLng } = __.require('lib', 'geo')
 
 // Parameters attributes:
 // - format (optional)
@@ -194,7 +195,10 @@ module.exports = {
     secret: true,
     validate: validations.user.password
   },
-  position: arrayOfNumbers,
+  position: {
+    format: truncateLatLng,
+    validate: arrayOfNumbers.validate
+  },
   prefix: whitelistedString,
   property: { validate: _.isPropertyUri },
   refresh: generics.boolean,

--- a/server/models/group.js
+++ b/server/models/group.js
@@ -2,6 +2,7 @@ const CONFIG = require('config')
 const __ = CONFIG.universalPath
 const _ = __.require('builders', 'utils')
 const error_ = __.require('lib', 'error/error')
+const { truncateLatLng } = __.require('lib', 'geo')
 
 const Group = module.exports = {}
 
@@ -141,3 +142,7 @@ Group.categories = {
 }
 
 Group.attributes = require('./attributes/group')
+
+Group.formatters = {
+  position: truncateLatLng
+}

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -8,6 +8,7 @@ const gravatar = __.require('lib', 'gravatar')
 const error_ = __.require('lib', 'error/error')
 const randomString = __.require('lib', 'utils/random_string')
 const generateReadToken = randomString.bind(null, 32)
+const { truncateDecimals } = __.require('lib', 'geo')
 
 const User = module.exports = {}
 
@@ -144,4 +145,8 @@ User.updateItemsCounts = itemsCounts => user => {
   assert_.object(itemsCounts.public)
   Object.assign(user.snapshot, itemsCounts)
   return user
+}
+
+User.formatters = {
+  position: latLng => latLng != null ? latLng.map(truncateDecimals) : null
 }

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -8,7 +8,7 @@ const gravatar = __.require('lib', 'gravatar')
 const error_ = __.require('lib', 'error/error')
 const randomString = __.require('lib', 'utils/random_string')
 const generateReadToken = randomString.bind(null, 32)
-const { truncateDecimals } = __.require('lib', 'geo')
+const { truncateLatLng } = __.require('lib', 'geo')
 
 const User = module.exports = {}
 
@@ -148,5 +148,5 @@ User.updateItemsCounts = itemsCounts => user => {
 }
 
 User.formatters = {
-  position: latLng => latLng != null ? latLng.map(truncateDecimals) : null
+  position: truncateLatLng
 }

--- a/tests/api/groups/create.test.js
+++ b/tests/api/groups/create.test.js
@@ -62,6 +62,13 @@ describe('groups:create', () => {
     .catch(done)
   })
 
+  it('should truncate position parameter', async () => {
+    const name = groupName()
+    const position = [ 1.123456789, 1.123456789 ]
+    const res = await authReq('post', endpoint, { name, position })
+    res.position.should.deepEqual([ 1.1235, 1.1235 ])
+  })
+
   it('should reject a group with an empty name or generated slug', done => {
     const name = '??'
     authReq('post', endpoint, { name })

--- a/tests/api/groups/update_settings.test.js
+++ b/tests/api/groups/update_settings.test.js
@@ -85,4 +85,15 @@ describe('groups:update-settings', () => {
     })
     .catch(done)
   })
+
+  it('should update position', async () => {
+    const { _id: groupId } = await groupPromise
+    await authReq('put', endpoint, {
+      group: groupId,
+      attribute: 'position',
+      value: [ 0.123456789, 0.123456789 ]
+    })
+    const { group } = await nonAuthReq('get', `/api/groups?action=by-id&id=${groupId}`)
+    group.position.should.deepEqual([ 0.1235, 0.1235 ])
+  })
 })

--- a/tests/api/groups/update_settings.test.js
+++ b/tests/api/groups/update_settings.test.js
@@ -96,4 +96,16 @@ describe('groups:update-settings', () => {
     const { group } = await nonAuthReq('get', `/api/groups?action=by-id&id=${groupId}`)
     group.position.should.deepEqual([ 0.1235, 0.1235 ])
   })
+
+  it('should update searchable parameter', async () => {
+    const { _id: groupId, searchable } = await groupPromise
+    searchable.should.be.true()
+    await authReq('put', endpoint, {
+      group: groupId,
+      attribute: 'searchable',
+      value: false
+    })
+    const { group } = await nonAuthReq('get', `/api/groups?action=by-id&id=${groupId}`)
+    group.searchable.should.be.false()
+  })
 })

--- a/tests/api/user/update.test.js
+++ b/tests/api/user/update.test.js
@@ -1,17 +1,18 @@
 const __ = require('config').universalPath
 const _ = __.require('builders', 'utils')
 const should = require('should')
-const { authReq, authReqB, getUser } = require('../utils/utils')
+const { customAuthReq, authReq, getReservedUser } = require('../utils/utils')
 const { getRefreshedUser } = require('../fixtures/users')
 const endpoint = '/api/user'
 const randomString = __.require('lib', 'utils/random_string')
 
 describe('user:update', () => {
   it('should update a user', async () => {
+    const user = await getReservedUser()
     const attribute = 'username'
     const value = randomString(6)
-    await authReq('put', endpoint, { attribute, value })
-    const updatedUser = await getRefreshedUser(getUser())
+    await customAuthReq(user, 'put', endpoint, { attribute, value })
+    const updatedUser = await getRefreshedUser(user)
     updatedUser[attribute].should.equal(value)
   })
 
@@ -20,21 +21,35 @@ describe('user:update', () => {
     const value = [ 10, 10 ]
 
     it('should update the position', async () => {
-      await authReq('put', endpoint, { attribute, value })
-      const updatedUser = await getRefreshedUser(getUser())
+      const user = await getReservedUser()
+      await customAuthReq(user, 'put', endpoint, { attribute, value })
+      const updatedUser = await getRefreshedUser(user)
       updatedUser[attribute].should.deepEqual(value)
-      await authReq('put', endpoint, { attribute, value: null })
-      const reupdatedUser = await getRefreshedUser(getUser())
-      console.log('reupdatedUser', reupdatedUser)
+    })
+
+    it('should truncate the coordinates', async () => {
+      const user = await getReservedUser()
+      await customAuthReq(user, 'put', endpoint, { attribute, value: [ 10.123456, 10.123456 ] })
+      const updatedUser = await getRefreshedUser(user)
+      updatedUser[attribute].should.deepEqual([ 10.1235, 10.1235 ])
+    })
+
+    it('should allow to delete the position by passing null', async () => {
+      const user = await getReservedUser()
+      await customAuthReq(user, 'put', endpoint, { attribute, value })
+      const updatedUser = await getRefreshedUser(user)
+      updatedUser[attribute].should.deepEqual(value)
+      await customAuthReq(user, 'put', endpoint, { attribute, value: null })
+      const reupdatedUser = await getRefreshedUser(user)
       should(reupdatedUser[attribute]).not.be.ok()
     })
 
     it('should update the position index', async () => {
-      await authReq('put', endpoint, { attribute, value })
-      const user = await getUser()
+      const user = await getReservedUser()
+      await customAuthReq(user, 'put', endpoint, { attribute, value })
       const foundUsersIds = await getUserIdsByPosition(value)
       foundUsersIds.should.containEql(user._id)
-      await authReq('put', endpoint, { attribute, value: null })
+      await customAuthReq(user, 'put', endpoint, { attribute, value: null })
       const foundUsersIdsAfterDeletedPosition = await getUserIdsByPosition(value)
       foundUsersIdsAfterDeletedPosition.should.not.containEql(user._id)
     })
@@ -45,6 +60,6 @@ const getUserIdsByPosition = async position => {
   const [ lat, lng ] = position
   const bbox = [ lng - 0.1, lat - 0.1, lng + 0.1, lat + 0.1 ]
   const url = `/api/users?action=search-by-position&bbox=${JSON.stringify(bbox)}`
-  const { users } = await authReqB('get', url)
+  const { users } = await authReq('get', url)
   return _.map(users, '_id')
 }


### PR DESCRIPTION
it seems that as of this day, we are guilty of keeping position coordinates at the atomic level
cf https://xkcd.com/2170/

for context (and as I wasn't sure myself), we are dealing with decimal degrees, as [that's what browsers give us](https://developer.mozilla.org/en-US/docs/Web/API/GeolocationCoordinates)

while that's not exactly a bug, relying on such precise coordinates just adds noise

but this PR also fixes a bug: it's currently impossible to update a group position, any group update returns a 400, see de4f527 and 8a043f45