### PR TITLE
resolver: allow to force update specific claims

### DIFF
--- a/server/controllers/entities/lib/resolver/create_unresolved_entry.js
+++ b/server/controllers/entities/lib/resolver/create_unresolved_entry.js
@@ -1,6 +1,7 @@
 const { createEdition, createWork, createAuthor } = require('./create_entity_from_seed')
 
-module.exports = (userId, batchId) => async entry => {
+module.exports = params => async entry => {
+  const { reqUserId: userId, batchId } = params
   const { edition, works, authors } = entry
 
   // If the edition has been resolved but not its associated works

--- a/server/controllers/entities/lib/resolver/update_resolved_entry.js
+++ b/server/controllers/entities/lib/resolver/update_resolved_entry.js
@@ -3,27 +3,27 @@ const __ = CONFIG.universalPath
 const _ = __.require('builders', 'utils')
 const entities_ = require('../entities')
 
-module.exports = (userId, batchId) => entry => {
+module.exports = params => entry => {
+  const { reqUserId: userId, batchId, forceUpdateProps } = params
   const { edition, works, authors } = entry
 
   const allResolvedSeeds = [ edition ].concat(works, authors).filter(hasUri)
 
-  return Promise.all(allResolvedSeeds.map(updateEntityFromSeed(userId, batchId)))
+  return Promise.all(allResolvedSeeds.map(updateEntityFromSeed(userId, batchId, forceUpdateProps)))
   .then(() => entry)
 }
 
 const hasUri = seed => seed.uri != null
 
-const updateEntityFromSeed = (userId, batchId) => seed => {
+const updateEntityFromSeed = (userId, batchId, forceUpdateProps) => seed => {
   const { uri, claims: seedClaims } = seed
   if (!uri) return
 
   const [ prefix, entityId ] = uri.split(':')
   // Do not try to update Wikidata for the moment
   if (prefix === 'wd') return
-
-  return getEntity(prefix, entityId)
-  .then(addMissingClaims(seedClaims, userId, batchId))
+  getEntity(prefix, entityId)
+  .then(updateClaims(seedClaims, userId, batchId, forceUpdateProps))
 }
 
 const getEntity = (prefix, entityId) => {
@@ -34,10 +34,29 @@ const getEntity = (prefix, entityId) => {
   }
 }
 
-const addMissingClaims = (seedClaims, userId, batchId) => entity => {
-  // Do not update if property already exists
+const updateClaims = (seedClaims, userId, batchId, forceUpdateProps) => entity => {
+  addMissinClaims(seedClaims, userId, batchId, entity)
+  // Only update if property exists in forceUpdateProps
   // Known cases: avoid updating authors who are actually edition translators
+  if (forceUpdateProps && _.some(forceUpdateProps)) {
+    forceUpdateClaims(seedClaims, userId, batchId, forceUpdateProps, entity)
+  }
+}
+const forceUpdateClaims = (seedClaims, userId, batchId, forceUpdateProps, currentDoc) => {
+  const updatedDoc = _.cloneDeep(currentDoc)
+  const { claims } = updatedDoc
+  forceUpdateProps.forEach(prop => {
+    if (claims && claims[prop]) {
+      claims[prop] = seedClaims[prop]
+    }
+  })
+  if (!_.isEqual(claims, currentDoc.claims)) {
+    entities_.putUpdate({ userId, currentDoc, updatedDoc })
+  }
+}
+
+const addMissinClaims = (seedClaims, userId, batchId, entity) => {
   const newClaims = _.omit(seedClaims, Object.keys(entity.claims))
   if (_.isEmpty(newClaims)) return
-  return entities_.addClaims(userId, newClaims, entity, batchId)
+  entities_.addClaims(userId, newClaims, entity, batchId)
 }

--- a/server/controllers/entities/resolve.js
+++ b/server/controllers/entities/resolve.js
@@ -9,6 +9,8 @@ const resolve = require('./lib/resolver/resolve')
 const UpdateResolvedEntry = require('./lib/resolver/update_resolved_entry')
 const CreateUnresolvedEntry = require('./lib/resolver/create_unresolved_entry')
 const { oneHour } = __.require('lib', 'times')
+const properties = require('./lib/properties/properties_values_constraints')
+const whitelistedProperties = Object.keys(properties)
 
 const sanitization = {
   entries: {
@@ -20,6 +22,10 @@ const sanitization = {
   },
   update: {
     generic: 'boolean',
+    optional: true
+  },
+  forceUpdateProps: {
+    whitelist: whitelistedProperties,
     optional: true
   },
   strict: {
@@ -90,9 +96,8 @@ const sequentialResolve = async (entries, params, errors) => {
 }
 
 const buildActionFn = (flag, ActionFn, params) => {
-  const { reqUserId, batchId } = params
   if (flag) {
-    return ActionFn(reqUserId, batchId)
+    return ActionFn(params)
   } else {
     return _.identity
   }

--- a/server/lib/sanitize/parameters.js
+++ b/server/lib/sanitize/parameters.js
@@ -173,6 +173,7 @@ module.exports = {
   description: nonEmptyString,
   filter: whitelistedString,
   from: entityUri,
+  forceUpdateProps: whitelistedStrings,
   generics,
   group: couchUuid,
   id: couchUuid,
@@ -202,6 +203,7 @@ module.exports = {
   prefix: whitelistedString,
   property: { validate: _.isPropertyUri },
   refresh: generics.boolean,
+  relatives: whitelistedStrings,
   range: Object.assign({}, positiveInteger, {
     default: 50,
     max: 500
@@ -222,7 +224,6 @@ module.exports = {
   users: couchUuids,
   username: { validate: validations.common.username },
   usernames,
-  relatives: whitelistedStrings,
   value: {
     // Endpoints accepting a 'value' can specify a type
     // or have to do their own validation

--- a/tests/api/entities/resolver/resolve_and_force_update.test.js
+++ b/tests/api/entities/resolver/resolve_and_force_update.test.js
@@ -1,0 +1,87 @@
+const CONFIG = require('config')
+const __ = CONFIG.universalPath
+const _ = __.require('builders', 'utils')
+require('should')
+const { authReq, shouldNotGetHere, rethrowShouldNotGetHereErrors } = __.require('apiTests', 'utils/utils')
+const { Wait } = __.require('lib', 'promises')
+const { getByUris, addClaim } = __.require('apiTests', 'utils/entities')
+const { createHuman, ensureEditionExists, someGoodReadsId, generateIsbn13 } = __.require('apiTests', 'fixtures/entities')
+
+const buildEditionEntry = (isbn = generateIsbn13()) => {
+  const claims = { 'wdt:P123': 'wd:Q1799264' }
+  return {
+    edition: {
+      isbn,
+      claims
+    }
+  }
+}
+
+const resolveAndForceUpdate = (entries, props) => {
+  entries = _.forceArray(entries)
+  return authReq('post', '/api/entities?action=resolve', {
+    entries,
+    update: true,
+    forceUpdateProps: props
+  })
+}
+
+describe('entities:resolver:force-update-resolved', () => {
+  it('should reject when properties to force update are unknown', async () => {
+    const propertiesToForce = [ 'wdt:P6' ]
+    const editionEntry = buildEditionEntry()
+    const isbn = editionEntry.edition.isbn
+    const editionUri = `isbn:${isbn}`
+    await ensureEditionExists(editionUri)
+
+    try {
+      const res = await resolveAndForceUpdate(editionEntry, propertiesToForce)
+      shouldNotGetHere(res)
+    } catch (err) {
+      rethrowShouldNotGetHereErrors(err)
+      err.statusCode.should.equal(400)
+      err.body.status_verbose.should.startWith('invalid forceUpdateProps')
+    }
+  })
+
+  it('should replace edition claim values when properties to force is specified', async () => {
+    const editionEntry = buildEditionEntry()
+    const editionUri = `isbn:${editionEntry.edition.isbn}`
+    await ensureEditionExists(editionUri)
+
+    const propertiesToForce = [ 'wdt:P123' ]
+    await resolveAndForceUpdate(editionEntry, propertiesToForce)
+    .then(Wait(100))
+    const res = await getByUris(editionUri)
+    const updatedEdition = res.entities[editionUri]
+    updatedEdition.claims['wdt:P123'].should.containEql(editionEntry.edition.claims['wdt:P123'])
+  })
+
+  it('should update authors claims', async () => {
+    // necessary id to resolve author
+    const goodReadsId = someGoodReadsId()
+    const currentOfficialWebsite = 'http://notOfficial.org'
+    const officialWebsite = 'http://Q35802.org'
+    const entry = {
+      edition: { isbn: generateIsbn13() },
+      authors: [ {
+        claims: {
+          'wdt:P2963': [ goodReadsId ],
+          'wdt:P856': [ officialWebsite ]
+        }
+      } ]
+    }
+    const human = await createHuman()
+    await addClaim(human.uri, 'wdt:P2963', goodReadsId)
+    await addClaim(human.uri, 'wdt:P856', currentOfficialWebsite)
+
+    const propertiesToForce = [ 'wdt:P856' ]
+    const { entries } = await resolveAndForceUpdate(entry, propertiesToForce)
+    .then(Wait(100))
+
+    const authorUri = entries[0].authors[0].uri
+    const { entities } = await getByUris(authorUri)
+    const updatedAuthor = entities[authorUri]
+    updatedAuthor.claims['wdt:P856'].should.containEql(officialWebsite)
+  })
+})

--- a/tests/api/entities/resolver/resolve_and_update.test.js
+++ b/tests/api/entities/resolver/resolve_and_update.test.js
@@ -15,7 +15,7 @@ const resolveAndUpdate = entries => {
 }
 
 describe('entities:resolver:update-resolved', () => {
-  it('should not update entity claim values if property exists', done => {
+  it('should not update entity claim values if claim exists', done => {
     const libraryThingsWorkId = someLibraryThingsWorkId()
     const authorUri = 'wd:Q35802'
     const authorUri2 = 'wd:Q184226'
@@ -41,6 +41,7 @@ describe('entities:resolver:update-resolved', () => {
         .then(({ entities }) => entities)
         .then(entities => {
           const workAuthorsUris = _.values(entities)[0].claims['wdt:P50']
+          workAuthorsUris.should.containEql(authorUri2)
           workAuthorsUris.should.not.containEql(authorUri)
           done()
         })
@@ -49,7 +50,7 @@ describe('entities:resolver:update-resolved', () => {
     .catch(done)
   })
 
-  it('should update entities claims values if property does not exist', done => {
+  it('should update entities claims values if claim does not exist', done => {
     const entryA = someEntryWithAGoodReadsWorkId()
     const entryB = someEntryWithAGoodReadsWorkId()
     const libraryThingsWorkIdA = entryA.works[0].claims['wdt:P1085'][0]


### PR DESCRIPTION
Replace entity claims with entry claims of properties declared in the `forceUpdateProps` parameter (renaming welcome)

Usecase: an editor catalogue, representing the most canonical data is passed through the resolver. But some formating of this catalogue may be less precise than existing inv entities claims.

`forceUpdateProps` allow to update only the publication date for example, date format being less subjected to interpretation than a title.

- early parameter validation: against properties values constraints list
- perform an update, aka only if claim already exists (allowing to not check entity type before update)
- rely on not updating wikidata items policy already implemented in
update_resolved_entry