### PR TITLE
user model: updateEmail: do not keep previous emails

### DIFF
--- a/server/models/user.js
+++ b/server/models/user.js
@@ -95,19 +95,7 @@ User.softDelete = userDoc => {
 }
 
 User.updateEmail = (doc, email) => {
-  doc = archivePreviousEmail(doc)
   doc.email = email
-  return doc
-}
-
-const archivePreviousEmail = doc => {
-  // Don't save the previous email if it had not been validated
-  if (doc.validEmail) {
-    if (!doc.previousEmails) { doc.previousEmails = [] }
-    doc.previousEmails.push(doc.email)
-    doc.previousEmails = _.uniq(doc.previousEmails)
-    doc.validEmail = false
-  }
   return doc
 }
 

--- a/tests/unit/libs/044-slugify.js
+++ b/tests/unit/libs/044-slugify.js
@@ -14,7 +14,7 @@ describe('slugify', () => {
     slugify('bla&mémùémd ùdém^&²Mdù é:azdza').should.be.a.String()
   })
 
-  it.only('should replace URL reserved characters', () => {
+  it('should replace URL reserved characters', () => {
     slugify("L:a;:? M[!Y]$'@,\"|N=.E - é<(}{h)>o").should.equal('la-myn-e-ého')
   })
 


### PR DESCRIPTION
keeping previous emails was initially added with the idea to cover the case where someone mistakenly changes their email to an invalid email, but with the side effect to keep more user data than explicitly allowed by the user. It was never used so far, so removing it seems like the right thing to do