### PR TITLE
recover tasks after entity merge was reverted

### DIFF
--- a/server/controllers/items/lib/snapshot/update_snapshot_on_entity_change.js
+++ b/server/controllers/items/lib/snapshot/update_snapshot_on_entity_change.js
@@ -23,7 +23,7 @@ module.exports = () => {
   radio.on('entity:update:label', refreshSnapshot.fromDoc)
   radio.on('entity:update:claim', refreshSnapshot.fromDoc)
   radio.on('entity:merge', updateSnapshotOnEntityMerge)
-  return radio.on('entity:revert:merge', refreshSnapshot.fromUri)
+  radio.on('entity:revert:merge', refreshSnapshot.fromUri)
 }
 
 // Using the toUri as its the URI the items are using now

--- a/server/controllers/tasks/hooks.js
+++ b/server/controllers/tasks/hooks.js
@@ -4,11 +4,11 @@ const tasks_ = __.require('controllers', 'tasks/lib/tasks')
 const radio = __.require('lib', 'radio')
 const checkEntity = require('./lib/check_entity')
 
-// TODO:
-// - revert archiveObsoleteEntityUriTasks on revert-merge
 module.exports = () => {
   radio.on('entity:merge', archiveObsoleteEntityUriTasks)
   radio.on('entity:remove', archiveObsoleteEntityUriTasks)
+  radio.on('entity:revert:merge', revertArchive)
+  radio.on('entity:recover', revertArchive)
   radio.on('wikidata:entity:redirect', deleteBySuggestionUriAndRecheckSuspects)
 }
 
@@ -31,4 +31,12 @@ const archiveTasks = tasks => {
   if (tasks.length === 0) return
   const ids = _.map(tasks, '_id')
   return tasks_.update({ ids, attribute: 'state', newValue: 'merged' })
+}
+
+const revertArchive = uri => {
+  return tasks_.bySuspectUriAndState(uri, 'merged')
+  .then(tasks => {
+    const ids = _.map(tasks, '_id')
+    return tasks_.update({ ids, attribute: 'state', newValue: undefined })
+  })
 }

--- a/server/controllers/tasks/lib/tasks.js
+++ b/server/controllers/tasks/lib/tasks.js
@@ -10,7 +10,6 @@ const tasks_ = module.exports = {
   createInBulk: tasksDocs => {
     return promises_.try(() => tasksDocs.map(Task.create))
     .then(db.bulk)
-    .then(_.Log('tasks created'))
   },
 
   update: options => {
@@ -20,7 +19,6 @@ const tasks_ = module.exports = {
     return tasks_.byIds(ids)
     .map(task => Task.update(task, attribute, newValue))
     .then(db.bulk)
-    .then(_.Log('tasks updated'))
   },
 
   bulkDelete: db.bulkDelete,

--- a/server/controllers/tasks/lib/tasks.js
+++ b/server/controllers/tasks/lib/tasks.js
@@ -39,8 +39,12 @@ const tasks_ = module.exports = {
     })
   },
 
-  bySuspectUri: suspectUri => {
-    return db.viewByKey('bySuspectUriAndState', [ suspectUri, null ])
+  bySuspectUri: (suspectUri, options) => {
+    return tasks_.bySuspectUris([ suspectUri ], options)
+  },
+
+  bySuspectUriAndState: (suspectUri, state) => {
+    return db.viewByKey('bySuspectUriAndState', [ suspectUri, state ])
   },
 
   bySuggestionUri: suggestionUri => {

--- a/server/models/attributes/task.js
+++ b/server/models/attributes/task.js
@@ -1,7 +1,7 @@
 module.exports = {
   type: [ 'deduplicate' ],
 
-  state: [ 'merged', 'dismissed' ],
+  state: [ undefined, 'merged', 'dismissed' ],
 
   relationScore: []
 }

--- a/server/models/task.js
+++ b/server/models/task.js
@@ -27,7 +27,8 @@ module.exports = {
   update: (task, attribute, value) => {
     assert_.object(task)
     assert_.string(attribute)
-    assert_.type('string|number', value)
+    // Accept an undefined state value as that's the default state
+    if (value || attribute !== 'state') assert_.type('string|number', value)
 
     validations.pass('attribute', attribute)
     validations.pass(attribute, value)


### PR DESCRIPTION
(I'm doing a cleanup of my old stashes, which sometimes have some useful bits (in CoffeeScript, yeay ><))