### PR TITLE
radio: wait for async listeners in test environment

### DIFF
--- a/config/tests-integration.js
+++ b/config/tests-integration.js
@@ -1,4 +1,6 @@
 module.exports = {
+  env: 'tests-integration',
+
   db: {
     suffix: 'tests'
   },

--- a/server/controllers/relations/lib/actions.js
+++ b/server/controllers/relations/lib/actions.js
@@ -2,7 +2,6 @@ const CONFIG = require('config')
 const __ = CONFIG.universalPath
 const queries_ = require('./queries')
 const radio = __.require('lib', 'radio')
-const { tap } = __.require('lib', 'promises')
 const { tapEmit } = radio
 
 module.exports = {
@@ -17,13 +16,12 @@ module.exports = {
     .then(tapEmit('notify:friend:request:accepted', userId, otherId))
   },
 
-  makeRequest: (inviterId, recipientId, notify = true) => {
-    return queries_.putRequestedStatus(inviterId, recipientId)
-    .then(tap(() => {
-      // Use notify=false to avoid emails when a new user is created with waiting
-      // email invitations, which are then converted into requests
-      if (notify) radio.emit('notify:friendship:request', recipientId, inviterId)
-    }))
+  makeRequest: async (inviterId, recipientId, notify = true) => {
+    const res = await queries_.putRequestedStatus(inviterId, recipientId)
+    // Use notify=false to avoid emails when a new user is created with waiting
+    // email invitations, which are then converted into requests
+    if (notify) await radio.emit('notify:friendship:request', recipientId, inviterId)
+    return res
   },
 
   removeRelation: queries_.putNoneStatus

--- a/server/lib/radio.js
+++ b/server/lib/radio.js
@@ -1,13 +1,44 @@
 // A server-wide event bus
+
+const CONFIG = require('config')
+const __ = CONFIG.universalPath
+const _ = __.require('builders', 'utils')
 const { EventEmitter } = require('events')
 const radio = new EventEmitter()
 
+// It's convenient in tests to have the guaranty that event listeners were called,
+// but in production, that would mean delaying API responses for secondary actions
+// (setting notifications, sending emails, analytics, etc)
+const waitForListeners = CONFIG.env.startsWith('tests')
+
+let emit
+if (waitForListeners) {
+  emit = async (eventName, ...args) => {
+    const listeners = radio.listeners(eventName)
+    await Promise.all(listeners.map(triggerAndWait(eventName, args)))
+  }
+} else {
+  emit = radio.emit.bind(radio)
+}
+
 module.exports = {
-  emit: radio.emit.bind(radio),
-  Emit: label => radio.emit.bind(radio, label),
+  emit,
+  Emit: label => emit.bind(null, label),
   tapEmit: (...args) => res => {
-    radio.emit(...args)
-    return res
+    if (waitForListeners) {
+      return emit(...args).then(() => res)
+    } else {
+      emit(...args)
+      return res
+    }
   },
   on: radio.on.bind(radio)
+}
+
+const triggerAndWait = (eventName, args) => async listener => {
+  try {
+    await listener(...args)
+  } catch (err) {
+    _.error(err, `${eventName} error`)
+  }
 }

--- a/tests/unit/libs/050-radio.js
+++ b/tests/unit/libs/050-radio.js
@@ -1,0 +1,37 @@
+const CONFIG = require('config')
+const __ = CONFIG.universalPath
+const { wait } = __.require('lib', 'promises')
+const radio = __.require('lib', 'radio')
+require('should')
+
+// Do not run without having set NODE_ENV
+CONFIG.env.should.startWith('tests')
+
+describe('radio', () => {
+  describe('emit [in test environment]', () => {
+    it('should return a promise', async () => {
+      let waited = false
+      radio.on('foo', async () => {
+        await wait(100)
+        waited = true
+      })
+      const promise = radio.emit('foo')
+      promise.should.be.a.Promise()
+      await promise
+      waited.should.be.true()
+    })
+
+    it('should return a resolved promise, even in case of a falling promise', async () => {
+      let waited = false
+      radio.on('foo', async () => {
+        await wait(100)
+        waited = true
+      })
+      radio.on('foo', async () => { throw new Error('nop') })
+      const promise = radio.emit('foo')
+      promise.should.be.a.Promise()
+      await promise
+      waited.should.be.true()
+    })
+  })
+})


### PR DESCRIPTION
this PR proposes to give the guaranty, in tests, that event listeners were executed before the HTTP response was sent, to avoid race conditions such as illustrated by https://github.com/inventaire/inventaire/pull/441#discussion_r516587600

How to use:
* replace `radio.emit` by `await radio.emit` to give that guaranty
* `tapEmit` always await in tests env