### PR TITLE
replace wd:Q571 by wd:Q47461344 as default work P31

### DIFF
--- a/server/controllers/entities/lib/resolver/create_entity_from_seed.js
+++ b/server/controllers/entities/lib/resolver/create_entity_from_seed.js
@@ -17,7 +17,7 @@ const createWork = (userId, batchId, authors) => work => {
   if (work.uri != null) return work
   const authorsUris = _.compact(_.map(authors, 'uri'))
   const claims = {}
-  addClaimIfValid(claims, 'wdt:P31', [ 'wd:Q571' ])
+  addClaimIfValid(claims, 'wdt:P31', [ 'wd:Q47461344' ])
   addClaimIfValid(claims, 'wdt:P50', authorsUris)
   return createEntityFromSeed({ type: 'work', seed: work, claims, userId, batchId })
 }

--- a/server/controllers/entities/lib/scaffold_entity_from_seed/work.js
+++ b/server/controllers/entities/lib/scaffold_entity_from_seed/work.js
@@ -94,7 +94,7 @@ const createWorkEntity = (title, lang, authorsUris) => {
   const labels = {}
   if (_.isNonEmptyString(title)) labels[lang] = title
   const claims = {
-    'wdt:P31': [ 'wd:Q571' ],
+    'wdt:P31': [ 'wd:Q47461344' ],
     'wdt:P50': authorsUris
   }
 

--- a/server/data/wikidata/queries/editions_reverse_claims.js
+++ b/server/data/wikidata/queries/editions_reverse_claims.js
@@ -7,6 +7,7 @@ module.exports = {
   ?item wdt:P31 wd:Q3331189 .
   # Filter-out entities tagged as both work and edition
   FILTER NOT EXISTS { ?item wdt:P31 wd:Q571 }
+  FILTER NOT EXISTS { ?item wdt:P31 wd:Q47461344 }
 }
 LIMIT 1000`
   }

--- a/tests/api/entities/create.test.js
+++ b/tests/api/entities/create.test.js
@@ -57,7 +57,7 @@ describe('entities:create', () => {
 
   it('should reject without a label (unless specific types)', done => {
     authReq('post', endpoint, {
-      claims: { 'wdt:P31': [ 'wd:Q571' ] }
+      claims: { 'wdt:P31': [ 'wd:Q47461344' ] }
     })
     .then(undesiredRes(done))
     .catch(err => {
@@ -70,13 +70,13 @@ describe('entities:create', () => {
   it('should create a work entity', done => {
     authReq('post', endpoint, {
       labels: { fr: humanName() },
-      claims: { 'wdt:P31': [ 'wd:Q571' ] }
+      claims: { 'wdt:P31': [ 'wd:Q47461344' ] }
     })
     .then(res => {
       res._id.should.be.a.String()
       res._rev.should.be.a.String()
       res.type.should.equal('work')
-      res.claims.should.deepEqual({ 'wdt:P31': [ 'wd:Q571' ] })
+      res.claims.should.deepEqual({ 'wdt:P31': [ 'wd:Q47461344' ] })
       res.uri.should.be.a.String()
       res.labels.should.be.an.Object()
       done()
@@ -88,7 +88,7 @@ describe('entities:create', () => {
     authReq('post', endpoint, {
       labels: { fr: humanName() },
       claims: {
-        'wdt:P31': [ 'wd:Q571' ],
+        'wdt:P31': [ 'wd:Q47461344' ],
         'wdt:P648': [ someOpenLibraryId('work') ]
       }
     })
@@ -102,7 +102,7 @@ describe('entities:create', () => {
   it('should reject multiple values for a property that take one', done => {
     authReq('post', endpoint, {
       labels: { fr: humanName() },
-      claims: { 'wdt:P31': [ 'wd:Q571', 'wd:Q572' ] }
+      claims: { 'wdt:P31': [ 'wd:Q47461344', 'wd:Q572' ] }
     })
     .then(undesiredRes(done))
     .catch(err => {
@@ -145,7 +145,7 @@ describe('entities:create', () => {
     authReq('post', endpoint, {
       labels: { fr: humanName() },
       claims: {
-        'wdt:P31': [ 'wd:Q571' ],
+        'wdt:P31': [ 'wd:Q47461344' ],
         'wdt:P50': 'wd:Q535'
       }
     })
@@ -162,7 +162,7 @@ describe('entities:create', () => {
     authReq('post', endpoint, {
       labels: { fr: humanName() },
       claims: {
-        'wdt:P31': [ 'wd:Q571' ],
+        'wdt:P31': [ 'wd:Q47461344' ],
         'wd:P50': [ 'wd:Q535' ]
       }
     })
@@ -179,7 +179,7 @@ describe('entities:create', () => {
     authReq('post', endpoint, {
       labels: { fr: humanName() },
       claims: {
-        'wdt:P31': [ 'wd:Q571' ],
+        'wdt:P31': [ 'wd:Q47461344' ],
         'wdt:P50': [ 'wd####Q535' ]
       }
     })
@@ -198,8 +198,10 @@ describe('entities:create', () => {
       await authReq('post', endpoint, {
         claims: {
           'wdt:P31': [ 'wd:Q3331189' ],
-          'wdt:P212': edition.claims['wdt:P212'],
-          'wdt:P1476': [ randomLabel() ]
+          'wdt:P1476': [ randomLabel() ],
+          'wdt:P629': edition.claims['wdt:P629'],
+          // The concurrent property
+          'wdt:P212': edition.claims['wdt:P212']
         }
       })
       .then(shouldNotBeCalled)
@@ -213,7 +215,7 @@ describe('entities:create', () => {
     authReq('post', endpoint, {
       labels: { fr: randomLabel() },
       claims: {
-        'wdt:P31': [ 'wd:Q571' ], // work
+        'wdt:P31': [ 'wd:Q47461344' ], // work
         'wdt:P1104': [ 124 ] // edition pages counts
       }
     })
@@ -246,7 +248,7 @@ describe('entities:create', () => {
       prefix: 'wd',
       labels: { fr: humanName() },
       claims: {
-        'wdt:P31': [ 'wd:Q571' ],
+        'wdt:P31': [ 'wd:Q47461344' ],
         'wdt:P648': [ someOpenLibraryId('work') ]
       }
     })

--- a/tests/api/fixtures/entities.js
+++ b/tests/api/fixtures/entities.js
@@ -23,7 +23,7 @@ const randomWords = length => faker.random.words(length)
 const API = module.exports = {
   createEntity,
   createHuman: createEntity('wd:Q5'),
-  createWork: createEntity('wd:Q571'),
+  createWork: createEntity('wd:Q47461344'),
   createSerie: createEntity('wd:Q277759'),
   createPublisher: createEntity('wd:Q2085381'),
   randomLabel: (length = 5) => randomWords(length),
@@ -36,7 +36,7 @@ const API = module.exports = {
     return authReq('post', '/api/entities?action=create', {
       labels: { en: label },
       claims: {
-        'wdt:P31': [ 'wd:Q571' ],
+        'wdt:P31': [ 'wd:Q47461344' ],
         'wdt:P50': [ human.uri ]
       }
     })

--- a/tests/unit/models/024-entity.js
+++ b/tests/unit/models/024-entity.js
@@ -9,7 +9,7 @@ const workDoc = () => {
   const doc = Entity.create()
   doc._id = '12345678900987654321123456789012'
   doc._rev = '5-12345678900987654321123456789012'
-  doc.claims['wdt:P31'] = [ 'wd:Q571' ]
+  doc.claims['wdt:P31'] = [ 'wd:Q47461344' ]
   doc.claims['wdt:P50'] = [ 'wd:Q535', 'wd:Q1541' ]
   doc.created = Date.now()
   doc.updated = Date.now()

--- a/tests/unit/models/025-patch.js
+++ b/tests/unit/models/025-patch.js
@@ -16,7 +16,7 @@ const currentDoc = {
     fr: 'yo'
   },
   claims: {
-    P31: [ 'Q571' ],
+    P31: [ 'Q47461344' ],
     P50: [ 'Q535' ]
   },
   notTrackedAttr: 123
@@ -29,7 +29,7 @@ const updatedDoc = {
     en: 'da'
   },
   claims: {
-    P31: [ 'Q571' ],
+    P31: [ 'Q47461344' ],
     P50: [ 'Q535', 'Q2001' ],
     P135: [ 'Q53121' ]
   },
@@ -41,7 +41,7 @@ const authorDoc = {
   _rev: '4-760b982ea416be33c6938774db2cfaeb',
   type: 'entity',
   labels: { en: 'GBKaRq' },
-  claims: { 'wdt:P31': [ 'wd:Q571' ] }
+  claims: { 'wdt:P31': [ 'wd:Q47461344' ] }
 }
 
 describe('patch', () => {


### PR DESCRIPTION
Q571 as a P31 value has been deprecated for a while on Wikidata, meaning that [Wikidata items created from an inventaire.io import need to be fixed](https://editgroups.toolforge.org/b/wikibase-cli/cbcf544f2f519/). This patch fixes the problem at the source.