### PR TITLE
473 search decrease popularity relevance

### DIFF
--- a/server/controllers/search/lib/entities_query_builder.js
+++ b/server/controllers/search/lib/entities_query_builder.js
@@ -68,7 +68,7 @@ const matchEntities = (search, userLang) => {
 
 const defaultEntitiesFields = userLang => {
   const fields = [
-    'labels.*^2',
+    'labels.*^4',
     'aliases.*^2',
     'descriptions.*'
   ]

--- a/server/controllers/search/lib/entities_query_builder.js
+++ b/server/controllers/search/lib/entities_query_builder.js
@@ -32,7 +32,10 @@ module.exports = params => {
               missing: '1'
             },
           }
-        ]
+        ],
+        // add the function result to the _score (instead of multiplying by default)
+        // which is drastically decreasing popularity boosting compared to default
+        boost_mode: 'sum'
       },
     },
     size,

--- a/server/controllers/search/lib/entities_query_builder.js
+++ b/server/controllers/search/lib/entities_query_builder.js
@@ -55,34 +55,27 @@ const matchEntities = (search, userLang) => {
       // see query strings doc : https://www.elastic.co/guide/en/elasticsearch/reference/7.9/query-dsl-query-string-query.html
       query_string: {
         query: search,
-        default_operator: 'AND',
-        boost: 5,
+        default_operator: 'AND'
       }
     },
     {
       multi_match: {
         query: search,
-        fields: flattenedTermsFields(userLang)
+        fields: entitiesFields(userLang)
       }
     }
   ]
 }
 
-const defaultEntitiesFields = userLang => {
+const entitiesFields = userLang => {
   const fields = [
     'labels.*^4',
     'aliases.*^2',
-    'descriptions.*'
+    'descriptions.*',
+    'flattenedLabels', // text type
+    'flattenedAliases', // text type
+    'flattenedDescriptions' // text type
   ]
   if (userLang) fields.push(`labels.${userLang}^4`)
   return fields
-}
-
-const flattenedTermsFields = userLang => {
-  return [
-    'flattenedLabels', // text type
-    'flattenedAliases', // text type
-    'flattenedDescriptions', // text type
-    ...defaultEntitiesFields(userLang)
-  ]
 }

--- a/server/controllers/search/lib/entities_query_builder.js
+++ b/server/controllers/search/lib/entities_query_builder.js
@@ -48,15 +48,14 @@ const matchType = types => {
 
 const matchEntities = (search, userLang) => {
   return [
-    // strict (operator 'and') match on all words
     {
-      multi_match: {
+      // see query strings doc : https://www.elastic.co/guide/en/elasticsearch/reference/7.9/query-dsl-query-string-query.html
+      query_string: {
         query: search,
-        operator: 'and',
-        fields: defaultEntitiesFields(userLang),
+        default_operator: 'AND',
+        boost: 5,
       }
     },
-    // match on some words
     {
       multi_match: {
         query: search,


### PR DESCRIPTION
fix #473 

tested with queries
"Jean baudrillard"
"Victor Hugo"
"Alexandre Dumas"
"Victor mees"
"Sanjay Gandhi"
on "All", "Author" and "Work"

one may see the score results by adding a function to `server/controllers/search/lib/type_search.js#L43` such as: 
```js
  .then(foo => {
    const bar = foo.hits.hits.map(f => {
      return {
        score: f._score,
        label: f._source.labels.en || f._source.labels.fr || 'foo',
        id: f._id
      }
    })
    console.log('result', bar)
    return foo
  })
```