### PR TITLE
temporarily stop to make requests to a host that answered with a timeout

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -203,6 +203,7 @@ const config = module.exports = {
   },
 
   outgoingRequests: {
-    baseBanTime: 60 * 60 * 1000
+    baseBanTime: 60 * 60 * 1000,
+    banTimeIncreaseFactor: 4
   }
 }

--- a/config/default.js
+++ b/config/default.js
@@ -200,5 +200,9 @@ const config = module.exports = {
       run: true,
       interval: 3000
     }
+  },
+
+  outgoingRequests: {
+    baseBanTime: 60 * 60 * 1000
   }
 }

--- a/config/tests-integration.js
+++ b/config/tests-integration.js
@@ -3,5 +3,9 @@ module.exports = {
     suffix: 'tests'
   },
 
-  leveldbMemoryBackend: false
+  leveldbMemoryBackend: false,
+
+  outgoingRequests: {
+    baseBanTime: 500
+  }
 }

--- a/server/lib/requests.js
+++ b/server/lib/requests.js
@@ -9,7 +9,7 @@ const { magenta } = require('chalk')
 const { repository } = __.require('root', 'package.json')
 const userAgent = `${CONFIG.name} (${repository.url})`
 const { getAgent, selfSignedHttpsAgent } = require('./requests_agent')
-const { throwIfTemporarilyBanned, declareTimeout } = require('./requests_temporary_host_ban')
+const { throwIfTemporarilyBanned, resetBanData, declareTimeout } = require('./requests_temporary_host_ban')
 const { URL } = require('url')
 // Setting the default timeout low
 const defaultTimeout = 10 * 1000
@@ -75,6 +75,8 @@ const req = method => async (url, options = {}) => {
     addContextToStack(err)
     throw err
   }
+
+  resetBanData(host)
 
   if (returnBodyOnly) {
     return body

--- a/server/lib/requests.js
+++ b/server/lib/requests.js
@@ -9,6 +9,8 @@ const { magenta } = require('chalk')
 const { repository } = __.require('root', 'package.json')
 const userAgent = `${CONFIG.name} (${repository.url})`
 const { getAgent, selfSignedHttpsAgent } = require('./requests_agent')
+const { checkHostBan, declareTimeout } = require('./requests_temporary_host_ban')
+const { URL } = require('url')
 // Setting the default timeout low
 const defaultTimeout = 10 * 1000
 
@@ -17,6 +19,9 @@ let requestId = 0
 const req = method => async (url, options = {}) => {
   assert_.string(url)
   assert_.object(options)
+
+  const { host } = new URL(url)
+  checkHostBan(host)
 
   const { returnBodyOnly = true, parseJson = true, body: reqBody } = options
   // Removing options that don't concern node-fetch
@@ -27,7 +32,15 @@ const req = method => async (url, options = {}) => {
 
   let reqTimerKey
   if (logOutgoingRequests) reqTimerKey = startReqTimer(method, url, options)
-  const res = await fetch(url, options)
+
+  let res
+  try {
+    res = await fetch(url, options)
+  } catch (err) {
+    declareTimeout(host, err)
+    throw err
+  }
+
   if (logOutgoingRequests) endReqTimer(reqTimerKey)
 
   const { status: statusCode } = res

--- a/server/lib/requests.js
+++ b/server/lib/requests.js
@@ -9,7 +9,7 @@ const { magenta } = require('chalk')
 const { repository } = __.require('root', 'package.json')
 const userAgent = `${CONFIG.name} (${repository.url})`
 const { getAgent, selfSignedHttpsAgent } = require('./requests_agent')
-const { checkHostBan, declareTimeout } = require('./requests_temporary_host_ban')
+const { throwIfTemporarilyBanned, declareTimeout } = require('./requests_temporary_host_ban')
 const { URL } = require('url')
 // Setting the default timeout low
 const defaultTimeout = 10 * 1000
@@ -21,7 +21,7 @@ const req = method => async (url, options = {}) => {
   assert_.object(options)
 
   const { host } = new URL(url)
-  checkHostBan(host)
+  throwIfTemporarilyBanned(host)
 
   const { returnBodyOnly = true, parseJson = true, body: reqBody } = options
   // Removing options that don't concern node-fetch

--- a/server/lib/requests.js
+++ b/server/lib/requests.js
@@ -37,7 +37,7 @@ const req = method => async (url, options = {}) => {
   try {
     res = await fetch(url, options)
   } catch (err) {
-    declareTimeout(host, err)
+    if (err.type === 'request-timeout') declareTimeout(host)
     throw err
   }
 

--- a/server/lib/requests_temporary_host_ban.js
+++ b/server/lib/requests_temporary_host_ban.js
@@ -1,0 +1,32 @@
+const CONFIG = require('config')
+const __ = CONFIG.universalPath
+const error_ = __.require('lib', 'error/error')
+const { baseBanTime } = CONFIG.outgoingRequests
+
+const timeoutData = {}
+
+const checkHostBan = host => {
+  const hostTimeoutData = timeoutData[host]
+  if (hostTimeoutData != null) {
+    if (Date.now() < hostTimeoutData.expire) {
+      throw error_.new('temporary ban', 500, { host, hostTimeoutData })
+    }
+  }
+}
+
+const declareTimeout = (host, err) => {
+  if (err.type !== 'request-timeout') return
+
+  let hostTimeoutData = timeoutData[host]
+
+  if (hostTimeoutData) {
+    // This host persists to timeout: renew and increase ban time
+    hostTimeoutData.banTime *= 4
+  } else {
+    hostTimeoutData = timeoutData[host] = { banTime: baseBanTime }
+  }
+
+  hostTimeoutData.expire = Date.now() + hostTimeoutData.banTime
+}
+
+module.exports = { checkHostBan, declareTimeout }

--- a/server/lib/requests_temporary_host_ban.js
+++ b/server/lib/requests_temporary_host_ban.js
@@ -1,7 +1,7 @@
 const CONFIG = require('config')
 const __ = CONFIG.universalPath
 const error_ = __.require('lib', 'error/error')
-const { baseBanTime } = CONFIG.outgoingRequests
+const { baseBanTime, banTimeIncreaseFactor } = CONFIG.outgoingRequests
 
 const timeoutData = {}
 
@@ -21,7 +21,7 @@ const declareTimeout = (host, err) => {
 
   if (hostTimeoutData) {
     // This host persists to timeout: renew and increase ban time
-    hostTimeoutData.banTime *= 4
+    hostTimeoutData.banTime *= banTimeIncreaseFactor
   } else {
     hostTimeoutData = timeoutData[host] = { banTime: baseBanTime }
   }

--- a/server/lib/requests_temporary_host_ban.js
+++ b/server/lib/requests_temporary_host_ban.js
@@ -12,6 +12,8 @@ const throwIfTemporarilyBanned = host => {
   }
 }
 
+const resetBanData = host => delete timeoutData[host]
+
 const declareTimeout = (host, err) => {
   if (err.type !== 'request-timeout') return
 
@@ -27,4 +29,4 @@ const declareTimeout = (host, err) => {
   hostTimeoutData.expire = Date.now() + hostTimeoutData.banTime
 }
 
-module.exports = { throwIfTemporarilyBanned, declareTimeout }
+module.exports = { throwIfTemporarilyBanned, resetBanData, declareTimeout }

--- a/server/lib/requests_temporary_host_ban.js
+++ b/server/lib/requests_temporary_host_ban.js
@@ -14,9 +14,7 @@ const throwIfTemporarilyBanned = host => {
 
 const resetBanData = host => delete timeoutData[host]
 
-const declareTimeout = (host, err) => {
-  if (err.type !== 'request-timeout') return
-
+const declareTimeout = host => {
   let hostTimeoutData = timeoutData[host]
 
   if (hostTimeoutData) {

--- a/server/lib/requests_temporary_host_ban.js
+++ b/server/lib/requests_temporary_host_ban.js
@@ -9,7 +9,7 @@ const checkHostBan = host => {
   const hostTimeoutData = timeoutData[host]
   if (hostTimeoutData != null) {
     if (Date.now() < hostTimeoutData.expire) {
-      throw error_.new('temporary ban', 500, { host, hostTimeoutData })
+      throw error_.new('temporary ban', 500, { host, timeoutData: hostTimeoutData })
     }
   }
 }

--- a/server/lib/requests_temporary_host_ban.js
+++ b/server/lib/requests_temporary_host_ban.js
@@ -5,12 +5,10 @@ const { baseBanTime, banTimeIncreaseFactor } = CONFIG.outgoingRequests
 
 const timeoutData = {}
 
-const checkHostBan = host => {
+const throwIfTemporarilyBanned = host => {
   const hostTimeoutData = timeoutData[host]
-  if (hostTimeoutData != null) {
-    if (Date.now() < hostTimeoutData.expire) {
-      throw error_.new('temporary ban', 500, { host, timeoutData: hostTimeoutData })
-    }
+  if (hostTimeoutData != null && Date.now() < hostTimeoutData.expire) {
+    throw error_.new('temporary ban', 500, { host, timeoutData: hostTimeoutData })
   }
 }
 
@@ -29,4 +27,4 @@ const declareTimeout = (host, err) => {
   hostTimeoutData.expire = Date.now() + hostTimeoutData.banTime
 }
 
-module.exports = { checkHostBan, declareTimeout }
+module.exports = { throwIfTemporarilyBanned, declareTimeout }

--- a/tests/integration/requests.js
+++ b/tests/integration/requests.js
@@ -54,5 +54,18 @@ describe('requests', () => {
         err.type.should.equal('request-timeout')
       }
     })
+
+    it('should keep timeout data for the whole host', async () => {
+      const { origin } = await startTimeoutServer()
+      await requests_.get(`${origin}/a`, { timeout: 100 }).catch(err => err.type.should.equal('request-timeout'))
+      await requests_.get(`${origin}/b`, { timeout: 100 }).catch(err => err.message.should.equal('temporary ban'))
+      await wait(baseBanTime + 100)
+      try {
+        await requests_.get(`${origin}/c`, { timeout: 100 }).then(shouldNotBeCalled)
+      } catch (err) {
+        rethrowShouldNotBeCalledErrors(err)
+        err.type.should.equal('request-timeout')
+      }
+    })
   })
 })

--- a/tests/integration/requests.js
+++ b/tests/integration/requests.js
@@ -5,7 +5,7 @@ const express = require('express')
 const requests_ = __.require('lib', 'requests')
 const { wait } = __.require('lib', 'promises')
 const { shouldNotBeCalled, rethrowShouldNotBeCalledErrors } = __.require('apiTests', 'utils/utils')
-const { baseBanTime } = require('config').outgoingRequests
+const { baseBanTime, banTimeIncreaseFactor } = require('config').outgoingRequests
 let port = 38463
 
 const startTimeoutServer = () => new Promise(resolve => {
@@ -84,9 +84,10 @@ describe('requests', () => {
         rethrowShouldNotBeCalledErrors(err)
         err.message.should.equal('temporary ban')
         const { banTime, expire } = err.context.timeoutData
-        banTime.should.equal(baseBanTime * 4)
+        banTime.should.equal(baseBanTime * banTimeIncreaseFactor)
         const execTimeMargin = 1000
-        should(expire > beforeReban && expire < beforeReban + baseBanTime * 4 + execTimeMargin).be.true()
+        should(expire > beforeReban).be.true()
+        should(expire < (beforeReban + baseBanTime * banTimeIncreaseFactor + execTimeMargin)).be.true()
       }
     })
   })

--- a/tests/integration/requests.js
+++ b/tests/integration/requests.js
@@ -1,0 +1,58 @@
+const CONFIG = require('config')
+const __ = CONFIG.universalPath
+require('should')
+const express = require('express')
+const requests_ = __.require('lib', 'requests')
+const { wait } = __.require('lib', 'promises')
+const { shouldNotBeCalled, rethrowShouldNotBeCalledErrors } = __.require('apiTests', 'utils/utils')
+const { baseBanTime } = require('config').outgoingRequests
+let port = 38463
+
+const startTimeoutServer = () => new Promise(resolve => {
+  port++
+  const app = express()
+  const host = `localhost:${port}`
+  const origin = `http://${host}`
+  // Always timeout
+  app.get('/*', () => {})
+  app.listen(port, () => resolve({ port, host, origin }))
+})
+
+describe('requests', () => {
+  describe('timeout', async () => {
+    it('should timeout after the specified time', async () => {
+      const { origin } = await startTimeoutServer()
+      try {
+        await requests_.get(origin, { timeout: 100 }).then(shouldNotBeCalled)
+      } catch (err) {
+        rethrowShouldNotBeCalledErrors(err)
+        err.type.should.equal('request-timeout')
+      }
+    })
+
+    it('should not re-request a host that just had a timeout', async () => {
+      const { origin, host } = await startTimeoutServer()
+      await requests_.get(origin, { timeout: 100 }).catch(err => err.type.should.equal('request-timeout'))
+      try {
+        await requests_.get(origin, { timeout: 100 }).then(shouldNotBeCalled)
+      } catch (err) {
+        rethrowShouldNotBeCalledErrors(err)
+        err.message.should.equal('temporary ban')
+        err.context.host.should.equal(host)
+      }
+    })
+
+    it('should retry after expiration of the ban', async () => {
+      const { origin } = await startTimeoutServer()
+      await requests_.get(origin, { timeout: 100 }).catch(err => err.type.should.equal('request-timeout'))
+      await requests_.get(origin, { timeout: 100 }).catch(err => err.message.should.equal('temporary ban'))
+      await wait(baseBanTime + 100)
+      try {
+        await requests_.get(origin, { timeout: 100 }).then(shouldNotBeCalled)
+      } catch (err) {
+        rethrowShouldNotBeCalledErrors(err)
+        err.type.should.equal('request-timeout')
+      }
+    })
+  })
+})


### PR DESCRIPTION
Among the SPARQL endpoints the resolver makes requests to, there is one that currently refuses to answer anything, which always end-up with a timeout after 60 seconds, which makes eeeeeeeverything slow. This PR brings a mechanism to automatically identify hosts that fail to answer and temporarily ban requests to those, with a growing ban time