### PR TITLE
keep a temporary cache of relations that aren't yet available to the Wikidata Query Service

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -33,6 +33,9 @@ const config = module.exports = {
   // - log requests body
   debug: false,
   logOutgoingRequests: true,
+  outgoingRequests: {
+    baseBanTime: 500
+  },
   // CouchDB settings
   db: {
     protocol: 'http',

--- a/config/default.js
+++ b/config/default.js
@@ -202,8 +202,8 @@ const config = module.exports = {
     }
   },
 
-  outgoingRequests: {
-    baseBanTime: 60 * 60 * 1000,
-    banTimeIncreaseFactor: 4
+  entitiesRelationsTemporaryCache: {
+    checkFrequency: 10 * 60 * 1000,
+    ttl: 4 * 60 * 60 * 1000
   }
 }

--- a/config/tests-api.js
+++ b/config/tests-api.js
@@ -31,6 +31,7 @@ module.exports = {
   },
 
   leveldbMemoryBackend: true,
+
   // Disable password hashing to make tests run faster
   hashPasswords: false,
   piwik: {

--- a/config/tests-integration.js
+++ b/config/tests-integration.js
@@ -7,5 +7,10 @@ module.exports = {
 
   outgoingRequests: {
     baseBanTime: 500
+  },
+
+  entitiesRelationsTemporaryCache: {
+    checkFrequency: 1000,
+    ttl: 3 * 1000
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,11 @@
       "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-0.3.2.tgz",
       "integrity": "sha1-WYc/Nej89sc2HBAjkmHXbhU0i7I="
     },
+    "after": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
+      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
+    },
     "ajv": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
@@ -3166,6 +3171,17 @@
         }
       }
     },
+    "level-ttl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/level-ttl/-/level-ttl-3.1.1.tgz",
+      "integrity": "sha1-REOkn+n0nWNNPD8x57nffI1HfRQ=",
+      "requires": {
+        "after": ">=0.8.1 <0.9.0-0",
+        "list-stream": ">=1.0.0 <1.1.0-0",
+        "lock": "~0.1.2",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      }
+    },
     "level-write-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/level-write-stream/-/level-write-stream-1.0.0.tgz",
@@ -3231,6 +3247,35 @@
       "resolved": "https://registry.npmjs.org/libqp/-/libqp-1.1.0.tgz",
       "integrity": "sha1-9ebgatdLeU+1tbZpiL9yjvHe2+g="
     },
+    "list-stream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/list-stream/-/list-stream-1.0.1.tgz",
+      "integrity": "sha1-40SSrdzNGhZbAorW15WjbE/ZXSk=",
+      "requires": {
+        "readable-stream": "~2.0.5",
+        "xtend": "~4.0.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~0.10.x",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
     "load-json-file": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
@@ -3260,6 +3305,11 @@
           "dev": true
         }
       }
+    },
+    "lock": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/lock/-/lock-0.1.4.tgz",
+      "integrity": "sha1-/sfervF+fDoKVeHaBCgD4l2RdF0="
     },
     "lodash": {
       "version": "4.17.15",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3256,6 +3256,11 @@
         "xtend": "~4.0.1"
       },
       "dependencies": {
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+        },
         "readable-stream": {
           "version": "2.0.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "./scripts/run_unit_tests",
     "test-api": "./tests/api/scripts/test_api",
     "test-api-quick": "./tests/api/scripts/test_api_quick",
-    "test-integration": "./scripts/run_integration_tests",
+    "test-integration": "./scripts/test_integration",
     "update-i18n": "./scripts/update_i18n",
     "update-toc": "./scripts/update_toc",
     "watch": "./scripts/watch"
@@ -66,6 +66,7 @@
     "level-geospatial": "git+https://github.com/maxlath/level-geospatial.git#5001a8f",
     "level-jobs": "^2.1.0",
     "level-party": "^4.0.0",
+    "level-ttl": "^3.1.1",
     "leven": "^2.1.0",
     "lodash": "^4.17.15",
     "moment": "^2.21.0",

--- a/scripts/test_integration
+++ b/scripts/test_integration
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+export NODE_ENV=tests-integration
+
+# If no test file is passed as argument, run all tests
+if [ -z "$1" ]
+then
+  mocha --exit ./tests/integration/*
+else
+  mocha --exit "$@"
+fi

--- a/server/controllers/entities/lib/entities.js
+++ b/server/controllers/entities/lib/entities.js
@@ -102,8 +102,12 @@ const entities_ = module.exports = {
 
   firstClaim: (entity, property) => {
     if (entity.claims[property] != null) return entity.claims[property][0]
-  }
+  },
+
+  uniqByUri: entities => _.uniqBy(entities, getUri)
 }
+
+const getUri = entity => entity.uri
 
 const triggerUpdateEvent = (currentDoc, updatedDoc) => {
   // Use currentDoc claims if the update removed the claims object

--- a/server/controllers/entities/lib/entities.js
+++ b/server/controllers/entities/lib/entities.js
@@ -98,7 +98,11 @@ const entities_ = module.exports = {
     return docAfterUpdate
   },
 
-  getUrlFromEntityImageHash: getUrlFromImageHash.bind(null, 'entities')
+  getUrlFromEntityImageHash: getUrlFromImageHash.bind(null, 'entities'),
+
+  firstClaim: (entity, property) => {
+    if (entity.claims[property] != null) return entity.claims[property][0]
+  }
 }
 
 const triggerUpdateEvent = (currentDoc, updatedDoc) => {

--- a/server/controllers/entities/lib/entities_relations_temporary_cache.js
+++ b/server/controllers/entities/lib/entities_relations_temporary_cache.js
@@ -1,0 +1,37 @@
+const CONFIG = require('config')
+const __ = CONFIG.universalPath
+const { promisify } = require('util')
+const levelTtl = require('level-ttl')
+const { checkFrequency, ttl } = CONFIG.entitiesRelationsTemporaryCache
+
+const db = __.require('level', 'get_sub_db')('entities-relations', 'utf8')
+const ttlDb = levelTtl(db, { checkFrequency, defaultTTL: ttl })
+const put = promisify(ttlDb.put).bind(ttlDb)
+const del = promisify(ttlDb.del).bind(ttlDb)
+
+module.exports = {
+  get: async (property, object) => {
+    const keys = await getKeyRange(property, object)
+    return keys.map(getSubject)
+  },
+
+  set: async (subject, property, object) => put(`${property}-${object}-${subject}`, ''),
+
+  del: async (subject, property, object) => del(`${property}-${object}-${subject}`)
+}
+
+const getKeyRange = (property, object) => {
+  const keys = []
+  const keyBase = `${property}-${object}-`
+  return new Promise((resolve, reject) => {
+    db.createKeyStream({
+      gte: keyBase,
+      lt: keyBase + 'z'
+    })
+    .on('data', key => keys.push(key))
+    .on('close', () => resolve(keys))
+    .on('error', reject)
+  })
+}
+
+const getSubject = key => key.split('-')[2]

--- a/server/controllers/entities/lib/entities_relations_temporary_cache.js
+++ b/server/controllers/entities/lib/entities_relations_temporary_cache.js
@@ -1,5 +1,7 @@
 const CONFIG = require('config')
 const __ = CONFIG.universalPath
+const _ = __.require('builders', 'utils')
+const error_ = __.require('lib', 'error/error')
 const { promisify } = require('util')
 const levelTtl = require('level-ttl')
 const { checkFrequency, ttl } = CONFIG.entitiesRelationsTemporaryCache
@@ -15,9 +17,9 @@ module.exports = {
     return keys.map(getSubject)
   },
 
-  set: async (subject, property, object) => put(`${property}-${object}-${subject}`, ''),
+  set: async (subject, property, object) => put(buildKey(subject, property, object), ''),
 
-  del: async (subject, property, object) => del(`${property}-${object}-${subject}`)
+  del: async (subject, property, object) => del(buildKey(subject, property, object))
 }
 
 const getKeyRange = (property, object) => {
@@ -35,3 +37,10 @@ const getKeyRange = (property, object) => {
 }
 
 const getSubject = key => key.split('-')[2]
+
+const buildKey = (subject, property, object) => {
+  if (!_.isInvEntityUri(subject)) throw error_.new('invalid subject', { subject })
+  if (!_.isPropertyUri(property)) throw error_.new('invalid property', { property })
+  if (!_.isEntityUri(object)) throw error_.new('invalid object', { object })
+  return `${property}-${object}-${subject}`
+}

--- a/server/controllers/entities/lib/entities_relations_temporary_cache.js
+++ b/server/controllers/entities/lib/entities_relations_temporary_cache.js
@@ -12,14 +12,14 @@ const put = promisify(ttlDb.put).bind(ttlDb)
 const del = promisify(ttlDb.del).bind(ttlDb)
 
 module.exports = {
-  get: async (property, object) => {
-    const keys = await getKeyRange(property, object)
+  get: async (property, valueUri) => {
+    const keys = await getKeyRange(property, valueUri)
     return keys.map(getSubject)
   },
 
-  set: async (subject, property, object) => put(buildKey(subject, property, object), ''),
+  set: async (subjectUri, property, valueUri) => put(buildKey(subjectUri, property, valueUri), ''),
 
-  del: async (subject, property, object) => del(buildKey(subject, property, object))
+  del: async (subjectUri, property, valueUri) => del(buildKey(subjectUri, property, valueUri))
 }
 
 const getKeyRange = (property, object) => {
@@ -38,9 +38,9 @@ const getKeyRange = (property, object) => {
 
 const getSubject = key => key.split('-')[2]
 
-const buildKey = (subject, property, object) => {
-  if (!_.isInvEntityUri(subject)) throw error_.new('invalid subject', { subject })
+const buildKey = (subjectUri, property, valueUri) => {
+  if (!_.isInvEntityUri(subjectUri)) throw error_.new('invalid subject', { subjectUri })
   if (!_.isPropertyUri(property)) throw error_.new('invalid property', { property })
-  if (!_.isEntityUri(object)) throw error_.new('invalid object', { object })
-  return `${property}-${object}-${subject}`
+  if (!_.isEntityUri(valueUri)) throw error_.new('invalid value', { valueUri })
+  return `${property}-${valueUri}-${subjectUri}`
 }

--- a/server/controllers/entities/lib/get_author_works.js
+++ b/server/controllers/entities/lib/get_author_works.js
@@ -1,7 +1,7 @@
 const __ = require('config').universalPath
 const _ = __.require('builders', 'utils')
 const entities_ = require('./entities')
-const { firstClaim } = entities_
+const { firstClaim, uniqByUri } = entities_
 const runWdQuery = __.require('data', 'wikidata/run_query')
 const { prefixifyWd } = __.require('controllers', 'entities/lib/prefix')
 const { getSimpleDayDate, sortByScore } = require('./queries_utils')
@@ -33,6 +33,8 @@ module.exports = params => {
 
   return Promise.all(promises)
   .then(_.flatten)
+  // There might be duplicates, mostly due to temporarily cached relations
+  .then(uniqByUri)
   .then(results => getPopularityScores(results)
   .then(spreadByType(worksByTypes, results)))
   .catch(_.ErrorRethrow('get author works err'))

--- a/server/controllers/entities/lib/get_serie_parts.js
+++ b/server/controllers/entities/lib/get_serie_parts.js
@@ -1,7 +1,7 @@
 const __ = require('config').universalPath
 const _ = __.require('builders', 'utils')
 const entities_ = require('./entities')
-const { firstClaim } = entities_
+const { firstClaim, uniqByUri } = entities_
 const runWdQuery = __.require('data', 'wikidata/run_query')
 const { prefixifyWd } = __.require('controllers', 'entities/lib/prefix')
 const { getSimpleDayDate, sortByOrdinalOrDate } = require('./queries_utils')
@@ -20,8 +20,11 @@ module.exports = params => {
   promises.push(getCachedRelations(uri, 'wdt:P179', formatEntity))
 
   return Promise.all(promises)
-  .then((...results) => ({
-    parts: _.flatten(...results).sort(sortByOrdinalOrDate)
+  .then(_.flatten)
+  // There might be duplicates, mostly due to temporarily cached relations
+  .then(uniqByUri)
+  .then(results => ({
+    parts: results.sort(sortByOrdinalOrDate)
   }))
   .catch(_.ErrorRethrow('get serie parts err'))
 }

--- a/server/controllers/entities/lib/merge_entities.js
+++ b/server/controllers/entities/lib/merge_entities.js
@@ -4,8 +4,7 @@ const error_ = __.require('lib', 'error/error')
 const assert_ = __.require('utils', 'assert_types')
 const entities_ = require('./entities')
 const Entity = __.require('models', 'entity')
-const placeholders_ = require('./placeholders')
-const propagateRedirection = require('./propagate_redirection')
+const turnIntoRedirection = require('./turn_into_redirection')
 const getInvEntityCanonicalUri = require('./get_inv_entity_canonical_uri')
 
 module.exports = (userId, fromUri, toUri) => {
@@ -68,65 +67,4 @@ const mergeEntities = async (userId, fromId, toId) => {
   const newToUri = getInvEntityCanonicalUri(toEntityDocAfterMerge)
 
   return turnIntoRedirection(userId, fromId, newToUri, previousToUri)
-}
-
-const turnIntoRedirection = (userId, fromId, toUri, previousToUri) => {
-  assert_.strings([ userId, fromId, toUri ])
-  if (previousToUri != null) { assert_.string(previousToUri) }
-
-  const fromUri = `inv:${fromId}`
-
-  return entities_.byId(fromId)
-  .then(currentFromDoc => {
-    Entity.preventRedirectionEdit(currentFromDoc, 'turnIntoRedirection')
-    // If an author has no more links to it, remove it
-    return removeObsoletePlaceholderEntities(userId, currentFromDoc)
-    .then(removedIds => {
-      const updatedFromDoc = Entity.turnIntoRedirection(currentFromDoc, toUri, removedIds)
-      return entities_.putUpdate({
-        userId,
-        currentDoc: currentFromDoc,
-        updatedDoc: updatedFromDoc
-      })
-    })
-  })
-  .then(propagateRedirection.bind(null, userId, fromUri, toUri, previousToUri))
-}
-
-// Removing the entities that were needed only by the entity about to be turned
-// into a redirection: this entity now don't have anymore reason to be and is quite
-// probably a duplicate of an existing entity referenced by the redirection
-// destination entity.
-const removeObsoletePlaceholderEntities = (userId, entityDocBeforeRedirection) => {
-  const entityUrisToCheck = getEntityUrisToCheck(entityDocBeforeRedirection.claims)
-  _.log(entityUrisToCheck, 'entityUrisToCheck')
-  const fromId = entityDocBeforeRedirection._id
-  return Promise.all(entityUrisToCheck.map(deleteIfIsolated(userId, fromId)))
-  // Returning removed docs ids
-  .then(_.compact)
-}
-
-const getEntityUrisToCheck = claims => {
-  return _(claims)
-  .pick(propertiesToCheckForPlaceholderDeletion)
-  .values()
-  // Merge properties arrays
-  .flatten()
-  .uniq()
-  .value()
-}
-
-const propertiesToCheckForPlaceholderDeletion = [
-  // author
-  'wdt:P50'
-]
-
-const deleteIfIsolated = (userId, fromId) => async entityUri => {
-  const [ prefix, entityId ] = entityUri.split(':')
-  // Ignore wd or isbn entities
-  if (prefix !== 'inv') return
-
-  let results = await entities_.byClaimsValue(entityUri)
-  results = results.filter(result => result.entity !== fromId)
-  if (results.length === 0) return placeholders_.remove(userId, entityId)
 }

--- a/server/controllers/entities/lib/merge_entities.js
+++ b/server/controllers/entities/lib/merge_entities.js
@@ -7,7 +7,7 @@ const Entity = __.require('models', 'entity')
 const turnIntoRedirection = require('./turn_into_redirection')
 const getInvEntityCanonicalUri = require('./get_inv_entity_canonical_uri')
 
-module.exports = (userId, fromUri, toUri) => {
+module.exports = ({ userId, fromUri, toUri }) => {
   let [ fromPrefix, fromId ] = fromUri.split(':')
   let [ toPrefix, toId ] = toUri.split(':')
 
@@ -26,11 +26,11 @@ module.exports = (userId, fromUri, toUri) => {
   } else {
     // TODO: invert fromId and toId if the merged entity is more popular
     // to reduce the amount of documents that need to be updated
-    return mergeEntities(userId, fromId, toId)
+    return mergeInvEntities(userId, fromId, toId)
   }
 }
 
-const mergeEntities = async (userId, fromId, toId) => {
+const mergeInvEntities = async (userId, fromId, toId) => {
   assert_.strings([ userId, fromId, toId ])
 
   // Fetching non-formmatted docs

--- a/server/controllers/entities/lib/merge_entities.js
+++ b/server/controllers/entities/lib/merge_entities.js
@@ -22,7 +22,7 @@ module.exports = ({ userId, fromUri, toUri }) => {
 
   if (toPrefix === 'wd') {
     // no merge to do for Wikidata entities, simply creating a redirection
-    return turnIntoRedirection(userId, fromId, toUri)
+    return turnIntoRedirection({ userId, fromId, toUri })
   } else {
     // TODO: invert fromId and toId if the merged entity is more popular
     // to reduce the amount of documents that need to be updated
@@ -64,7 +64,7 @@ const mergeInvEntities = async (userId, fromId, toId) => {
   }
 
   // Refresh the URI in case an ISBN was transfered and the URI changed
-  const newToUri = getInvEntityCanonicalUri(toEntityDocAfterMerge)
+  const toUri = getInvEntityCanonicalUri(toEntityDocAfterMerge)
 
-  return turnIntoRedirection(userId, fromId, newToUri, previousToUri)
+  return turnIntoRedirection({ userId, fromId, toUri, previousToUri })
 }

--- a/server/controllers/entities/lib/move_to_wikidata.js
+++ b/server/controllers/entities/lib/move_to_wikidata.js
@@ -15,7 +15,7 @@ module.exports = async (user, invEntityUri) => {
   const { labels, claims } = entity
   const { uri: wdEntityUri } = await createWdEntity({ labels, claims, user, isAlreadyValidated: true })
 
-  await mergeEntities(reqUserId, invEntityUri, wdEntityUri)
+  await mergeEntities({ userId: reqUserId, fromUri: invEntityUri, toUri: wdEntityUri })
 
   return { uri: wdEntityUri }
 }

--- a/server/controllers/entities/lib/move_to_wikidata.js
+++ b/server/controllers/entities/lib/move_to_wikidata.js
@@ -5,24 +5,25 @@ const mergeEntities = require('./merge_entities')
 const { unprefixify } = require('./prefix')
 const createWdEntity = require('./create_wd_entity')
 
-module.exports = (user, invEntityUri) => {
+module.exports = async (user, invEntityUri) => {
   const { _id: reqUserId } = user
 
   const entityId = unprefixify(invEntityUri)
 
-  return entities_.byId(entityId)
-  .catch(err => {
-    if (err.statusCode === 404) {
-      throw error_.new('entity not found', 400, { invEntityUri })
-    }
-  })
-  .then(entity => {
-    const { labels, claims } = entity
-    return createWdEntity({ labels, claims, user, isAlreadyValidated: true })
-  })
-  .then(createdEntity => {
-    const { uri: wdEntityUri } = createdEntity
-    return mergeEntities(reqUserId, invEntityUri, wdEntityUri)
-    .then(() => ({ uri: wdEntityUri }))
-  })
+  const entity = await entities_.byId(entityId).catch(rewrite404(invEntityUri))
+
+  const { labels, claims } = entity
+  const { uri: wdEntityUri } = await createWdEntity({ labels, claims, user, isAlreadyValidated: true })
+
+  await mergeEntities(reqUserId, invEntityUri, wdEntityUri)
+
+  return { uri: wdEntityUri }
+}
+
+const rewrite404 = invEntityUri => err => {
+  if (err.statusCode === 404) {
+    throw error_.new('entity not found', 400, { invEntityUri })
+  } else {
+    throw err
+  }
 }

--- a/server/controllers/entities/lib/move_to_wikidata.js
+++ b/server/controllers/entities/lib/move_to_wikidata.js
@@ -2,6 +2,7 @@ const __ = require('config').universalPath
 const error_ = __.require('lib', 'error/error')
 const entities_ = require('./entities')
 const mergeEntities = require('./merge_entities')
+const { cacheEntityRelations } = require('./temporarily_cache_relations')
 const { unprefixify } = require('./prefix')
 const createWdEntity = require('./create_wd_entity')
 
@@ -14,6 +15,11 @@ module.exports = async (user, invEntityUri) => {
 
   const { labels, claims } = entity
   const { uri: wdEntityUri } = await createWdEntity({ labels, claims, user, isAlreadyValidated: true })
+
+  // Caching relations for some hours, as Wikidata Query Service can take some time to update,
+  // at the very minimum some minutes, during which the data contributor might be confused
+  // by the absence of the entity they just moved to Wikidata in lists generated with the help of the WQS
+  await cacheEntityRelations(invEntityUri)
 
   await mergeEntities({ userId: reqUserId, fromUri: invEntityUri, toUri: wdEntityUri })
 

--- a/server/controllers/entities/lib/prefix.js
+++ b/server/controllers/entities/lib/prefix.js
@@ -22,14 +22,9 @@ const prefixifyIsbn = isbn => prefixify(isbn_.normalizeIsbn(isbn), 'isbn')
 
 const unprefixify = uri => uri.split(':')[1]
 
-const dropPrefix = value => {
-  if (_.isEntityUri(value)) return unprefixify(value)
-  else return value
-}
-
 const getInvEntityUri = entity => {
   const { _id } = entity
   if (_id != null) return `inv:${_id}`
 }
 
-module.exports = { prefixify, Prefixify, unprefixify, dropPrefix, prefixifyWd, prefixifyInv, prefixifyIsbn, getInvEntityUri }
+module.exports = { prefixify, Prefixify, unprefixify, prefixifyWd, prefixifyInv, prefixifyIsbn, getInvEntityUri }

--- a/server/controllers/entities/lib/prefix.js
+++ b/server/controllers/entities/lib/prefix.js
@@ -22,9 +22,14 @@ const prefixifyIsbn = isbn => prefixify(isbn_.normalizeIsbn(isbn), 'isbn')
 
 const unprefixify = uri => uri.split(':')[1]
 
+const dropPrefix = value => {
+  if (_.isEntityUri(value)) return unprefixify(value)
+  else return value
+}
+
 const getInvEntityUri = entity => {
   const { _id } = entity
   if (_id != null) return `inv:${_id}`
 }
 
-module.exports = { prefixify, Prefixify, unprefixify, prefixifyWd, prefixifyInv, prefixifyIsbn, getInvEntityUri }
+module.exports = { prefixify, Prefixify, unprefixify, dropPrefix, prefixifyWd, prefixifyInv, prefixifyIsbn, getInvEntityUri }

--- a/server/controllers/entities/lib/temporarily_cache_relations.js
+++ b/server/controllers/entities/lib/temporarily_cache_relations.js
@@ -15,8 +15,8 @@ const cacheEntityRelations = async invEntityUri => {
 
   for (const property of cachedRelationProperties) {
     if (claims[property]) {
-      for (const value of claims[property]) {
-        const promise = entitiesRelationsTemporaryCache.set(invEntityUri, property, value)
+      for (const valueUri of claims[property]) {
+        const promise = entitiesRelationsTemporaryCache.set(invEntityUri, property, valueUri)
         promises.push(promise)
       }
     }
@@ -25,8 +25,8 @@ const cacheEntityRelations = async invEntityUri => {
   return Promise.all(promises)
 }
 
-const getCachedRelations = async (uri, property, formatEntity) => {
-  const uris = await entitiesRelationsTemporaryCache.get(property, uri)
+const getCachedRelations = async (valueUri, property, formatEntity) => {
+  const uris = await entitiesRelationsTemporaryCache.get(property, valueUri)
   const entities = await getEntitiesList(uris)
   return entities.map(formatEntity)
 }

--- a/server/controllers/entities/lib/temporarily_cache_relations.js
+++ b/server/controllers/entities/lib/temporarily_cache_relations.js
@@ -1,0 +1,26 @@
+const entities_ = require('./entities')
+const { unprefixify } = require('./prefix')
+const entitiesRelationsTemporaryCache = require('./entities_relations_temporary_cache')
+const relationProperties = [
+  'wdt:P50',
+  'wdt:P179'
+]
+
+module.exports = async invEntityUri => {
+  const id = unprefixify(invEntityUri)
+
+  const { claims } = await entities_.byId(id)
+  const promises = []
+
+  for (const property of relationProperties) {
+    if (claims[property]) {
+      for (const value of claims[property]) {
+        console.log({ invEntityUri, property, value })
+        const promise = entitiesRelationsTemporaryCache.set(invEntityUri, property, value)
+        promises.push(promise)
+      }
+    }
+  }
+
+  return Promise.all(promises)
+}

--- a/server/controllers/entities/lib/temporarily_cache_relations.js
+++ b/server/controllers/entities/lib/temporarily_cache_relations.js
@@ -2,7 +2,7 @@ const entities_ = require('./entities')
 const { unprefixify } = require('./prefix')
 const getEntitiesList = require('./get_entities_list')
 const entitiesRelationsTemporaryCache = require('./entities_relations_temporary_cache')
-const relationProperties = [
+const cachedRelationProperties = [
   'wdt:P50',
   'wdt:P179'
 ]
@@ -13,7 +13,7 @@ const cacheEntityRelations = async invEntityUri => {
   const { claims } = await entities_.byId(id)
   const promises = []
 
-  for (const property of relationProperties) {
+  for (const property of cachedRelationProperties) {
     if (claims[property]) {
       for (const value of claims[property]) {
         const promise = entitiesRelationsTemporaryCache.set(invEntityUri, property, value)
@@ -31,4 +31,4 @@ const getCachedRelations = async (uri, property, formatEntity) => {
   return entities.map(formatEntity)
 }
 
-module.exports = { cacheEntityRelations, getCachedRelations }
+module.exports = { cacheEntityRelations, getCachedRelations, cachedRelationProperties }

--- a/server/controllers/entities/lib/temporarily_cache_relations.js
+++ b/server/controllers/entities/lib/temporarily_cache_relations.js
@@ -1,12 +1,13 @@
 const entities_ = require('./entities')
 const { unprefixify } = require('./prefix')
+const getEntitiesList = require('./get_entities_list')
 const entitiesRelationsTemporaryCache = require('./entities_relations_temporary_cache')
 const relationProperties = [
   'wdt:P50',
   'wdt:P179'
 ]
 
-module.exports = async invEntityUri => {
+const cacheEntityRelations = async invEntityUri => {
   const id = unprefixify(invEntityUri)
 
   const { claims } = await entities_.byId(id)
@@ -15,7 +16,6 @@ module.exports = async invEntityUri => {
   for (const property of relationProperties) {
     if (claims[property]) {
       for (const value of claims[property]) {
-        console.log({ invEntityUri, property, value })
         const promise = entitiesRelationsTemporaryCache.set(invEntityUri, property, value)
         promises.push(promise)
       }
@@ -24,3 +24,11 @@ module.exports = async invEntityUri => {
 
   return Promise.all(promises)
 }
+
+const getCachedRelations = async (uri, property, formatEntity) => {
+  const uris = await entitiesRelationsTemporaryCache.get(property, uri)
+  const entities = await getEntitiesList(uris)
+  return entities.map(formatEntity)
+}
+
+module.exports = { cacheEntityRelations, getCachedRelations }

--- a/server/controllers/entities/lib/turn_into_redirection.js
+++ b/server/controllers/entities/lib/turn_into_redirection.js
@@ -1,0 +1,68 @@
+const __ = require('config').universalPath
+const _ = __.require('builders', 'utils')
+const assert_ = __.require('utils', 'assert_types')
+const entities_ = require('./entities')
+const Entity = __.require('models', 'entity')
+const placeholders_ = require('./placeholders')
+const propagateRedirection = require('./propagate_redirection')
+
+module.exports = (userId, fromId, toUri, previousToUri) => {
+  assert_.strings([ userId, fromId, toUri ])
+  if (previousToUri != null) { assert_.string(previousToUri) }
+
+  const fromUri = `inv:${fromId}`
+
+  return entities_.byId(fromId)
+  .then(currentFromDoc => {
+    Entity.preventRedirectionEdit(currentFromDoc, 'turnIntoRedirection')
+    // If an author has no more links to it, remove it
+    return removeObsoletePlaceholderEntities(userId, currentFromDoc)
+    .then(removedIds => {
+      const updatedFromDoc = Entity.turnIntoRedirection(currentFromDoc, toUri, removedIds)
+      return entities_.putUpdate({
+        userId,
+        currentDoc: currentFromDoc,
+        updatedDoc: updatedFromDoc
+      })
+    })
+  })
+  .then(propagateRedirection.bind(null, userId, fromUri, toUri, previousToUri))
+}
+
+// Removing the entities that were needed only by the entity about to be turned
+// into a redirection: this entity now don't have anymore reason to be and is quite
+// probably a duplicate of an existing entity referenced by the redirection
+// destination entity.
+const removeObsoletePlaceholderEntities = (userId, entityDocBeforeRedirection) => {
+  const entityUrisToCheck = getEntityUrisToCheck(entityDocBeforeRedirection.claims)
+  _.log(entityUrisToCheck, 'entityUrisToCheck')
+  const fromId = entityDocBeforeRedirection._id
+  return Promise.all(entityUrisToCheck.map(deleteIfIsolated(userId, fromId)))
+  // Returning removed docs ids
+  .then(_.compact)
+}
+
+const getEntityUrisToCheck = claims => {
+  return _(claims)
+  .pick(propertiesToCheckForPlaceholderDeletion)
+  .values()
+  // Merge properties arrays
+  .flatten()
+  .uniq()
+  .value()
+}
+
+const propertiesToCheckForPlaceholderDeletion = [
+  // author
+  'wdt:P50'
+]
+
+const deleteIfIsolated = (userId, fromId) => async entityUri => {
+  const [ prefix, entityId ] = entityUri.split(':')
+  // Ignore wd or isbn entities
+  if (prefix !== 'inv') return
+
+  let results = await entities_.byClaimsValue(entityUri)
+  results = results.filter(result => result.entity !== fromId)
+  if (results.length === 0) return placeholders_.remove(userId, entityId)
+}

--- a/server/controllers/entities/lib/turn_into_redirection.js
+++ b/server/controllers/entities/lib/turn_into_redirection.js
@@ -6,9 +6,9 @@ const Entity = __.require('models', 'entity')
 const placeholders_ = require('./placeholders')
 const propagateRedirection = require('./propagate_redirection')
 
-module.exports = async (userId, fromId, toUri, previousToUri) => {
+module.exports = async ({ userId, fromId, toUri, previousToUri }) => {
   assert_.strings([ userId, fromId, toUri ])
-  if (previousToUri != null) { assert_.string(previousToUri) }
+  if (previousToUri != null) assert_.string(previousToUri)
 
   const fromUri = `inv:${fromId}`
 

--- a/server/controllers/entities/lib/update_wd_claim.js
+++ b/server/controllers/entities/lib/update_wd_claim.js
@@ -9,17 +9,19 @@ const wdOauth = require('./wikidata_oauth')
 const properties = require('./properties/properties_values_constraints')
 const entitiesRelationsTemporaryCache = require('./entities_relations_temporary_cache')
 const { cachedRelationProperties } = require('./temporarily_cache_relations')
-const { dropPrefix, prefixifyWd } = require('./prefix')
+const { unprefixify, prefixifyWd } = require('./prefix')
 
 module.exports = async (user, id, property, oldValue, newValue) => {
   wdOauth.validate(user)
 
-  if ((properties[property].datatype === 'entity') && _.isInvEntityUri(newValue)) {
-    throw error_.new("wikidata entities can't link to inventaire entities", 400)
-  }
+  if ((properties[property].datatype === 'entity')) {
+    if (_.isInvEntityUri(newValue)) {
+      throw error_.new("wikidata entities can't link to inventaire entities", 400)
+    }
 
-  oldValue = dropPrefix(oldValue)
-  newValue = dropPrefix(newValue)
+    oldValue = unprefixify(oldValue)
+    newValue = unprefixify(newValue)
+  }
 
   const [ propertyPrefix, propertyId ] = property.split(':')
 

--- a/server/controllers/entities/lib/update_wd_claim.js
+++ b/server/controllers/entities/lib/update_wd_claim.js
@@ -7,6 +7,9 @@ const wdk = require('wikidata-sdk')
 const wdEdit = __.require('lib', 'wikidata/edit')
 const wdOauth = require('./wikidata_oauth')
 const properties = require('./properties/properties_values_constraints')
+const entitiesRelationsTemporaryCache = require('./entities_relations_temporary_cache')
+const { cachedRelationProperties } = require('./temporarily_cache_relations')
+const { dropPrefix, prefixifyWd } = require('./prefix')
 
 module.exports = async (user, id, property, oldValue, newValue) => {
   wdOauth.validate(user)
@@ -26,16 +29,26 @@ module.exports = async (user, id, property, oldValue, newValue) => {
 
   const credentials = wdOauth.getOauthCredentials(user)
 
+  let res
+
   if (newValue) {
     if (oldValue) {
-      return wdEdit.claim.update({ id, property: propertyId, oldValue, newValue }, { credentials })
+      res = await wdEdit.claim.update({ id, property: propertyId, oldValue, newValue }, { credentials })
     } else {
-      return wdEdit.claim.create({ id, property: propertyId, value: newValue }, { credentials })
+      res = await wdEdit.claim.create({ id, property: propertyId, value: newValue }, { credentials })
     }
   } else {
     const guid = await getClaimGuid(id, propertyId, oldValue)
-    return wdEdit.claim.remove({ guid }, { credentials })
+    res = await wdEdit.claim.remove({ guid }, { credentials })
   }
+
+  if (cachedRelationProperties.includes(property)) {
+    const uri = prefixifyWd(id)
+    if (newValue != null) await entitiesRelationsTemporaryCache.set(uri, property, newValue)
+    if (oldValue != null) await entitiesRelationsTemporaryCache.del(uri, property, oldValue)
+  }
+
+  return res
 }
 
 const getClaimGuid = async (id, propertyId, oldVal) => {
@@ -45,12 +58,4 @@ const getClaimGuid = async (id, propertyId, oldVal) => {
   const oldValIndex = simplifyPropClaims.indexOf(oldVal)
   const targetClaim = propClaims[oldValIndex]
   return targetClaim.id
-}
-
-const dropPrefix = value => {
-  if (_.isEntityUri(value)) {
-    return value.replace('wd:', '')
-  } else {
-    return value
-  }
 }

--- a/server/controllers/entities/merge.js
+++ b/server/controllers/entities/merge.js
@@ -108,7 +108,7 @@ const merge = (reqUserId, fromUri, toUri) => entities => {
   fromUri = replaceIsbnUriByInvUri(fromUri, fromEntity._id)
   toUri = replaceIsbnUriByInvUri(toUri, toEntity._id)
 
-  return mergeEntities(reqUserId, fromUri, toUri)
+  return mergeEntities({ userId: reqUserId, fromUri, toUri })
 }
 
 const replaceIsbnUriByInvUri = (uri, invId) => {

--- a/server/controllers/tasks/lib/automerge.js
+++ b/server/controllers/tasks/lib/automerge.js
@@ -15,7 +15,7 @@ module.exports = (suspectUri, suggestion) => {
 
   _.log({ suspectUri, suggestionUri }, 'automerging')
 
-  return mergeEntities(reconcilerUserId, suspectUri, suggestionUri)
+  return mergeEntities({ userId: reconcilerUserId, fromUri: suspectUri, toUri: suggestionUri })
   // Give the time to CouchDB to update its views so that the works
   // of the merged author are correctly found
   .then(Wait(100))

--- a/server/controllers/tasks/lib/automerge_author_works.js
+++ b/server/controllers/tasks/lib/automerge_author_works.js
@@ -62,7 +62,8 @@ const automergeWorks = authorUri => mergeableCouples => {
   const mergeNext = () => {
     const nextCouple = mergeableCouples.pop()
     if (nextCouple == null) return
-    return mergeEntities(reconcilerUserId, ...nextCouple)
+    const [ fromUri, toUri ] = nextCouple
+    return mergeEntities({ userId: reconcilerUserId, fromUri, toUri })
     .then(mergeNext)
   }
 

--- a/server/db/level/get_sub_db.js
+++ b/server/db/level/get_sub_db.js
@@ -32,7 +32,7 @@ const leveldownOptions = {
 
 let globalDb
 if (CONFIG.leveldbMemoryBackend) {
-  _.info('leveldb in memory')
+  _.warn('leveldb in memory')
   const level = require('level-test')()
   globalDb = level()
 } else {

--- a/server/lib/boolean_validations.js
+++ b/server/lib/boolean_validations.js
@@ -38,13 +38,13 @@ const tests = module.exports = {
   isUsername: bindedTest('Username'),
   isEntityUri: bindedTest('EntityUri'),
   isPatchId: bindedTest('PatchId'),
+  isPropertyUri: bindedTest('PropertyUri'),
   isExtendedEntityUri: uri => {
     const [ prefix, id ] = uri.split(':')
     // Accept alias URIs.
     // Ex: twitter:Bouletcorp -> wd:Q1524522
     return isNonEmptyString(prefix) && isNonEmptyString(id)
   },
-  isPropertyUri: bindedTest('PropertyUri'),
   isSimpleDay: str => {
     let isValidDate = false
     try {

--- a/server/lib/wikidata/aliases.js
+++ b/server/lib/wikidata/aliases.js
@@ -1,3 +1,6 @@
+const __ = require('config').universalPath
+const error_ = __.require('lib', 'error/error')
+
 // TODO: replace this list by a SPARQL generated list
 // that can be refreshed from time to time
 const typesAliases = module.exports = {
@@ -133,6 +136,12 @@ for (let type in typesAliases) {
 
 const typesNames = Object.keys(typesAliases)
 
+const getTypePluralName = singularType => {
+  const pluralizedType = singularType + 's'
+  if (!typesAliases[pluralizedType]) throw error_.new('invalid type', { singularType })
+  return pluralizedType
+}
+
 const getTypePluralNameByTypeUri = uri => types[uri] ? `${types[uri]}s` : null
 
-module.exports = { types, typesNames, getTypePluralNameByTypeUri }
+module.exports = { types, typesNames, getTypePluralName, getTypePluralNameByTypeUri }

--- a/tests/api/entities/get_by_uris.test.js
+++ b/tests/api/entities/get_by_uris.test.js
@@ -1,6 +1,6 @@
 const should = require('should')
 const { undesiredRes } = require('../utils/utils')
-const { createEditionWithIsbn, createWorkWithAuthor, createEditionWithWorkAuthorAndSerie, createHuman } = require('../fixtures/entities')
+const { createEditionWithIsbn, createWorkWithAuthor, createEditionWithWorkAuthorAndSerie, createHuman, someFakeUri } = require('../fixtures/entities')
 const { getByUris, merge } = require('../utils/entities')
 const workWithAuthorPromise = createWorkWithAuthor()
 
@@ -42,9 +42,8 @@ describe('entities:get:by-uris', () => {
   })
 
   it('should return uris not found', async () => {
-    const fakeUri = 'inv:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-    const { notFound } = await getByUris(fakeUri)
-    notFound.should.deepEqual([ fakeUri ])
+    const { notFound } = await getByUris(someFakeUri)
+    notFound.should.deepEqual([ someFakeUri ])
   })
 
   it('should return redirected uris', async () => {

--- a/tests/api/entities/merge.test.js
+++ b/tests/api/entities/merge.test.js
@@ -5,7 +5,7 @@ const { authReq, dataadminReq, undesiredRes, shouldNotBeCalled } = require('../u
 const randomString = __.require('lib', './utils/random_string')
 const { getByUris, merge, getHistory, addClaim } = require('../utils/entities')
 const { getByIds: getItemsByIds } = require('../utils/items')
-const { createWork, createHuman, createEdition, createEditionWithIsbn, createItemFromEntityUri, createWorkWithAuthor } = require('../fixtures/entities')
+const { createWork, createHuman, createEdition, createEditionWithIsbn, createItemFromEntityUri, createWorkWithAuthor, someFakeUri } = require('../fixtures/entities')
 
 describe('entities:merge', () => {
   it('should require dataadmin rights', async () => {
@@ -26,7 +26,7 @@ describe('entities:merge', () => {
   })
 
   it('should reject without to uri', async () => {
-    await dataadminReq('put', '/api/entities?action=merge', { from: 'inv:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' })
+    await dataadminReq('put', '/api/entities?action=merge', { from: someFakeUri })
     .then(shouldNotBeCalled)
     .catch(err => {
       err.body.status_verbose.should.equal('missing parameter in body: to')
@@ -44,8 +44,7 @@ describe('entities:merge', () => {
   })
 
   it('should reject invalid from prefix', async () => {
-    const fakeUri = 'inv:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-    await dataadminReq('put', '/api/entities?action=merge', { from: 'wd:Q42', to: fakeUri })
+    await dataadminReq('put', '/api/entities?action=merge', { from: 'wd:Q42', to: someFakeUri })
     .then(shouldNotBeCalled)
     .catch(err => {
       err.body.status_verbose.should.startWith("invalid 'from' uri domain: wd. Accepted domains: inv,isbn")
@@ -54,8 +53,7 @@ describe('entities:merge', () => {
   })
 
   it('should return uris not found', async () => {
-    const fakeUri = 'inv:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-    await dataadminReq('put', '/api/entities?action=merge', { from: fakeUri, to: 'wd:Q42' })
+    await dataadminReq('put', '/api/entities?action=merge', { from: someFakeUri, to: 'wd:Q42' })
     .then(shouldNotBeCalled)
     .catch(err => {
       err.body.status_verbose.should.equal("'from' entity not found")

--- a/tests/api/entities/move_to_wikidata.test.js
+++ b/tests/api/entities/move_to_wikidata.test.js
@@ -36,6 +36,6 @@ describe('entities:move-to-wikidata', () => {
       err.statusCode.should.equal(400)
       done()
     })
-  .catch(done)
+    .catch(done)
   })
 })

--- a/tests/api/entities/temporarily_cache_relations.test.js
+++ b/tests/api/entities/temporarily_cache_relations.test.js
@@ -10,8 +10,16 @@ const { wait } = __.require('lib', 'promises')
 // so the following tests try to reproduce conditions as close as possible to the real use-cases
 const { cacheEntityRelations } = __.require('controllers', 'entities/lib/temporarily_cache_relations')
 
+const assertLeveldbDiskBackend = () => {
+  if (CONFIG.leveldbMemoryBackend) {
+    throw new Error(`this test requires ${CONFIG.env} config to have CONFIG.leveldbMemoryBackend=false`)
+  }
+}
+
 describe('temporarily cache relations', () => {
-  it('should preserve an author relation', async () => {
+  // Test dependency: CONFIG.leveldbMemoryBackend=false
+  xit('should preserve an author relation', async () => {
+    assertLeveldbDiskBackend()
     const someAuthorUri = 'wd:Q1345582'
     const someUnrelatedWorkUri = 'wd:Q176470'
     const workWithAuthor = await createWorkWithAuthor({ uri: someAuthorUri })
@@ -31,7 +39,9 @@ describe('temporarily cache relations', () => {
     foundWork.serie.should.equal(newWork.claims['wdt:P179'][0])
   })
 
-  it('should preserve a serie relation', async () => {
+  // Test dependency: CONFIG.leveldbMemoryBackend=false
+  xit('should preserve a serie relation', async () => {
+    assertLeveldbDiskBackend()
     const someSerieUri = 'wd:Q3656893'
     const someUnrelatedWorkUri = 'wd:Q187655'
     const workWithSerie = await createWorkWithSerie({ uri: someSerieUri })

--- a/tests/api/entities/temporarily_cache_relations.test.js
+++ b/tests/api/entities/temporarily_cache_relations.test.js
@@ -1,28 +1,53 @@
 const CONFIG = require('config')
 const __ = CONFIG.universalPath
 require('should')
-const { createWorkWithAuthor } = require('../fixtures/entities')
+const { createWorkWithAuthor, createWorkWithSerie } = require('../fixtures/entities')
 const { getByUri, merge } = require('../utils/entities')
 const { nonAuthReq } = require('../utils/utils')
 const { wait } = __.require('lib', 'promises')
 
-const temporarilyCacheRelations = __.require('controllers', 'entities/lib/temporarily_cache_relations')
+// We are calling directly cacheEntityRelations, as the cases that use it would require to edit Wikidata,
+// so the following tests try to reproduce conditions as close as possible to the real use-cases
+const { cacheEntityRelations } = __.require('controllers', 'entities/lib/temporarily_cache_relations')
 
 describe('temporarily cache relations', () => {
   it('should preserve an author relation', async () => {
-    const workWithAuthor = await createWorkWithAuthor({ uri: 'wd:Q1345582' })
+    const someAuthorUri = 'wd:Q1345582'
+    const someUnrelatedWorkUri = 'wd:Q176470'
+    const workWithAuthor = await createWorkWithAuthor({ uri: someAuthorUri })
     const { uri } = workWithAuthor
     const authorUri = workWithAuthor.claims['wdt:P50'][0]
-    await temporarilyCacheRelations(uri)
+    await cacheEntityRelations(uri)
     // Merge with a work entity that doesn't have wdt:P50=wd:Q1345582
-    const newWorkUri = 'wd:Q176470'
-    await merge(uri, newWorkUri)
+    await merge(uri, someUnrelatedWorkUri)
     // Give some extra time to CouchDB to update its view
     await wait(500)
     const { works } = await nonAuthReq('get', `/api/entities?action=author-works&uri=${authorUri}`)
-    const foundWork = works.find(work => work.uri === newWorkUri)
-    const newWork = await getByUri(newWorkUri)
+    const foundWork = works.find(work => work.uri === someUnrelatedWorkUri)
+    const newWork = await getByUri(someUnrelatedWorkUri)
     foundWork.date.should.equal(newWork.claims['wdt:P577'][0])
     foundWork.serie.should.equal(newWork.claims['wdt:P179'][0])
+  })
+
+  it('should preserve a serie relation', async () => {
+    const someSerieUri = 'wd:Q3656893'
+    const someUnrelatedWorkUri = 'wd:Q187655'
+    const workWithSerie = await createWorkWithSerie({ uri: someSerieUri })
+    const { uri } = workWithSerie
+    const serieUri = workWithSerie.claims['wdt:P179'][0]
+    await cacheEntityRelations(uri)
+    // Merge with a work entity that doesn't have wdt:P179=wd:Q3656893
+    await merge(uri, someUnrelatedWorkUri)
+    // Give some extra time to CouchDB to update its view
+    await wait(500)
+    const { parts } = await nonAuthReq('get', `/api/entities?action=serie-parts&uri=${serieUri}`)
+    const foundWork = parts.find(work => work.uri === someUnrelatedWorkUri)
+    const newWork = await getByUri(someUnrelatedWorkUri)
+    foundWork.date.should.equal(newWork.claims['wdt:P577'][0])
+    // It's is likely that, due to the preference for P1545 as qualifiers on Wikidata,
+    // this assertion will fail at some point in the future, thus the 'if'
+    if (newWork.claims['wdt:P1545'][0]) {
+      foundWork.ordinal.should.equal(newWork.claims['wdt:P1545'][0])
+    }
   })
 })

--- a/tests/api/entities/temporarily_cache_relations.test.js
+++ b/tests/api/entities/temporarily_cache_relations.test.js
@@ -3,7 +3,7 @@ const __ = CONFIG.universalPath
 require('should')
 const { createWorkWithAuthor, createWorkWithSerie } = require('../fixtures/entities')
 const { getByUri, merge } = require('../utils/entities')
-const { nonAuthReq } = require('../utils/utils')
+const { publicReq } = require('../utils/utils')
 const { wait } = __.require('lib', 'promises')
 
 // We are calling directly cacheEntityRelations, as the cases that use it would require to edit Wikidata,
@@ -22,7 +22,7 @@ describe('temporarily cache relations', () => {
     await merge(uri, someUnrelatedWorkUri)
     // Give some extra time to CouchDB to update its view
     await wait(500)
-    const { works } = await nonAuthReq('get', `/api/entities?action=author-works&uri=${authorUri}`)
+    const { works } = await publicReq('get', `/api/entities?action=author-works&uri=${authorUri}`)
     const matchingWorks = works.filter(work => work.uri === someUnrelatedWorkUri)
     matchingWorks.length.should.equal(1)
     const foundWork = matchingWorks[0]
@@ -42,7 +42,7 @@ describe('temporarily cache relations', () => {
     await merge(uri, someUnrelatedWorkUri)
     // Give some extra time to CouchDB to update its view
     await wait(500)
-    const { parts } = await nonAuthReq('get', `/api/entities?action=serie-parts&uri=${serieUri}`)
+    const { parts } = await publicReq('get', `/api/entities?action=serie-parts&uri=${serieUri}`)
     const matchingWorks = parts.filter(work => work.uri === someUnrelatedWorkUri)
     matchingWorks.length.should.equal(1)
     const foundWork = matchingWorks[0]

--- a/tests/api/entities/temporarily_cache_relations.test.js
+++ b/tests/api/entities/temporarily_cache_relations.test.js
@@ -23,7 +23,9 @@ describe('temporarily cache relations', () => {
     // Give some extra time to CouchDB to update its view
     await wait(500)
     const { works } = await nonAuthReq('get', `/api/entities?action=author-works&uri=${authorUri}`)
-    const foundWork = works.find(work => work.uri === someUnrelatedWorkUri)
+    const matchingWorks = works.filter(work => work.uri === someUnrelatedWorkUri)
+    matchingWorks.length.should.equal(1)
+    const foundWork = matchingWorks[0]
     const newWork = await getByUri(someUnrelatedWorkUri)
     foundWork.date.should.equal(newWork.claims['wdt:P577'][0])
     foundWork.serie.should.equal(newWork.claims['wdt:P179'][0])
@@ -41,7 +43,9 @@ describe('temporarily cache relations', () => {
     // Give some extra time to CouchDB to update its view
     await wait(500)
     const { parts } = await nonAuthReq('get', `/api/entities?action=serie-parts&uri=${serieUri}`)
-    const foundWork = parts.find(work => work.uri === someUnrelatedWorkUri)
+    const matchingWorks = parts.filter(work => work.uri === someUnrelatedWorkUri)
+    matchingWorks.length.should.equal(1)
+    const foundWork = matchingWorks[0]
     const newWork = await getByUri(someUnrelatedWorkUri)
     foundWork.date.should.equal(newWork.claims['wdt:P577'][0])
     // It's is likely that, due to the preference for P1545 as qualifiers on Wikidata,

--- a/tests/api/entities/temporarily_cache_relations.test.js
+++ b/tests/api/entities/temporarily_cache_relations.test.js
@@ -1,0 +1,28 @@
+const CONFIG = require('config')
+const __ = CONFIG.universalPath
+require('should')
+const { createWorkWithAuthor } = require('../fixtures/entities')
+const { getByUri, merge } = require('../utils/entities')
+const { nonAuthReq } = require('../utils/utils')
+const { wait } = __.require('lib', 'promises')
+
+const temporarilyCacheRelations = __.require('controllers', 'entities/lib/temporarily_cache_relations')
+
+describe('temporarily cache relations', () => {
+  it('should preserve an author relation', async () => {
+    const workWithAuthor = await createWorkWithAuthor({ uri: 'wd:Q1345582' })
+    const { uri } = workWithAuthor
+    const authorUri = workWithAuthor.claims['wdt:P50'][0]
+    await temporarilyCacheRelations(uri)
+    // Merge with a work entity that doesn't have wdt:P50=wd:Q1345582
+    const newWorkUri = 'wd:Q176470'
+    await merge(uri, newWorkUri)
+    // Give some extra time to CouchDB to update its view
+    await wait(500)
+    const { works } = await nonAuthReq('get', `/api/entities?action=author-works&uri=${authorUri}`)
+    const foundWork = works.find(work => work.uri === newWorkUri)
+    const newWork = await getByUri(newWorkUri)
+    foundWork.date.should.equal(newWork.claims['wdt:P577'][0])
+    foundWork.serie.should.equal(newWork.claims['wdt:P179'][0])
+  })
+})

--- a/tests/api/entities/update_claims.test.js
+++ b/tests/api/entities/update_claims.test.js
@@ -3,7 +3,7 @@ const __ = CONFIG.universalPath
 const should = require('should')
 const { tap } = __.require('lib', 'promises')
 const { undesiredRes } = require('../utils/utils')
-const { createWork, createEdition, createHuman, someOpenLibraryId } = require('../fixtures/entities')
+const { createWork, createEdition, createHuman, someOpenLibraryId, someFakeUri } = require('../fixtures/entities')
 const { getByUri, addClaim, updateClaim, removeClaim, merge } = require('../utils/entities')
 
 describe('entities:update-claims', () => {
@@ -19,8 +19,7 @@ describe('entities:update-claims', () => {
   })
 
   it('should reject without property', done => {
-    const uri = 'inv:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-    updateClaim(uri)
+    updateClaim(someFakeUri)
     .then(undesiredRes(done))
     .catch(err => {
       err.body.status_verbose.should.equal('missing parameter in body: property')
@@ -31,9 +30,8 @@ describe('entities:update-claims', () => {
   })
 
   it('should reject without old-value or new-value', done => {
-    const uri = 'inv:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
     const property = 'wdt:P1104'
-    updateClaim(uri, property)
+    updateClaim(someFakeUri, property)
     .then(undesiredRes(done))
     .catch(err => {
       err.body.status_verbose.should.equal('missing parameter in body: old-value or new-value')
@@ -58,10 +56,9 @@ describe('entities:update-claims', () => {
   })
 
   it('should reject unfound entity', done => {
-    const uri = 'inv:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
     const property = 'wdt:P1104'
     const oldValue = '1312'
-    updateClaim(uri, property, oldValue)
+    updateClaim(someFakeUri, property, oldValue)
     .then(undesiredRes(done))
     .catch(err => {
       err.body.status_verbose.should.equal('entity not found')

--- a/tests/api/fixtures/entities.js
+++ b/tests/api/fixtures/entities.js
@@ -123,6 +123,8 @@ const API = module.exports = {
     return authReq('post', '/api/items', Object.assign({}, data, { entity: uri }))
   },
 
+  someFakeUri: 'inv:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+
   someImageHash,
 
   someOpenLibraryId: (type = 'human') => {

--- a/tests/api/fixtures/entities.js
+++ b/tests/api/fixtures/entities.js
@@ -40,19 +40,6 @@ const API = module.exports = {
   }),
   randomLabel: (length = 5) => randomWords(length),
   humanName,
-  createWorkWithAuthor: async (human, label) => {
-    label = label || API.randomLabel()
-    const humanPromise = human ? Promise.resolve(human) : API.createHuman()
-
-    human = await humanPromise
-    return authReq('post', '/api/entities?action=create', {
-      labels: { en: label },
-      claims: {
-        'wdt:P31': [ 'wd:Q47461344' ],
-        'wdt:P50': [ human.uri ]
-      }
-    })
-  },
 
   createEdition: async (params = {}) => {
     const { work } = params
@@ -102,6 +89,27 @@ const API = module.exports = {
     return API.createEdition(params)
   },
 
+  createWorkWithAuthor: async (human, label) => {
+    label = label || API.randomLabel()
+    const humanPromise = human ? Promise.resolve(human) : API.createHuman()
+
+    human = await humanPromise
+    return authReq('post', '/api/entities?action=create', {
+      labels: { en: label },
+      claims: {
+        'wdt:P31': [ 'wd:Q47461344' ],
+        'wdt:P50': [ human.uri ]
+      }
+    })
+  },
+
+  createWorkWithSerie: async serie => {
+    const work = await API.createWork()
+    await API.addSerie(work, serie)
+    // Get a refreshed version of the work
+    return getByUri(work.uri)
+  },
+
   createWorkWithAuthorAndSerie: async () => {
     const work = await API.createWorkWithAuthor()
     await API.addSerie(work)
@@ -149,10 +157,17 @@ const API = module.exports = {
   generateIsbn13h: () => isbn_.toIsbn13h(API.generateIsbn13())
 }
 
-const addEntityClaim = (createFnName, property) => async subjectEntity => {
+const addEntityClaim = (createFnName, property) => async (subjectEntity, objectEntity) => {
   const subjectUri = _.isString(subjectEntity) ? subjectEntity : subjectEntity.uri
-  const entity = await API[createFnName]()
-  await addClaim(subjectUri, property, entity.uri)
+  let objectUri, entity
+  if (objectEntity) {
+    objectUri = _.isString(objectEntity) ? objectEntity : objectEntity.uri
+    entity = getByUri(objectUri)
+  } else {
+    entity = await API[createFnName]()
+    objectUri = entity.uri
+  }
+  await addClaim(subjectUri, property, objectUri)
   return entity
 }
 

--- a/tests/api/tasks/get.test.js
+++ b/tests/api/tasks/get.test.js
@@ -1,5 +1,5 @@
 require('should')
-const { createHuman } = require('../fixtures/entities')
+const { createHuman, someFakeUri } = require('../fixtures/entities')
 const { getByScore, getBySuspectUris, getBySuggestionUris, update } = require('../utils/tasks')
 const { createTask } = require('../fixtures/tasks')
 
@@ -86,13 +86,12 @@ describe('tasks:bySuspectUris', () => {
   })
 
   it('should return an array of tasks even when no tasks is found', done => {
-    const fakeUri = 'inv:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-    getBySuspectUris(fakeUri)
+    getBySuspectUris(someFakeUri)
     .then(tasks => {
       tasks.should.be.an.Object()
       Object.keys(tasks).length.should.equal(1)
-      tasks[fakeUri].should.be.an.Array()
-      tasks[fakeUri].length.should.equal(0)
+      tasks[someFakeUri].should.be.an.Array()
+      tasks[someFakeUri].length.should.equal(0)
       done()
     })
     .catch(done)

--- a/tests/integration/entities_relations_temporary_cache.js
+++ b/tests/integration/entities_relations_temporary_cache.js
@@ -1,0 +1,34 @@
+const CONFIG = require('config')
+const __ = CONFIG.universalPath
+const { wait } = __.require('lib', 'promises')
+require('should')
+const { checkFrequency, ttl } = CONFIG.entitiesRelationsTemporaryCache
+
+const { someFakeUri } = __.require('apiTests', 'fixtures/entities')
+const { get, set, del } = __.require('controllers', 'entities/lib/entities_relations_temporary_cache')
+
+const property = 'wdt:P50'
+const targetEntityUri = 'wd:Q1'
+
+describe('entities relations temporary cache', () => {
+  beforeEach(async () => {
+    await del(someFakeUri, property, targetEntityUri)
+  })
+
+  it('should store a relation', async () => {
+    await set(someFakeUri, property, targetEntityUri)
+    const subjects = await get(property, targetEntityUri)
+    subjects.should.containEql(someFakeUri)
+  })
+
+  it('should delete a relation after the ttl expired', async function () {
+    const delay = ttl + checkFrequency
+    this.timeout(5000 + delay)
+    await set(someFakeUri, property, targetEntityUri)
+    const subjects = await get(property, targetEntityUri)
+    subjects.should.containEql(someFakeUri)
+    await wait(delay)
+    const refreshedSubjects = await get(property, targetEntityUri)
+    refreshedSubjects.should.not.containEql(someFakeUri)
+  })
+})

--- a/tests/integration/entities_relations_temporary_cache.js
+++ b/tests/integration/entities_relations_temporary_cache.js
@@ -5,6 +5,7 @@ require('should')
 const { checkFrequency, ttl } = CONFIG.entitiesRelationsTemporaryCache
 
 const { someFakeUri } = __.require('apiTests', 'fixtures/entities')
+const { shouldNotBeCalled } = __.require('apiTests', 'utils/utils')
 const { get, set, del } = __.require('controllers', 'entities/lib/entities_relations_temporary_cache')
 
 const property = 'wdt:P50'
@@ -13,6 +14,33 @@ const targetEntityUri = 'wd:Q1'
 describe('entities relations temporary cache', () => {
   beforeEach(async () => {
     await del(someFakeUri, property, targetEntityUri)
+  })
+
+  it('should reject missing subject', async () => {
+    try {
+      await set(null, property, targetEntityUri)
+      shouldNotBeCalled()
+    } catch (err) {
+      err.message.should.equal('invalid subject')
+    }
+  })
+
+  it('should reject missing property', async () => {
+    try {
+      await set(someFakeUri, null, targetEntityUri)
+      shouldNotBeCalled()
+    } catch (err) {
+      err.message.should.equal('invalid property')
+    }
+  })
+
+  it('should reject missing object', async () => {
+    try {
+      await set(someFakeUri, property, null)
+      shouldNotBeCalled()
+    } catch (err) {
+      err.message.should.equal('invalid object')
+    }
   })
 
   it('should store a relation', async () => {

--- a/tests/integration/entities_relations_temporary_cache.js
+++ b/tests/integration/entities_relations_temporary_cache.js
@@ -34,12 +34,12 @@ describe('entities relations temporary cache', () => {
     }
   })
 
-  it('should reject missing object', async () => {
+  it('should reject missing value', async () => {
     try {
       await set(someFakeUri, property, null)
       shouldNotBeCalled()
     } catch (err) {
-      err.message.should.equal('invalid object')
+      err.message.should.equal('invalid value')
     }
   })
 


### PR DESCRIPTION
addressing #313 

The proposed implementation:
- puts the desired relations in a LevelDB db, from which they will be removed once their TTL expired (after 4 hours by default)
- checks that cache for graph queries (list of authors works or series parts), in addition to other sources (Wikidata and local entities)