### PR TITLE
get existing entities by isbn

### DIFF
--- a/server/controllers/entities/by_uris_get.js
+++ b/server/controllers/entities/by_uris_get.js
@@ -14,6 +14,10 @@ const validRelativesProperties = [
 const sanitization = {
   uris: {},
   refresh: { optional: true },
+  autocreate: {
+    generic: 'boolean',
+    optional: true
+  },
   relatives: {
     allowlist: validRelativesProperties,
     optional: true
@@ -23,8 +27,8 @@ const sanitization = {
 module.exports = (req, res) => {
   sanitize(req, res, sanitization)
   .then(params => {
-    const { uris, refresh, relatives } = params
-    return getEntitiesByUris({ uris, refresh })
+    const { uris, refresh, relatives, autocreate } = params
+    return getEntitiesByUris({ uris, refresh, autocreate })
     .then(addRelatives(relatives, refresh))
   })
   .then(responses_.Send(res))

--- a/server/controllers/entities/by_uris_get.js
+++ b/server/controllers/entities/by_uris_get.js
@@ -16,7 +16,8 @@ const sanitization = {
   refresh: { optional: true },
   autocreate: {
     generic: 'boolean',
-    optional: true
+    optional: true,
+    default: false
   },
   relatives: {
     allowlist: validRelativesProperties,

--- a/server/controllers/entities/lib/get_entities_by_isbns.js
+++ b/server/controllers/entities/lib/get_entities_by_isbns.js
@@ -31,9 +31,7 @@ module.exports = async (rawIsbns, params) => {
       results.notFound = _.map(notFound, 'isbn').map(prefixifyIsbn)
     }
   } else {
-    results.notFound = missingIsbns.map(isbn => {
-      return prefixifyIsbn(isbn.replace(/\W/g, ''))
-    })
+    results.notFound = missingIsbns.map(prefixifyIsbn)
   }
 
   return addRedirections(results, redirections)

--- a/server/controllers/entities/lib/get_entities_by_isbns.js
+++ b/server/controllers/entities/lib/get_entities_by_isbns.js
@@ -7,40 +7,38 @@ const formatEditionEntity = require('./format_edition_entity')
 const isbn_ = __.require('lib', 'isbn/isbn')
 const { prefixifyIsbn } = __.require('controllers', 'entities/lib/prefix')
 
-module.exports = (rawIsbns, params) => {
+module.exports = async (rawIsbns, params) => {
   const [ isbns, redirections ] = getRedirections(rawIsbns)
   const { refresh } = params
   // search entities by isbn locally
-  return entities_.byIsbns(isbns)
-  .then(entities => {
-    const foundIsbns = entities.map(getIsbn13h)
-    const missingIsbns = _.difference(isbns, foundIsbns)
+  let entities = await entities_.byIsbns(isbns)
+  const foundIsbns = entities.map(getIsbn13h)
+  const missingIsbns = _.difference(isbns, foundIsbns)
 
-    entities = entities.map(formatEditionEntity)
+  entities = entities.map(formatEditionEntity)
 
-    if (missingIsbns.length === 0) {
-      const results = { entities }
-      return addRedirections(results, redirections)
-    }
+  if (missingIsbns.length === 0) {
+    const results = { entities }
+    return addRedirections(results, redirections)
+  }
 
-    // then look for missing isbns on dataseed
-    return getMissingEditionEntitiesFromSeeds(missingIsbns, refresh)
-    .then(([ newEntities, notFound ]) => {
-      const results = { entities: entities.concat(newEntities) }
+  // then look for missing isbns on dataseed
+  const [ newEntities, notFound ] = await getMissingEditionEntitiesFromSeeds(missingIsbns, refresh)
 
-      if (notFound.length > 0) {
-        results.notFound = _.map(notFound, 'isbn').map(prefixifyIsbn)
-      }
+  const results = { entities: entities.concat(newEntities) }
 
-      return addRedirections(results, redirections)
-    })
-  })
+  if (notFound.length > 0) {
+    results.notFound = _.map(notFound, 'isbn').map(prefixifyIsbn)
+  }
+
+  return addRedirections(results, redirections)
 }
 
 const getIsbn13h = entity => entity.claims['wdt:P212'][0]
 
 const getMissingEditionEntitiesFromSeeds = async (isbns, refresh) => {
   const seeds = await dataseed.getByIsbns(isbns, refresh)
+
   const insufficientData = []
   const validSeeds = []
   // TODO: Filter out more aggressively bad quality seeds

--- a/server/controllers/entities/lib/get_entities_by_isbns.js
+++ b/server/controllers/entities/lib/get_entities_by_isbns.js
@@ -30,7 +30,12 @@ module.exports = async (rawIsbns, params) => {
   if (notFound.length > 0) {
     results.notFound = _.map(notFound, 'isbn').map(prefixifyIsbn)
   }
-
+  // if dataseed results are empty, populate notFound with missing uris
+  if (!(_.isNonEmptyArray(newEntities)) && (!(_.isNonEmptyArray(notFound)))) {
+    results.notFound = missingIsbns.map(isbn => {
+      return prefixifyIsbn(isbn.replace(/\W/g, ''))
+    })
+  }
   return addRedirections(results, redirections)
 }
 

--- a/tests/api/entities/get_by_uris.test.js
+++ b/tests/api/entities/get_by_uris.test.js
@@ -1,7 +1,7 @@
 const should = require('should')
 const { shouldNotBeCalled, rethrowShouldNotBeCalledErrors } = require('../utils/utils')
 
-const { createEditionWithIsbn, createWorkWithAuthor, createEditionWithWorkAuthorAndSerie, createHuman, someFakeUri } = require('../fixtures/entities')
+const { createEditionWithIsbn, createWorkWithAuthor, createEditionWithWorkAuthorAndSerie, createHuman, someFakeUri, generateIsbn13 } = require('../fixtures/entities')
 const { getByUris, merge } = require('../utils/entities')
 const workWithAuthorPromise = createWorkWithAuthor()
 
@@ -108,5 +108,21 @@ describe('entities:get:by-uris', () => {
       const serie = res.entities[serieUri]
       serie.should.be.an.Object()
     })
+  })
+})
+
+describe('entities:get:by-isbns', () => {
+  it('should return existing edition', async () => {
+    const { uri } = await createEditionWithIsbn()
+    const res = await getByUris(uri)
+    res.entities[uri].should.be.an.Object()
+  })
+
+  it('should return an isbns array of not found editions ', async () => {
+    const randomIsbn = generateIsbn13()
+    const uri = `isbn:${randomIsbn}`
+    const res = await getByUris(uri)
+    const { notFound } = res
+    notFound[0].should.equal(uri)
   })
 })

--- a/tests/api/entities/get_by_uris.test.js
+++ b/tests/api/entities/get_by_uris.test.js
@@ -1,5 +1,5 @@
 const should = require('should')
-const { shouldNotBeCalled, rethrowShouldNotBeCalledErrors } = require('../utils/utils')
+const { authReq, shouldNotBeCalled, rethrowShouldNotBeCalledErrors } = require('../utils/utils')
 
 const { createEditionWithIsbn, createWorkWithAuthor, createEditionWithWorkAuthorAndSerie, createHuman, someFakeUri, generateIsbn13 } = require('../fixtures/entities')
 const { getByUris, merge } = require('../utils/entities')
@@ -118,11 +118,9 @@ describe('entities:get:by-isbns', () => {
     res.entities[uri].should.be.an.Object()
   })
 
-  it('should return an isbns array of not found editions ', async () => {
-    const randomIsbn = generateIsbn13()
-    const uri = `isbn:${randomIsbn}`
-    const res = await getByUris(uri)
-    const { notFound } = res
-    notFound[0].should.equal(uri)
+  it('should return editions isbn in notFound array when autocreation if false', async () => {
+    const uri = `isbn:${generateIsbn13()}`
+    const res = await authReq('get', `/api/entities?action=by-uris&uris=${uri}&autocreate=false`)
+    res.notFound[0].should.equal(uri)
   })
 })


### PR DESCRIPTION
pass a boolean param (`existing`) to get_entity_by_uris to not trigger any creation when the requester does not want to create any entity when passing an isbn
known cases: checking if entity exists and/or if it has a cover before
uploading the image in order to feed the resolver with an `"invp:P2" : "imageHash"` from the media container only when necessary