### PR TITLE
fix media storage cross device EXDEV error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5342,7 +5342,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
       "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
-      "optional": true,
       "requires": {
         "mkdirp": "~0.5.1",
         "ncp": "~2.0.0",
@@ -5353,7 +5352,6 @@
           "version": "6.0.4",
           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-          "optional": true,
           "requires": {
             "inflight": "^1.0.4",
             "inherits": "2",
@@ -5366,7 +5364,6 @@
           "version": "2.4.5",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
           "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
-          "optional": true,
           "requires": {
             "glob": "^6.0.1"
           }
@@ -5469,8 +5466,7 @@
     "ncp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
-      "optional": true
+      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M="
     },
     "ndjson": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "leven": "^2.1.0",
     "lodash": "^4.17.15",
     "moment": "^2.21.0",
+    "mv": "^2.1.1",
     "node-polyglot": "^1.0.0",
     "nodemailer": "git+https://github.com/inventaire/Nodemailer.git",
     "nodemailer-express-handlebars": "^2.0.0",

--- a/server/lib/fs.js
+++ b/server/lib/fs.js
@@ -1,6 +1,8 @@
-const { rename, stat } = require('fs').promises
+const { stat } = require('fs').promises
+const { promisify } = require('util')
+const mv = require('mv')
 
 module.exports = {
-  mv: rename,
+  mv: promisify(mv),
   getContentLength: src => stat(src).then(({ size }) => size)
 }


### PR DESCRIPTION
by reverting commit b8b48d4

fix #375 , using the module `mv` rather than `fs-extra`, as it's way smaller