### PR TITLE
decouple patches ids from entities revs

### DIFF
--- a/scripts/dumps/lib/serialize_entity_in_turtle.js
+++ b/scripts/dumps/lib/serialize_entity_in_turtle.js
@@ -5,7 +5,7 @@ const properties = __.require('controllers', 'entities/lib/properties/properties
 const { yellow } = require('chalk')
 
 module.exports = entity => {
-  const { _id, _rev, created, updated, type, redirect } = entity
+  const { _id, version, created, updated, type, redirect } = entity
 
   if (type !== 'entity' || redirect != null) return ''
 
@@ -17,10 +17,6 @@ module.exports = entity => {
   const dateModified = new Date(updated).toISOString()
   text += `\n  schema:dateModified "${dateModified}"^^xsd:dateTime ;`
 
-  // Using the _rev to deduce the version might give a version number
-  // higher than the real number of patches, but that's better than nothing
-
-  const version = parseInt(_rev.split('-'))
   text += `\n  schema:version ${version} ;`
 
   for (const lang in entity.labels) {

--- a/scripts/dumps/prepare_entities_dumps
+++ b/scripts/dumps/prepare_entities_dumps
@@ -47,13 +47,13 @@ cat "$raw_db_json_filename" |
   # Filter-out redirections
   grep -v "redirect" |
   # Filter-out entities empty canvas (entity creation process failure)
-  grep -v '_rev":"1-' |
+  grep -v '"version":1' |
   drop_comma > "${filtered_dump_filename_with_seeds}"
 
 echo "filtering $raw_db_json_filename without seeds into $filtered_dump_filename"
 cat "${filtered_dump_filename_with_seeds}" |
-  # Filter-out entities that are just unedited data seeds
-  grep -v '_rev":"2-' > "$filtered_dump_filename"
+  # Filter-out entities that are likely to be unedited data seeds
+  grep -v '"version":2' > "$filtered_dump_filename"
 
 # TTL dump
 # We need to return to the root directory so that convert_ndjson_dump_to_ttl.js

--- a/scripts/update_entities.js
+++ b/scripts/update_entities.js
@@ -19,6 +19,7 @@ const assert_ = __.require('utils', 'assert_types')
 const entitiesDb = __.require('couch', 'base')('entities')
 const patchesDb = __.require('couch', 'base')('patches')
 const docDiff = __.require('couchdb', 'doc_diffs')
+const Entity = __.require('models', 'entity')
 const Patch = __.require('models', 'patch')
 const userId = __.require('couch', 'hard_coded_documents').users.updater._id
 
@@ -43,6 +44,7 @@ const updateSequentially = () => {
     const updatesData = rows.map(row => {
       const { doc: currentDoc } = row
       const updatedDoc = updateFn(_.cloneDeep(currentDoc))
+      Entity.beforeSave(updatedDoc)
       if (!silent) { docDiff(currentDoc, updatedDoc, preview) }
       return { currentDoc, updatedDoc }
     })

--- a/server/controllers/entities/lib/entities.js
+++ b/server/controllers/entities/lib/entities.js
@@ -88,7 +88,7 @@ const entities_ = module.exports = {
     const { userId, currentDoc, updatedDoc } = params
     assert_.types([ 'string', 'object', 'object' ], [ userId, currentDoc, updatedDoc ])
 
-    Entity.validateBeforeSave(updatedDoc)
+    Entity.beforeSave(updatedDoc)
 
     // It is to the consumers responsability to check if there is an update:
     // empty patches at this stage will throw 500 errors

--- a/server/controllers/entities/lib/entities.js
+++ b/server/controllers/entities/lib/entities.js
@@ -94,7 +94,16 @@ const entities_ = module.exports = {
     // empty patches at this stage will throw 500 errors
     const docAfterUpdate = await db.putAndReturn(updatedDoc)
     triggerUpdateEvent(currentDoc, docAfterUpdate)
-    await patches_.create(params)
+
+    try {
+      await patches_.create(params)
+    } catch (err) {
+      err.type = 'patch_creation_failed'
+      err.context = err.context || {}
+      err.context.data = { currentDoc, updatedDoc }
+      throw err
+    }
+
     return docAfterUpdate
   },
 

--- a/server/controllers/entities/lib/revert_merge.js
+++ b/server/controllers/entities/lib/revert_merge.js
@@ -15,8 +15,9 @@ module.exports = async (userId, fromId) => {
   const fromUri = `inv:${fromId}`
   targetVersion._id = currentVersion._id
   targetVersion._rev = currentVersion._rev
+  targetVersion.version = currentVersion.version
 
-  const updateRes = entities_.putUpdate({
+  const updateRes = await entities_.putUpdate({
     userId,
     currentDoc: currentVersion,
     updatedDoc: targetVersion

--- a/server/lib/retry_on_conflict.js
+++ b/server/lib/retry_on_conflict.js
@@ -15,7 +15,8 @@ module.exports = params => {
 
       return updateFn.apply(null, args)
       .catch(err => {
-        if (err.statusCode === 409) {
+        // Retry only if the conflict comes from then entity
+        if (err.statusCode === 409 && err.type !== 'patch_creation_failed') {
           return runAfterDelay(run, attemptsCount, err)
         } else {
           throw err

--- a/server/lib/retry_on_conflict.js
+++ b/server/lib/retry_on_conflict.js
@@ -1,4 +1,5 @@
 const __ = require('config').universalPath
+const _ = __.require('builders', 'utils')
 const { wait } = __.require('lib', 'promises')
 const error_ = __.require('lib', 'error/error')
 
@@ -12,6 +13,12 @@ module.exports = params => {
       }
 
       attemptsCount += 1
+
+      if (attemptsCount > 1) {
+        // Avoid logging user document
+        const contextArgs = args.filter(arg => arg != null && arg.type !== 'user')
+        _.warn({ updateFn, contextArgs }, 'retrying after conflict')
+      }
 
       return updateFn.apply(null, args)
       .catch(err => {

--- a/tests/api/entities/create.test.js
+++ b/tests/api/entities/create.test.js
@@ -77,6 +77,7 @@ describe('entities:create', () => {
       res._id.should.be.a.String()
       res._rev.should.be.a.String()
       res.type.should.equal('work')
+      res.version.should.equal(2)
       res.claims.should.deepEqual({ 'wdt:P31': [ 'wd:Q47461344' ] })
       res.uri.should.be.a.String()
       res.labels.should.be.an.Object()

--- a/tests/unit/models/024-entity.js
+++ b/tests/unit/models/024-entity.js
@@ -43,7 +43,6 @@ describe('entity model', () => {
       entityDoc.created.should.be.a.Number()
       entityDoc.created.should.be.aboveOrEqual(now)
       entityDoc.created.should.be.below(now + 10)
-      entityDoc.updated.should.be.ok()
     })
   })
 
@@ -51,14 +50,6 @@ describe('entity model', () => {
     it('should add a claim value', () => {
       const doc = Entity.createClaim(workDoc(), 'wdt:P50', 'wd:Q42')
       _.last(doc.claims['wdt:P50']).should.equal('wd:Q42')
-    })
-
-    it('should update the timestamp', () => {
-      const now = Date.now()
-      const entityDoc = Entity.createClaim(workDoc(), 'wdt:P50', 'wd:Q42')
-      entityDoc.updated.should.be.a.Number()
-      entityDoc.updated.should.be.aboveOrEqual(now)
-      entityDoc.updated.should.be.below(now + 10)
     })
 
     it('should return a doc with the new value for an existing property', () => {
@@ -92,19 +83,6 @@ describe('entity model', () => {
       it('should not throw if not passed an old value', () => {
         const updater = () => Entity.updateClaim(workDoc(), 'wdt:P50', null, 'wd:Q42')
         updater.should.not.throw()
-      })
-
-      it('should update the timestamp', done => {
-        const now = Date.now()
-        const entityDoc = workDoc()
-        const update = () => {
-          const updatedDoc = Entity.updateClaim(entityDoc, 'wdt:P135', null, 'wd:Q53121')
-          updatedDoc.updated.should.be.a.Number()
-          updatedDoc.updated.should.be.above(now)
-          updatedDoc.updated.should.be.below(now + 10)
-          done()
-        }
-        setTimeout(update, 5)
       })
 
       it('should return a doc with the new value for an existing property', () => {
@@ -172,22 +150,6 @@ describe('entity model', () => {
         const updater = () => Entity.updateClaim(entityDoc, 'wdt:P50', 'wd:Q535', 'wd:Q1541')
         updater.should.throw()
       })
-
-      it('should update the timestamp', done => {
-        const now = Date.now()
-        const entityDoc = workDoc()
-        entityDoc.claims['wdt:P50'][0].should.equal('wd:Q535')
-        const update = () => {
-          const updatedDoc = Entity.updateClaim(entityDoc, 'wdt:P50', 'wd:Q535', 'wd:Q42')
-          updatedDoc.claims['wdt:P50'][0].should.equal('wd:Q42')
-          updatedDoc.updated.should.be.a.Number()
-          updatedDoc.updated.should.be.above(now)
-          updatedDoc.updated.should.be.below(now + 10)
-          done()
-        }
-
-        setTimeout(update, 5)
-      })
     })
 
     describe('delete claim', () => {
@@ -213,23 +175,6 @@ describe('entity model', () => {
         entityDoc = Entity.updateClaim(entityDoc, 'wdt:P212', '978-2-7073-0152-9', null)
         should(entityDoc.claims['wdt:P957']).not.be.ok()
         should(entityDoc.claims['wdt:P407']).not.be.ok()
-      })
-
-      it('should update the timestamp', done => {
-        const now = Date.now()
-        const entityDoc = workDoc()
-        entityDoc.updated.should.be.a.Number()
-        entityDoc.updated.should.be.aboveOrEqual(now)
-        entityDoc.updated.should.be.below(now + 10)
-        const update = () => {
-          const updatedDoc = Entity.updateClaim(entityDoc, 'wdt:P50', 'wd:Q535', null)
-          updatedDoc.updated.should.be.a.Number()
-          updatedDoc.updated.should.be.above(now)
-          updatedDoc.updated.should.be.below(now + 10)
-          done()
-        }
-
-        setTimeout(update, 5)
       })
     })
 
@@ -270,20 +215,6 @@ describe('entity model', () => {
         const entityDoc = workDoc()
         Entity.setLabel(entityDoc, 'fr', nonTrimmedString)
         entityDoc.labels.fr.should.equal('foo bar')
-      })
-
-      it('should update the timestamp', done => {
-        const entityDoc = workDoc()
-        const initialTimestamp = entityDoc.updated
-        entityDoc.updated.should.be.a.Number()
-        const update = () => {
-          const updatedDoc = Entity.setLabel(entityDoc, 'fr', 'hello')
-          updatedDoc.updated.should.be.a.Number()
-          updatedDoc.updated.should.be.above(initialTimestamp)
-          updatedDoc.updated.should.be.below(initialTimestamp + 10)
-          done()
-        }
-        setTimeout(update, 5)
       })
     })
 
@@ -339,35 +270,6 @@ describe('entity model', () => {
         entityB.claims['wdt:P921'].should.deepEqual([ 'wd:Q3' ])
       })
 
-      it('should update the timestamp', done => {
-        const entityA = workDoc()
-        const entityB = workDoc()
-        Entity.createClaim(entityA, 'wdt:P921', 'wd:Q3')
-        const now = Date.now()
-        const update = () => {
-          Entity.mergeDocs(entityA, entityB)
-          entityB.updated.should.be.a.Number()
-          entityB.updated.should.be.above(now)
-          entityB.updated.should.be.below(now + 10)
-          done()
-        }
-        setTimeout(update, 5)
-      })
-
-      it('should not update the timestamp if no data was transfered', done => {
-        const entityA = workDoc()
-        const entityB = workDoc()
-        Entity.createClaim(entityA, 'wdt:P921', 'wd:Q3')
-        Entity.createClaim(entityB, 'wdt:P921', 'wd:Q3')
-        const initialTimestamp = entityB.updated
-        const update = () => {
-          Entity.mergeDocs(entityA, entityB)
-          entityB.updated.should.equal(initialTimestamp)
-          done()
-        }
-        setTimeout(update, 5)
-      })
-
       it('should keep the target claim in case of claim uniqueness restrictions', () => {
         const entityA = workDoc()
         const entityB = workDoc()
@@ -398,7 +300,6 @@ describe('entity model', () => {
         should(redirection.claims).not.be.ok()
         should(redirection.labels).not.be.ok()
         redirection.created.should.equal(fromEntityDoc.created)
-        redirection.updated.should.be.ok()
       })
 
       it('should be a different object', () => {
@@ -406,23 +307,6 @@ describe('entity model', () => {
         const toUri = 'wd:Q3209796'
         const redirection = Entity.turnIntoRedirection(fromEntityDoc, toUri)
         should(redirection === fromEntityDoc).not.be.true()
-      })
-
-      it('should update the timestamp', done => {
-        const fromEntityDoc = workDoc()
-        const toUri = 'wd:Q3209796'
-        const redirect = () => {
-          const redirection = Entity.turnIntoRedirection(fromEntityDoc, toUri)
-          redirection.should.be.an.Object()
-          redirection._id.should.equal(fromEntityDoc._id)
-          redirection._rev.should.equal(fromEntityDoc._rev)
-          redirection._rev.should.equal(fromEntityDoc._rev)
-          redirection.redirect.should.equal(toUri)
-          redirection.updated.should.be.above(fromEntityDoc.updated)
-          done()
-        }
-
-        setTimeout(redirect, 5)
       })
     })
 
@@ -440,16 +324,29 @@ describe('entity model', () => {
         const removedPlaceholder = Entity.removePlaceholder(entity)
         should(removedPlaceholder === entity).not.be.true()
       })
+    })
+  })
 
-      it('should update the timestamp', done => {
-        const entity = workDoc()
-        const remove = () => {
-          const removedPlaceholder = Entity.removePlaceholder(entity)
-          removedPlaceholder.updated.should.be.above(entity.updated)
-          done()
-        }
-        setTimeout(remove, 5)
-      })
+  describe('beforeSave', () => {
+    it('should validate that no critical claim is missing', () => {
+      const entityDoc = workDoc()
+      delete entityDoc.claims['wdt:P31']
+      Entity.beforeSave.bind(null, entityDoc).should.throw()
+    })
+
+    it('should update the timestamp', () => {
+      const entityDoc = workDoc()
+      entityDoc.updated -= 1000
+      const timestampBefore = entityDoc.updated
+      Entity.beforeSave(entityDoc)
+      entityDoc.updated.should.be.above(timestampBefore)
+    })
+
+    it('should increment the version number', () => {
+      const entityDoc = workDoc()
+      const { version: versionBefore } = entityDoc
+      Entity.beforeSave(entityDoc)
+      entityDoc.version.should.equal(versionBefore + 1)
     })
   })
 })

--- a/tests/unit/models/025-patch.js
+++ b/tests/unit/models/025-patch.js
@@ -20,7 +20,8 @@ const currentDoc = {
     P31: [ 'Q47461344' ],
     P50: [ 'Q535' ]
   },
-  notTrackedAttr: 123
+  notTrackedAttr: 123,
+  version: 4
 }
 
 const updatedDoc = {
@@ -34,7 +35,8 @@ const updatedDoc = {
     P50: [ 'Q535', 'Q2001' ],
     P135: [ 'Q53121' ]
   },
-  notTrackedAttr: 456
+  notTrackedAttr: 456,
+  version: 5
 }
 
 const authorDoc = {
@@ -90,8 +92,8 @@ describe('patch', () => {
     it('should return with a timestamp', () => {
       const now = _.now()
       const patch = Patch.create({ userId, currentDoc, updatedDoc })
-      patch.timestamp.should.be.a.Number();
-      (patch.timestamp >= now).should.be.true()
+      patch.timestamp.should.be.a.Number()
+      should(patch.timestamp >= now).be.true()
     })
 
     it('should return with a patch object', () => {
@@ -115,12 +117,9 @@ describe('patch', () => {
       updateFromPatch.notTrackedAttr.should.not.equal(updatedDoc.notTrackedAttr)
     })
 
-    it('should return with an _id built from the document id and the version', () => {
+    it('should return with an id based on the updated doc version number', () => {
       const patch = Patch.create({ userId, currentDoc, updatedDoc })
-      const docId = updatedDoc._id
-      const version = updatedDoc._rev.split('-')[0]
-      patch._id.split(':')[0].should.equal(docId)
-      patch._id.split(':')[1].should.equal(version)
+      patch._id.should.equal(`${updatedDoc._id}:${updatedDoc.version}`)
     })
 
     it('should accept an arbitrary context object', () => {
@@ -310,16 +309,9 @@ describe('patch', () => {
 const generateSomePatch = previousVersion => {
   const newVersion = _.cloneDeep(previousVersion)
   newVersion._id = validDocId
-  newVersion._rev = incrementRev(previousVersion._rev)
+  newVersion.version++
   if (newVersion.labels.en) delete newVersion.labels.en
   else newVersion.labels = { en: randomString(6) }
   const patch = Patch.create({ userId, currentDoc: previousVersion, updatedDoc: newVersion })
   return { patch, newVersion }
-}
-
-const incrementRev = rev => {
-  if (!rev) return someRev
-  const [ numId, hash ] = rev.split('-')
-  const incrementedNumId = parseInt(numId) + 1
-  return `${incrementedNumId}-${hash}`
 }


### PR DESCRIPTION
After restoring the entities database without documents revs ids, all entities got their `_rev` integer component reset to `1`, which meant that new edits on those entities triggered the creation of patches with the same id as an existing patch, which is thus rejected as a conflict.

This PR addresses the problem by creating a version number on entities independent from revs ids.

After merging, and **before** deploying:
- set a `version` number on all entities
- try to recover lost patches
