### PR TITLE
upgrade CouchDB from 1.7 to 3.1

### DIFF
--- a/server/controllers/user/lib/geo/follow.js
+++ b/server/controllers/user/lib/geo/follow.js
@@ -47,4 +47,5 @@ const update = (id, lat, lon) => db.put({ lat, lon }, id, emptyValue)
 const reset = () => {
   _.log('reseting users geo index', null, 'yellow')
   return level_.reset(db.sub)
+  .catch(_.ErrorRethrow('users geo index reset err'))
 }


### PR DESCRIPTION
This is an exploration of the opportunity to upgrade CouchDB from 1.7 to 3.1.

## Benefits
Upgrading to the 3.1 (the latest stable version) would bring [quite a few changes](https://docs.couchdb.org/en/stable/whatsnew/), especially:
- improved perf
- security patches
- adds [automatic compaction](https://docs.couchdb.org/en/stable/maintenance/compaction.html#compact-auto)
- updated SpiderMoney version: would allow to replace coffeescript views by modern JS syntax
- new recommended query language: Mango Query Server, see [`/db/_find`](https://docs.couchdb.org/en/stable/api/database/find.html#api-db-find)
  - that's mostly an alternative syntax to map/reduce views, but with some indexation benefits in terms of perfs, and possibly a nicer developer experience
  - Includes some interesting new pagination features (bookmarks)
- [integration of dreyfus](https://docs.couchdb.org/en/stable/config/query-servers.html#config-search), which could be used to easily keep instances of Apache Lucene in sync: in some simple cases (users and groups?) that could be used in place of ElasticSearch for full-text search without the hassle of using `couch2elastic4sync`. For more advanced cases (entities), it's not clear if that can be an option. The [available documentation](https://lucene.apache.org/core/8_4_1/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#package.description) compared to ElasticSearch seems to also be a limiting factor, and that would require to learn to use yet another tool.

## Changes
The only breaking change affecting us seem to be the change in the `seq` number format, which is addressed by d775219

## Ops
* [From Docker, the upgrade is trivial](https://github.com/inventaire/docker-inventaire/commit/6408d2c)
* Outside of Docker, there are options:
   * [with apt-get](https://docs.couchdb.org/en/stable/install/unix.html)
   * [as a snap package](https://docs.couchdb.org/en/3.0.0/install/snap.html)

## Migration
The easiest way to migrate from a `1.x` to a `3.x` database seems to be to get all the docs out in back in in the new database, after having removed the `_rev`:

```sh
# Dump docs without the _rev
curl "http://${couch_1_7_host}/users-tests/_all_docs?include_docs=true" | jq '.rows[] | .doc | del(._rev)' -cr > users-tests
# Create the new db
curl -XPUT "http://${couch_3_1_host}/users-tests"
# Load new db
cat users-tests | couch-bulk2 "http://${couch_3_1_host}/users-tests/_all_docs?include_docs=true"
```

That means loosing all revs numbers though.

## Conclusion
The costs aren't that high (mostly the migration work, now that the breaking changes have been addressed) and there are some real benefits, but maybe we should just wait for [`4.x`](https://blog.couchdb.org/2020/02/26/the-road-to-couchdb-3-0-prepare-for-4-0/)?