### PR TITLE
entities: add a revert-edit endpoint

### DIFF
--- a/server/controllers/entities/entities.js
+++ b/server/controllers/entities/entities.js
@@ -41,6 +41,7 @@ module.exports = {
     },
     admin: {
       merge: require('./merge'),
+      'revert-edit': require('./revert_edit'),
       'revert-merge': require('./revert_merge')
     }
   })

--- a/server/controllers/entities/lib/revert_edit.js
+++ b/server/controllers/entities/lib/revert_edit.js
@@ -1,0 +1,19 @@
+const __ = require('config').universalPath
+const Patch = __.require('models', 'patch')
+const entities_ = require('./entities')
+const patches_ = require('./patches')
+
+const revertFromPatchDoc = async (patch, userId) => {
+  const entityId = patch._id.split(':')[0]
+  const currentDoc = await entities_.byId(entityId)
+  const updatedDoc = Patch.revert(currentDoc, patch)
+  const context = { revertPatch: patch._id }
+  return entities_.putUpdate({ userId, currentDoc, updatedDoc, context })
+}
+
+const revertFromPatchId = async (patchId, userId) => {
+  const patch = await patches_.byId(patchId)
+  return revertFromPatchDoc(patch, userId)
+}
+
+module.exports = { revertFromPatchDoc, revertFromPatchId }

--- a/server/controllers/entities/revert_edit.js
+++ b/server/controllers/entities/revert_edit.js
@@ -1,0 +1,16 @@
+const __ = require('config').universalPath
+const sanitize = __.require('lib', 'sanitize/sanitize')
+const responses_ = __.require('lib', 'responses')
+const error_ = __.require('lib', 'error/error')
+const { revertFromPatchId } = require('./lib/revert_edit')
+
+const sanitization = {
+  patch: {}
+}
+
+module.exports = (req, res) => {
+  sanitize(req, res, sanitization)
+  .then(({ patchId, reqUserId }) => revertFromPatchId(patchId, reqUserId))
+  .then(responses_.Ok(res))
+  .catch(error_.Handler(req, res))
+}

--- a/server/lib/boolean_validations.js
+++ b/server/lib/boolean_validations.js
@@ -37,6 +37,7 @@ const tests = module.exports = {
   isItemId: isCouchUuid,
   isUsername: bindedTest('Username'),
   isEntityUri: bindedTest('EntityUri'),
+  isPatchId: bindedTest('PatchId'),
   isExtendedEntityUri: uri => {
     const [ prefix, id ] = uri.split(':')
     // Accept alias URIs.

--- a/server/lib/regex.js
+++ b/server/lib/regex.js
@@ -12,27 +12,27 @@ const urlPattern = '^(https?:\\/\\/)' + // protocol
   '(\\#[-a-z\\d_]*)?$' // fragment?
 
 module.exports = {
+  AssetImg: /^\/img\/assets\/\w/,
   CouchUuid: /^[0-9a-f]{32}$/,
   // minimanlist email regex
   // cf http://davidcel.is/blog/2012/09/06/stop-validating-email-addresses-with-regex/
   Email: /^[^@]+@[^@]+\.[^@]+$/,
   EntityUri: /^(wd:Q\d+|inv:[0-9a-f]{32}|isbn:\w{10}(\w{3})?)$/,
+  Float: /^-?[\d.]+$/,
   ImageHash: /^[0-9a-f]{40}$/,
-  Url: new RegExp(urlPattern, 'i'),
-  Uuid: /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+  Integer: /^-?\d+$/,
   // Accepting second level languages (like es-AR)
   Lang: /^\w{2}(-\w{2})?$/,
   LocalImg: /^\/img\/(users|entities)\/[0-9a-f]{40}$/,
-  AssetImg: /^\/img\/assets\/\w/,
-  UserImg: /^\/img\/users\/[0-9a-f]{40}$/,
-  // all 1 letter strings are reserved for the application
-  Username: /^\w{2,20}$/,
+  PositiveInteger: /^\d+$/,
   PropertyUri: /^(wdt|invp):P\d+$/,
   // A year can't start by a 0
   Sha1: /^[0-9a-f]{40}$/,
   SimpleDay: /^-?([1-9]{1}[0-9]{0,3}|0)(-\d{2})?(-\d{2})?$/,
-  Integer: /^-?\d+$/,
-  PositiveInteger: /^\d+$/,
   StrictlyPositiveInteger: /^[1-9]\d*$/,
-  Float: /^-?[\d.]+$/
+  Url: new RegExp(urlPattern, 'i'),
+  UserImg: /^\/img\/users\/[0-9a-f]{40}$/,
+  // all 1 letter strings are reserved for the application
+  Username: /^\w{2,20}$/,
+  Uuid: /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 }

--- a/server/lib/regex.js
+++ b/server/lib/regex.js
@@ -24,6 +24,7 @@ module.exports = {
   // Accepting second level languages (like es-AR)
   Lang: /^\w{2}(-\w{2})?$/,
   LocalImg: /^\/img\/(users|entities)\/[0-9a-f]{40}$/,
+  PatchId: /^[0-9a-f]{32}:[1-9]\d{0,3}$/,
   PositiveInteger: /^\d+$/,
   PropertyUri: /^(wdt|invp):P\d+$/,
   // A year can't start by a 0

--- a/server/lib/sanitize/parameters.js
+++ b/server/lib/sanitize/parameters.js
@@ -23,9 +23,11 @@ const parseNumberString = value => {
   else return parsedValue
 }
 
+const renameId = name => `${name}Id`
+
 const couchUuid = {
   validate: validations.common.couchUuid,
-  rename: name => `${name}Id`
+  rename: renameId
 }
 
 const positiveInteger = {
@@ -182,6 +184,10 @@ module.exports = {
   password: {
     secret: true,
     validate: validations.user.password
+  },
+  patch: {
+    validate: _.isPatchId,
+    rename: renameId
   },
   position: {
     format: truncateLatLng,

--- a/server/models/validations/common.js
+++ b/server/models/validations/common.js
@@ -24,7 +24,8 @@ const validations = module.exports = {
     // Allow a user or a group to delete their position by passing a null value
     if (latLng === null) return true
     else return _.isArray(latLng) && (latLng.length === 2) && _.every(latLng, _.isNumber)
-  }
+  },
+  patchId: _.isPatchId
 }
 
 validations.boundedString = (str, minLength, maxLength) => {

--- a/tests/api/entities/revert_edit.test.js
+++ b/tests/api/entities/revert_edit.test.js
@@ -1,0 +1,43 @@
+const CONFIG = require('config')
+const __ = CONFIG.universalPath
+const should = require('should')
+const { authReq, shouldNotBeCalled } = require('../utils/utils')
+const randomString = __.require('lib', './utils/random_string')
+const { getByUri, updateLabel, revertEdit, getHistory, addClaim } = require('../utils/entities')
+const { createWork } = require('../fixtures/entities')
+
+describe('entities:revert-edit', () => {
+  it('should require admin rights', async () => {
+    try {
+      await authReq('put', '/api/entities?action=revert-edit').then(shouldNotBeCalled)
+    } catch (err) {
+      err.statusCode.should.equal(403)
+    }
+  })
+
+  it('should revert a label update', async () => {
+    const { uri } = await createWork()
+    const label = randomString(6)
+    await updateLabel(uri, 'es', label)
+    const lastPatchId = await getLastPatchId(uri)
+    const res = await revertEdit(lastPatchId)
+    res.should.be.ok()
+    const work = await getByUri(uri)
+    should(work.labels.es).not.be.ok()
+  })
+
+  it('should revert a claim update', async () => {
+    const { uri } = await createWork()
+    await addClaim(uri, 'wdt:P50', 'wd:Q1174579')
+    const lastPatchId = await getLastPatchId(uri)
+    const res = await revertEdit(lastPatchId)
+    res.should.be.ok()
+    const work = await getByUri(uri)
+    should(work.claims['wdt:P50']).not.be.ok()
+  })
+})
+
+const getLastPatchId = async uri => {
+  const history = await getHistory(uri)
+  return history.slice(-1)[0]._id
+}

--- a/tests/api/utils/entities.js
+++ b/tests/api/utils/entities.js
@@ -70,6 +70,11 @@ const entitiesUtils = module.exports = {
   getRefreshedPopularityByUri: uri => {
     return entitiesUtils.getRefreshedPopularityByUris(uri)
     .then(res => res.scores[uri])
+  },
+
+  revertEdit: patchId => {
+    assert_.string(patchId)
+    return adminReq('put', '/api/entities?action=revert-edit', { patch: patchId })
   }
 }
 


### PR DESCRIPTION
addressing #408 

That was much easier than anticipated as all the work was already done for the needs of `/api/entities?action=revert-merge`