### PR TITLE
add an endpoint to get the gravatar url corresponding to the email of the requesting user

### DIFF
--- a/server/controllers/images/gravatar.js
+++ b/server/controllers/images/gravatar.js
@@ -1,0 +1,36 @@
+// An endpoint to get the request user email and convert it to a gravatar url
+// so that a client can offer to import an existing avatar
+
+const CONFIG = require('config')
+const __ = CONFIG.universalPath
+const error_ = __.require('lib', 'error/error')
+const responses_ = __.require('lib', 'responses')
+const sanitize = __.require('lib', 'sanitize/sanitize')
+const { md5 } = __.require('lib', 'crypto')
+
+const sanitization = {}
+
+// Get an image data-url from a URL
+module.exports = (req, res) => {
+  sanitize(req, res, sanitization)
+  .then(() => {
+    const { email } = req.user
+    return getGravatarUrl(email)
+  })
+  .then(responses_.Wrap(res, 'url'))
+  .catch(error_.Handler(req, res))
+}
+
+const getGravatarUrl = email => `${baseUrl}${getHash(email)}${queryString}`
+
+const baseUrl = 'https://www.gravatar.com/avatar/'
+
+// Default to a 404 error if no image exists
+// see https://fr.gravatar.com/site/implement/images/
+const queryString = '?d=404&s=500'
+
+// See https://fr.gravatar.com/site/implement/hash/
+const getHash = email => {
+  email = email.trim().toLowerCase()
+  return md5(email)
+}

--- a/server/controllers/images/images.js
+++ b/server/controllers/images/images.js
@@ -5,7 +5,8 @@ const ActionsControllers = __.require('lib', 'actions_controllers')
 module.exports = {
   get: ActionsControllers({
     authentified: {
-      'data-url': require('./data_url')
+      'data-url': require('./data_url'),
+      gravatar: require('./gravatar')
     }
   }),
 

--- a/tests/api/images/gravatar.test.js
+++ b/tests/api/images/gravatar.test.js
@@ -1,0 +1,13 @@
+require('should')
+const { authReq } = require('../utils/utils')
+const endpoint = '/api/images?action=gravatar'
+
+describe('images:gravatar', () => {
+  it('should return a gravatar url', async () => {
+    const { url } = await authReq('get', endpoint)
+    url.should.startWith('https://www.gravatar.com/avatar/')
+    url.should.endWith('?d=404&s=500')
+    const md5Hash = url.split('/').slice(-1)[0].split('?')[0]
+    md5Hash.should.match(/^[0-9a-f]{32}$/)
+  })
+})


### PR DESCRIPTION
An endpoint to get the request user email and convert it to a gravatar url so that a client can offer to import an existing avatar

This endpoint is being depended on by https://github.com/inventaire/inventaire-client/pull/195