### PR TITLE
rss redirections

### DIFF
--- a/server/controllers/extensions_redirections.js
+++ b/server/controllers/extensions_redirections.js
@@ -1,0 +1,72 @@
+const __ = require('config').universalPath
+const _ = __.require('builders', 'utils')
+const error_ = __.require('lib', 'error/error')
+const user_ = __.require('controllers', 'user/lib/user')
+const groups_ = __.require('controllers', 'groups/lib/groups')
+
+const extensionRedirect = extension => (req, res) => {
+  const { domain, id } = parseUrl(req, extension)
+  const redirectionFn = redirections[extension][domain]
+
+  if (redirectionFn == null) {
+    error_.bundleInvalid(req, res, 'domain', domain)
+  } else {
+    // redirectionFn might return a promise
+    // thus using Promise.resolve allows to normalize the returned value
+    Promise.resolve(redirectionFn(id))
+    .then(url => res.redirect(url))
+    .catch(_.Error('rssRedirection error'))
+  }
+}
+
+module.exports = {
+  json: extensionRedirect('json'),
+  rss: extensionRedirect('rss')
+}
+
+const extensionPatterns = {
+  json: /\.json$/,
+  rss: /\.rss$/
+}
+
+const parseUrl = (req, extension) => {
+  const { pathname } = req._parsedUrl
+  let [ domain, id ] = pathname.split('/').slice(1)
+  if (id) id = id.replace(extensionPatterns[extension], '')
+  return { domain, id }
+}
+
+const redirections = {
+  json: {
+    entity: uri => `/api/entities?action=by-uris&uris=${uri}`,
+    inventory: username => `/api/users?action=by-usernames&usernames=${username}`,
+    users: id => `/api/users?action=by-ids&ids=${id}`,
+    groups: id => {
+      if (_.isGroupId(id)) {
+        return `/api/groups?action=by-id&id=${id}`
+      } else {
+        return `/api/groups?action=by-slug&slug=${id}`
+      }
+    },
+    items: id => `/api/items?action=by-ids&ids=${id}`
+    // transactions: id =>
+  },
+
+  rss: {
+    users: id => `/api/feeds?user=${id}`,
+    inventory: username => {
+      return user_.findOneByUsername(username)
+      .get('_id')
+      .then(userId => `/api/feeds?user=${userId}`)
+    },
+    groups: id => {
+      if (_.isGroupId(id)) {
+        return `/api/feeds?group=${id}`
+      } else {
+        const slug = id
+        return groups_.bySlug(slug)
+        .then(({ _id }) => `/api/feeds?group=${_id}`)
+      }
+    }
+  }
+}

--- a/server/controllers/feeds/lib/get_item_description.js
+++ b/server/controllers/feeds/lib/get_item_description.js
@@ -33,9 +33,9 @@ module.exports = (item, user, lang) => {
     </a>
   </td>
   <td>
-    <a href="${item.href}" title="${title}" style="color: white; text-decoration: none; background-color: ${transacColor}; text-align: center; padding: 16px; height: 64px;" >${transacLabel}</a>
+    <a href="${item.href}" title="${title}" style="color: white; text-decoration: none; background-color: ${transacColor}; text-align: center; padding: 16px; display: block;" >${transacLabel}</a>
   </td>
 </tr></table>
 ${detailsHtml}
-<small>item:${item._id} - ${item.entity}<small>`
+<small>item:${item._id} - ${item.entity}</small>`
 }

--- a/server/controllers/glob.js
+++ b/server/controllers/glob.js
@@ -1,9 +1,6 @@
 const __ = require('config').universalPath
-const _ = __.require('builders', 'utils')
 const error_ = __.require('lib', 'error/error')
 const publicFolder = __.path('client', 'public')
-const user_ = __.require('controllers', 'user/lib/user')
-const groups_ = __.require('controllers', 'groups/lib/groups')
 
 module.exports = {
   get: (req, res) => {
@@ -22,36 +19,6 @@ module.exports = {
     }
   },
 
-  jsonRedirection: (req, res) => {
-    const { pathname } = req._parsedUrl
-    let [ domain, id ] = pathname.split('/').slice(1)
-    id = id && id.replace(/\.json$/, '')
-    const redirectionFn = jsonRedirections[domain]
-
-    if (redirectionFn == null) {
-      error_.bundleInvalid(req, res, 'domain', domain)
-    } else {
-      res.redirect(redirectionFn(id))
-    }
-  },
-
-  rssRedirection: (req, res) => {
-    const { pathname } = req._parsedUrl
-    let [ domain, id ] = pathname.split('/').slice(1)
-    id = id && id.replace(/\.rss$/, '')
-    const redirectionFn = rssRedirections[domain]
-
-    if (redirectionFn == null) {
-      error_.bundleInvalid(req, res, 'domain', domain)
-    } else {
-      // redirectionFn might return a promise
-      // thus using Promise.resolve allows to normalize the returned value
-      Promise.resolve(redirectionFn(id))
-      .then(url => res.redirect(url))
-      .catch(_.Error('rssRedirection error'))
-    }
-  },
-
   redirectToApiDoc: (req, res) => res.redirect('https://api.inventaire.io'),
 
   api: (req, res) => {
@@ -63,36 +30,3 @@ module.exports = {
 }
 
 const imageHeader = req => /^image/.test(req.headers.accept)
-
-const jsonRedirections = {
-  entity: uri => `/api/entities?action=by-uris&uris=${uri}`,
-  inventory: username => `/api/users?action=by-usernames&usernames=${username}`,
-  users: id => `/api/users?action=by-ids&ids=${id}`,
-  groups: id => {
-    if (_.isGroupId(id)) {
-      return `/api/groups?action=by-id&id=${id}`
-    } else {
-      return `/api/groups?action=by-slug&slug=${id}`
-    }
-  },
-  items: id => `/api/items?action=by-ids&ids=${id}`
-  // transactions: id =>
-}
-
-const rssRedirections = {
-  users: id => `/api/feeds?user=${id}`,
-  inventory: username => {
-    return user_.findOneByUsername(username)
-    .get('_id')
-    .then(userId => `/api/feeds?user=${userId}`)
-  },
-  groups: id => {
-    if (_.isGroupId(id)) {
-      return `/api/feeds?group=${id}`
-    } else {
-      const slug = id
-      return groups_.bySlug(slug)
-      .then(({ _id }) => `/api/feeds?group=${_id}`)
-    }
-  }
-}

--- a/server/controllers/routes.js
+++ b/server/controllers/routes.js
@@ -53,6 +53,9 @@ Object.assign(routes, {
   '*.json': {
     get: glob.jsonRedirection
   },
+  '*.rss': {
+    get: glob.rssRedirection
+  },
   '*': {
     get: glob.get
   }

--- a/server/controllers/routes.js
+++ b/server/controllers/routes.js
@@ -1,5 +1,6 @@
 const CONFIG = require('config')
 const endpoint = require('./endpoint')
+const extensionsRedirections = require('./extensions_redirections')
 const glob = require('./glob')
 
 // Routes structure:
@@ -51,13 +52,12 @@ Object.assign(routes, {
     all: glob.api
   },
   '*.json': {
-    get: glob.jsonRedirection
+    get: extensionsRedirections.json
   },
   '*.rss': {
-    get: glob.rssRedirection
+    get: extensionsRedirections.rss
   },
   '*': {
     get: glob.get
   }
-}
-)
+})

--- a/tests/api/redirections/json.test.js
+++ b/tests/api/redirections/json.test.js
@@ -1,0 +1,68 @@
+const CONFIG = require('config')
+const host = CONFIG.fullHost()
+require('should')
+const { rawRequest } = require('../utils/request')
+const { createHuman } = require('../fixtures/entities')
+const { createUser } = require('../fixtures/users')
+const { groupPromise } = require('../fixtures/groups')
+const { createItem } = require('../fixtures/items')
+const someEntityPromise = createHuman()
+const someUserPromise = createUser()
+const someItemPromise = createItem()
+
+describe('json redirections', () => {
+  it('should redirect to an entity', async () => {
+    const { _id } = await someEntityPromise
+    const uri = `inv:${_id}`
+    const { headers } = await rawRequest('get', {
+      url: `${host}/entity/${uri}.json`,
+      followRedirect: false
+    })
+    headers.location.should.equal(`/api/entities?action=by-uris&uris=${uri}`)
+  })
+
+  it('should redirect to a user by id', async () => {
+    const { _id } = await someUserPromise
+    const { headers } = await rawRequest('get', {
+      url: `${host}/users/${_id}.json`,
+      followRedirect: false
+    })
+    headers.location.should.equal(`/api/users?action=by-ids&ids=${_id}`)
+  })
+
+  it('should redirect to a user by username', async () => {
+    const { username } = await someUserPromise
+    const { headers } = await rawRequest('get', {
+      url: `${host}/inventory/${username}.json`,
+      followRedirect: false
+    })
+    headers.location.should.equal(`/api/users?action=by-usernames&usernames=${username}`)
+  })
+
+  it('should redirect to a group by id', async () => {
+    const { _id } = await groupPromise
+    const { headers } = await rawRequest('get', {
+      url: `${host}/groups/${_id}.json`,
+      followRedirect: false
+    })
+    headers.location.should.equal(`/api/groups?action=by-id&id=${_id}`)
+  })
+
+  it('should redirect to a group by slug', async () => {
+    const { slug } = await groupPromise
+    const { headers } = await rawRequest('get', {
+      url: `${host}/groups/${slug}.json`,
+      followRedirect: false
+    })
+    headers.location.should.equal(`/api/groups?action=by-slug&slug=${slug}`)
+  })
+
+  it('should redirect to an item by id', async () => {
+    const { _id } = await someItemPromise
+    const { headers } = await rawRequest('get', {
+      url: `${host}/items/${_id}.json`,
+      followRedirect: false
+    })
+    headers.location.should.equal(`/api/items?action=by-ids&ids=${_id}`)
+  })
+})

--- a/tests/api/redirections/rss.test.js
+++ b/tests/api/redirections/rss.test.js
@@ -1,0 +1,47 @@
+const CONFIG = require('config')
+const host = CONFIG.fullHost()
+require('should')
+const { rawRequest } = require('../utils/request')
+const { createHuman } = require('../fixtures/entities')
+const { createUser } = require('../fixtures/users')
+const { groupPromise } = require('../fixtures/groups')
+const { createItem } = require('../fixtures/items')
+const someUserPromise = createUser()
+
+describe('rss redirections', () => {
+  it('should redirect to a user feed by id', async () => {
+    const { _id } = await someUserPromise
+    const { headers } = await rawRequest('get', {
+      url: `${host}/users/${_id}.rss`,
+      followRedirect: false
+    })
+    headers.location.should.equal(`/api/feeds?user=${_id}`)
+  })
+
+  it('should redirect to a user feed by username', async () => {
+    const { _id, username } = await someUserPromise
+    const { headers } = await rawRequest('get', {
+      url: `${host}/inventory/${username}.rss`,
+      followRedirect: false
+    })
+    headers.location.should.equal(`/api/feeds?user=${_id}`)
+  })
+
+  it('should redirect to a group feed by id', async () => {
+    const { _id } = await groupPromise
+    const { headers } = await rawRequest('get', {
+      url: `${host}/groups/${_id}.rss`,
+      followRedirect: false
+    })
+    headers.location.should.equal(`/api/feeds?group=${_id}`)
+  })
+
+  it('should redirect to a group feed by slug', async () => {
+    const { _id, slug } = await groupPromise
+    const { headers } = await rawRequest('get', {
+      url: `${host}/groups/${slug}.rss`,
+      followRedirect: false
+    })
+    headers.location.should.equal(`/api/feeds?group=${_id}`)
+  })
+})


### PR DESCRIPTION
easing rss feed discoverability by allowing to just add `.rss` to client side routes to get redirected to the API feed urls:
* `/inventory/${username}.rss` => `/api/feeds?user=${userId}`
* `/users/${userId}.rss` => `/api/feeds?user=${userId}`
* `/groups/${groupId}.rss` => `/api/feeds?group=${groupId}`
* `/groups/${groupSlug}.rss` => `/api/feeds?group=${groupId}`
