### PR TITLE
add OAuth server

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -30,6 +30,7 @@
     "eqeqeq": [ "error", "smart" ],
     "implicit-arrow-linebreak": [ "error", "beside" ],
     "indent": [ "error", 2, { "MemberExpression": "off" } ],
+    "no-ex-assign": [ "off" ],
     "no-var": [ "error" ],
     "nonblock-statement-body-position": [ "error", "beside" ],
     "object-curly-spacing": [ "error", "always" ],

--- a/config/default.js
+++ b/config/default.js
@@ -91,7 +91,7 @@ const config = module.exports = {
 
   serveStaticFiles: true,
 
-  hashPasswords: true,
+  useSlowPasswordHashFunction: true,
   requestsLogger: {
     // Use to mute certain requests if it gets too noisy or you want to focus on a certain domain
     // Possible values: js, css, img, api

--- a/config/default.js
+++ b/config/default.js
@@ -201,5 +201,9 @@ const config = module.exports = {
   entitiesRelationsTemporaryCache: {
     checkFrequency: 10 * 60 * 1000,
     ttl: 4 * 60 * 60 * 1000
+  },
+
+  oauthServer: {
+    authorizationCodeLifetimeMs: 5 * 60 * 1000
   }
 }

--- a/config/tests-api.js
+++ b/config/tests-api.js
@@ -37,8 +37,8 @@ module.exports = {
 
   leveldbMemoryBackend: false,
 
-  // Disable password hashing to make tests run faster
-  hashPasswords: false,
+  // Makes tests run faster
+  useSlowPasswordHashFunction: false,
   piwik: {
     enabled: false
   },

--- a/config/tests-api.js
+++ b/config/tests-api.js
@@ -50,5 +50,9 @@ module.exports = {
     disabled: true
   },
 
-  itemsCountDebounceTime: 500
+  itemsCountDebounceTime: 500,
+
+  oauthServer: {
+    authorizationCodeLifetimeMs: 1000
+  },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "credential": "^2.0.0",
         "email-addresses": "^2.0.1",
         "express": "^4.16.3",
+        "express-oauth-server": "^2.0.0",
         "express-session": "^1.15.6",
         "formidable": "^1.0.17",
         "gm": "^1.23.1",
@@ -368,6 +369,14 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/basic-auth": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.1.0.tgz",
+      "integrity": "sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ=",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.1",
       "license": "BSD-3-Clause",
@@ -417,6 +426,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "node_modules/body-parser": {
       "version": "1.18.2",
@@ -857,6 +871,31 @@
       "license": "MIT",
       "bin": {
         "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/co-bluebird": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/co-bluebird/-/co-bluebird-1.1.0.tgz",
+      "integrity": "sha1-yLnzqTIKftMJh9zKGlw8/1llXHw=",
+      "dependencies": {
+        "bluebird": "^2.10.0",
+        "co-use": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/co-bluebird/node_modules/bluebird": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+      "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+    },
+    "node_modules/co-use": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/co-use/-/co-use-1.1.0.tgz",
+      "integrity": "sha1-xrs83xDLc17Kqdru2kbXJclKTmI=",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/color-convert": {
@@ -1923,6 +1962,19 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/express-oauth-server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/express-oauth-server/-/express-oauth-server-2.0.0.tgz",
+      "integrity": "sha1-V7CGZcEgFTL1LEwC8ZcJI4uZpI0=",
+      "dependencies": {
+        "bluebird": "^3.0.5",
+        "express": "^4.13.3",
+        "oauth2-server": "3.0.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      }
+    },
     "node_modules/express-session": {
       "version": "1.15.6",
       "license": "MIT",
@@ -2725,6 +2777,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/is-generator": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-generator/-/is-generator-1.0.3.tgz",
+      "integrity": "sha1-wUwhBX7TbjKNuANHlmxpP4hjifM="
     },
     "node_modules/is-glob": {
       "version": "4.0.1",
@@ -3832,6 +3889,32 @@
       "version": "2.2.6",
       "license": "MIT"
     },
+    "node_modules/oauth2-server": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/oauth2-server/-/oauth2-server-3.0.0.tgz",
+      "integrity": "sha1-xGJ2t0w9KGNNWe6YH3a1imRZzCg=",
+      "dependencies": {
+        "basic-auth": "1.1.0",
+        "bluebird": "3.5.0",
+        "lodash": "4.17.4",
+        "promisify-any": "2.0.1",
+        "statuses": "1.3.1",
+        "type-is": "1.6.15"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/oauth2-server/node_modules/bluebird": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
+    },
+    "node_modules/oauth2-server/node_modules/lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
     "node_modules/object-inspect": {
       "version": "1.7.0",
       "dev": true,
@@ -4343,6 +4426,24 @@
       "dependencies": {
         "asap": "~2.0.6"
       }
+    },
+    "node_modules/promisify-any": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promisify-any/-/promisify-any-2.0.1.tgz",
+      "integrity": "sha1-QD4AqIE/F1JCq1D+M6afjuzkcwU=",
+      "dependencies": {
+        "bluebird": "^2.10.0",
+        "co-bluebird": "^1.1.0",
+        "is-generator": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/promisify-any/node_modules/bluebird": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+      "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
     },
     "node_modules/protocol-buffers-encodings": {
       "version": "1.1.0",
@@ -5992,6 +6093,11 @@
     "base64-js": {
       "version": "0.0.2"
     },
+    "basic-auth": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.1.0.tgz",
+      "integrity": "sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ="
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
       "optional": true,
@@ -6031,6 +6137,11 @@
       "requires": {
         "node-fetch": "^2.6.0"
       }
+    },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "body-parser": {
       "version": "1.18.2",
@@ -6335,6 +6446,27 @@
           "version": "3.4.0"
         }
       }
+    },
+    "co-bluebird": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/co-bluebird/-/co-bluebird-1.1.0.tgz",
+      "integrity": "sha1-yLnzqTIKftMJh9zKGlw8/1llXHw=",
+      "requires": {
+        "bluebird": "^2.10.0",
+        "co-use": "^1.1.0"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+        }
+      }
+    },
+    "co-use": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/co-use/-/co-use-1.1.0.tgz",
+      "integrity": "sha1-xrs83xDLc17Kqdru2kbXJclKTmI="
     },
     "color-convert": {
       "version": "1.9.3",
@@ -7113,6 +7245,16 @@
         "promise": "^8.0.2"
       }
     },
+    "express-oauth-server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/express-oauth-server/-/express-oauth-server-2.0.0.tgz",
+      "integrity": "sha1-V7CGZcEgFTL1LEwC8ZcJI4uZpI0=",
+      "requires": {
+        "bluebird": "^3.0.5",
+        "express": "^4.13.3",
+        "oauth2-server": "3.0.0"
+      }
+    },
     "express-session": {
       "version": "1.15.6",
       "requires": {
@@ -7534,6 +7676,11 @@
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "dev": true
+    },
+    "is-generator": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-generator/-/is-generator-1.0.3.tgz",
+      "integrity": "sha1-wUwhBX7TbjKNuANHlmxpP4hjifM="
     },
     "is-glob": {
       "version": "4.0.1",
@@ -8308,6 +8455,31 @@
     "oauth-1.0a": {
       "version": "2.2.6"
     },
+    "oauth2-server": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/oauth2-server/-/oauth2-server-3.0.0.tgz",
+      "integrity": "sha1-xGJ2t0w9KGNNWe6YH3a1imRZzCg=",
+      "requires": {
+        "basic-auth": "1.1.0",
+        "bluebird": "3.5.0",
+        "lodash": "4.17.4",
+        "promisify-any": "2.0.1",
+        "statuses": "1.3.1",
+        "type-is": "1.6.15"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+        }
+      }
+    },
     "object-inspect": {
       "version": "1.7.0",
       "dev": true
@@ -8619,6 +8791,23 @@
       "version": "8.1.0",
       "requires": {
         "asap": "~2.0.6"
+      }
+    },
+    "promisify-any": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promisify-any/-/promisify-any-2.0.1.tgz",
+      "integrity": "sha1-QD4AqIE/F1JCq1D+M6afjuzkcwU=",
+      "requires": {
+        "bluebird": "^2.10.0",
+        "co-bluebird": "^1.1.0",
+        "is-generator": "^1.0.2"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+        }
       }
     },
     "protocol-buffers-encodings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "email-addresses": "^2.0.1",
         "express": "^4.16.3",
         "express-oauth-server": "^2.0.0",
-        "express-session": "^1.15.6",
         "formidable": "^1.0.17",
         "gm": "^1.23.1",
         "inv-loggers": "^3.3.15",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "credential": "^2.0.0",
     "email-addresses": "^2.0.1",
     "express": "^4.16.3",
+    "express-oauth-server": "^2.0.0",
     "express-session": "^1.15.6",
     "formidable": "^1.0.17",
     "gm": "^1.23.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "email-addresses": "^2.0.1",
     "express": "^4.16.3",
     "express-oauth-server": "^2.0.0",
-    "express-session": "^1.15.6",
     "formidable": "^1.0.17",
     "gm": "^1.23.1",
     "inv-loggers": "^3.3.15",

--- a/server/controllers/auth/clients_by_ids.js
+++ b/server/controllers/auth/clients_by_ids.js
@@ -1,0 +1,29 @@
+const __ = require('config').universalPath
+const _ = __.require('builders', 'utils')
+const responses_ = __.require('lib', 'responses')
+const error_ = __.require('lib', 'error/error')
+const sanitize = __.require('lib', 'sanitize/sanitize')
+const clients_ = require('./lib/oauth/clients')
+
+const sanitization = {
+  ids: {},
+}
+
+module.exports = (req, res, next) => {
+  sanitize(req, res, sanitization)
+  .then(getClientsByIds)
+  .then(responses_.Wrap(res, 'clients'))
+  .catch(error_.Handler(req, res))
+}
+
+const getClientsByIds = async ({ ids }) => {
+  let clients = await clients_.byIds(ids)
+  clients = clients.map(omitPrivateData)
+  return _.keyBy(clients, '_id')
+}
+
+const omitPrivateData = client => _.omit(client, privateAttributes)
+
+const privateAttributes = [
+  'secret'
+]

--- a/server/controllers/auth/clients_by_ids.js
+++ b/server/controllers/auth/clients_by_ids.js
@@ -1,8 +1,7 @@
-const __ = require('config').universalPath
-const _ = __.require('builders', 'utils')
-const responses_ = __.require('lib', 'responses')
-const error_ = __.require('lib', 'error/error')
-const sanitize = __.require('lib', 'sanitize/sanitize')
+const _ = require('builders/utils')
+const responses_ = require('lib/responses')
+const error_ = require('lib/error/error')
+const sanitize = require('lib/sanitize/sanitize')
 const clients_ = require('./lib/oauth/clients')
 
 const sanitization = {

--- a/server/controllers/auth/lib/oauth/authorizations.js
+++ b/server/controllers/auth/lib/oauth/authorizations.js
@@ -1,0 +1,29 @@
+const __ = require('config').universalPath
+const db = __.require('couch', 'base')('oauth_authorizations')
+const assert_ = __.require('utils', 'assert_types')
+const { omit } = require('lodash')
+const idAttribute = 'authorizationCode'
+
+module.exports = {
+  byId: async id => {
+    const doc = await db.get(id)
+    doc[idAttribute] = doc._id
+    doc.expiresAt = new Date(doc.expiresAt)
+    return doc
+  },
+
+  save: async (code, userId, clientId) => {
+    assert_.object(code)
+    assert_.string(userId)
+    assert_.string(clientId)
+
+    const idAttributeValue = code[idAttribute]
+    const doc = omit(code, [ idAttribute ])
+    doc._id = idAttributeValue
+    doc.userId = userId
+    doc.clientId = clientId
+    await db.put(doc)
+  },
+
+  delete: async ({ _id, _rev }) => db.delete(_id, _rev)
+}

--- a/server/controllers/auth/lib/oauth/authorizations.js
+++ b/server/controllers/auth/lib/oauth/authorizations.js
@@ -1,6 +1,5 @@
-const __ = require('config').universalPath
-const db = __.require('couch', 'base')('oauth_authorizations')
-const assert_ = __.require('utils', 'assert_types')
+const db = require('db/couchdb/base')('oauth_authorizations')
+const assert_ = require('lib/utils/assert_types')
 const { omit } = require('lodash')
 const idAttribute = 'authorizationCode'
 

--- a/server/controllers/auth/lib/oauth/clients.js
+++ b/server/controllers/auth/lib/oauth/clients.js
@@ -6,5 +6,7 @@ module.exports = {
     const doc = await db.get(id)
     doc.id = doc._id
     return doc
-  }
+  },
+
+  byIds: db.byIds
 }

--- a/server/controllers/auth/lib/oauth/clients.js
+++ b/server/controllers/auth/lib/oauth/clients.js
@@ -1,0 +1,10 @@
+const __ = require('config').universalPath
+const db = __.require('couch', 'base')('oauth_clients')
+
+module.exports = {
+  byId: async id => {
+    const doc = await db.get(id)
+    doc.id = doc._id
+    return doc
+  }
+}

--- a/server/controllers/auth/lib/oauth/clients.js
+++ b/server/controllers/auth/lib/oauth/clients.js
@@ -1,5 +1,4 @@
-const __ = require('config').universalPath
-const db = __.require('couch', 'base')('oauth_clients')
+const db = require('db/couchdb/base')('oauth_clients')
 
 module.exports = {
   byId: async id => {

--- a/server/controllers/auth/lib/oauth/model.js
+++ b/server/controllers/auth/lib/oauth/model.js
@@ -1,0 +1,81 @@
+// This module implements a model object as expected by express-oauth-server and oauth2-server
+// See specification https://oauth2-server.readthedocs.io/en/latest/model/overview.html
+
+const clientsDb = {
+  c4252a3321c1234b0bf82430dd2f7f69: {
+    id: 'c4252a3321c1234b0bf82430dd2f7f69',
+    redirectUris: [
+      'http://localhost:8888/wiki/Special:OAuth2Client/callback',
+    ],
+    grants: [ 'authorization_code' ],
+    scope: [ 'profile' ]
+  }
+}
+const usersDb = {}
+const authorizationCodesDb = {}
+const tokensDb = {}
+
+module.exports = {
+  // Spec https://oauth2-server.readthedocs.io/en/latest/model/spec.html#getaccesstoken-accesstoken-callback
+  getAccessToken: async bearerToken => {
+    if (!bearerToken) return false
+    const token = tokensDb[bearerToken]
+    if (!token) return false
+    const client = clientsDb[token.client]
+    const user = usersDb[token.user]
+    return Object.assign({}, token, { client, user })
+  },
+
+  // Spec https://oauth2-server.readthedocs.io/en/latest/model/spec.html#getclient-clientid-clientsecret-callback
+  getClient: async (clientId, clientSecret) => {
+    const client = clientsDb[clientId]
+    return client
+  },
+
+  // Spec https://oauth2-server.readthedocs.io/en/latest/model/spec.html#saveauthorizationcode-code-client-user-callback
+  saveAuthorizationCode: async (code, client, user) => {
+    const { authorizationCode } = code
+    authorizationCodesDb[authorizationCode] = code
+    authorizationCodesDb[authorizationCode].user = user._id
+    authorizationCodesDb[authorizationCode].client = client.id
+
+    // Temp hack to keep user doc at hand
+    usersDb[user._id] = user
+
+    return Object.assign({}, code, { client, user })
+  },
+
+  // Spec https://oauth2-server.readthedocs.io/en/latest/model/spec.html#getauthorizationcode-authorizationcode-callback
+  getAuthorizationCode: authorizationCode => {
+    const foundAuthorizationCode = authorizationCodesDb[authorizationCode]
+    const client = clientsDb[foundAuthorizationCode.client]
+    const user = usersDb[foundAuthorizationCode.user]
+    return Object.assign({}, foundAuthorizationCode, { client, user })
+  },
+
+  // Spec https://oauth2-server.readthedocs.io/en/latest/model/spec.html#savetoken-token-client-user-callback
+  saveToken: (token, client, user) => {
+    tokensDb[token.accessToken] = token
+    tokensDb[token.accessToken].user = user._id
+    tokensDb[token.accessToken].client = client.id
+    return Object.assign({}, token, { client, user })
+  },
+
+  // Spec https://oauth2-server.readthedocs.io/en/latest/model/spec.html#revokeauthorizationcode-code-callback
+  revokeAuthorizationCode: code => {
+    const { authorizationCode } = code
+    const foundAuthorizationCode = authorizationCodesDb[authorizationCode]
+    if (foundAuthorizationCode != null) {
+      delete authorizationCodesDb[authorizationCode]
+      return true
+    } else {
+      return false
+    }
+  },
+
+  // Spec https://oauth2-server.readthedocs.io/en/latest/model/spec.html#validatescope-user-client-scope-callback
+  validateScope: (user, client, scope) => {
+    if (client.scope.length === 1 && client.scope[0] === scope) return scope
+    else return false
+  }
+}

--- a/server/controllers/auth/lib/oauth/model.js
+++ b/server/controllers/auth/lib/oauth/model.js
@@ -4,12 +4,12 @@
 const __ = require('config').universalPath
 const user_ = __.require('controllers', 'user/lib/user')
 const error_ = __.require('lib', 'error/error')
-const assert_ = __.require('utils', 'assert_types')
 const { catchNotFound } = error_
-
+const assert_ = __.require('utils', 'assert_types')
 const clients_ = require('./clients')
 const authorizations_ = require('./authorizations')
 const tokens_ = require('./tokens')
+const { passwords } = __.require('lib', 'crypto')
 const InvalidClientError = require('oauth2-server/lib/errors/invalid-client-error')
 
 module.exports = {
@@ -25,19 +25,24 @@ module.exports = {
 
   // Spec https://oauth2-server.readthedocs.io/en/latest/model/spec.html#getclient-clientid-clientsecret-callback
   getClient: async (clientId, clientSecret) => {
-    return clients_.byId(clientId)
-    .then(client => {
-      // Secret validation is done only while trying to optain a token, not when generating an authorization
-      if (clientSecret === null) return client
-      // TODO: store the client secret as we would store a password: hashed and slow
-      if (client.secret === clientSecret) return client
-      // Without a valid client, oauth2-server@3.0.0 throws 'client is invalid', which is quite unspecific
-      else throw new InvalidClientError('Invalid client: client credentials are invalid')
-    })
-    .catch(err => {
+    let client
+    try {
+      client = await clients_.byId(clientId)
+    } catch (err) {
       if (err.statusCode === 404) throw error_.new('unknown client', 400, { clientId })
       else throw err
-    })
+    }
+
+    // Secret validation is done only while trying to optain a token, not when generating an authorization
+    if (clientSecret === null) return client
+
+    const isValidSecret = await passwords.verify(client.secret, clientSecret)
+    if (isValidSecret) {
+      return client
+    } else {
+      // Without a valid client, oauth2-server@3.0.0 throws 'client is invalid', which is quite unspecific
+      throw new InvalidClientError('Invalid client: client credentials are invalid')
+    }
   },
 
   // Spec https://oauth2-server.readthedocs.io/en/latest/model/spec.html#saveauthorizationcode-code-client-user-callback

--- a/server/controllers/auth/lib/oauth/model.js
+++ b/server/controllers/auth/lib/oauth/model.js
@@ -1,72 +1,61 @@
 // This module implements a model object as expected by express-oauth-server and oauth2-server
 // See specification https://oauth2-server.readthedocs.io/en/latest/model/overview.html
 
-const clientsDb = {
-  c4252a3321c1234b0bf82430dd2f7f69: {
-    id: 'c4252a3321c1234b0bf82430dd2f7f69',
-    redirectUris: [
-      'http://localhost:8888/wiki/Special:OAuth2Client/callback',
-    ],
-    grants: [ 'authorization_code' ],
-    scope: [ 'profile' ]
-  }
-}
-const usersDb = {}
-const authorizationCodesDb = {}
-const tokensDb = {}
+const __ = require('config').universalPath
+const user_ = __.require('controllers', 'user/lib/user')
+const error_ = __.require('lib', 'error/error')
+const assert_ = __.require('utils', 'assert_types')
+
+const clients_ = require('./clients')
+const authorizations_ = require('./authorizations')
+const tokens_ = require('./tokens')
 
 module.exports = {
   // Spec https://oauth2-server.readthedocs.io/en/latest/model/spec.html#getaccesstoken-accesstoken-callback
   getAccessToken: async bearerToken => {
     if (!bearerToken) return false
-    const token = tokensDb[bearerToken]
+    const token = await tokens_.byId(bearerToken)
     if (!token) return false
-    const client = clientsDb[token.client]
-    const user = usersDb[token.user]
-    return Object.assign({}, token, { client, user })
+    const client = await clients_.byId(token.clientId)
+    const user = await user_.byId(token.userId)
+    return Object.assign(token, { client, user })
   },
 
   // Spec https://oauth2-server.readthedocs.io/en/latest/model/spec.html#getclient-clientid-clientsecret-callback
   getClient: async (clientId, clientSecret) => {
-    const client = clientsDb[clientId]
-    return client
+    return clients_.byId(clientId)
+    .catch(err => {
+      if (err.statusCode === 404) throw error_.new('unknown client', 400, { clientId })
+      else throw err
+    })
   },
 
   // Spec https://oauth2-server.readthedocs.io/en/latest/model/spec.html#saveauthorizationcode-code-client-user-callback
   saveAuthorizationCode: async (code, client, user) => {
-    const { authorizationCode } = code
-    authorizationCodesDb[authorizationCode] = code
-    authorizationCodesDb[authorizationCode].user = user._id
-    authorizationCodesDb[authorizationCode].client = client.id
-
-    // Temp hack to keep user doc at hand
-    usersDb[user._id] = user
-
-    return Object.assign({}, code, { client, user })
+    await authorizations_.save(code, user._id, client.id)
+    return Object.assign(code, { client, user })
   },
 
   // Spec https://oauth2-server.readthedocs.io/en/latest/model/spec.html#getauthorizationcode-authorizationcode-callback
-  getAuthorizationCode: authorizationCode => {
-    const foundAuthorizationCode = authorizationCodesDb[authorizationCode]
-    const client = clientsDb[foundAuthorizationCode.client]
-    const user = usersDb[foundAuthorizationCode.user]
-    return Object.assign({}, foundAuthorizationCode, { client, user })
+  getAuthorizationCode: async authorizationCode => {
+    const foundAuthorizationCode = await authorizations_.byId(authorizationCode)
+    const client = await clients_.byId(foundAuthorizationCode.clientId)
+    const user = await user_.byId(foundAuthorizationCode.userId)
+    return Object.assign(foundAuthorizationCode, { client, user })
   },
 
   // Spec https://oauth2-server.readthedocs.io/en/latest/model/spec.html#savetoken-token-client-user-callback
-  saveToken: (token, client, user) => {
-    tokensDb[token.accessToken] = token
-    tokensDb[token.accessToken].user = user._id
-    tokensDb[token.accessToken].client = client.id
-    return Object.assign({}, token, { client, user })
+  saveToken: async (token, client, user) => {
+    await tokens_.save(token, user._id, client.id)
+    return Object.assign(token, { client, user })
   },
 
   // Spec https://oauth2-server.readthedocs.io/en/latest/model/spec.html#revokeauthorizationcode-code-callback
-  revokeAuthorizationCode: code => {
+  revokeAuthorizationCode: async code => {
     const { authorizationCode } = code
-    const foundAuthorizationCode = authorizationCodesDb[authorizationCode]
+    const foundAuthorizationCode = await authorizations_.byId(authorizationCode)
     if (foundAuthorizationCode != null) {
-      delete authorizationCodesDb[authorizationCode]
+      await authorizations_.delete(foundAuthorizationCode)
       return true
     } else {
       return false
@@ -74,7 +63,8 @@ module.exports = {
   },
 
   // Spec https://oauth2-server.readthedocs.io/en/latest/model/spec.html#validatescope-user-client-scope-callback
-  validateScope: (user, client, scope) => {
+  validateScope: async (user, client, scope) => {
+    assert_.array(client.scope)
     if (client.scope.length === 1 && client.scope[0] === scope) return scope
     else return false
   }

--- a/server/controllers/auth/lib/oauth/model.js
+++ b/server/controllers/auth/lib/oauth/model.js
@@ -64,16 +64,23 @@ module.exports = {
 
   // Spec https://oauth2-server.readthedocs.io/en/latest/model/spec.html#validatescope-user-client-scope-callback
   validateScope: async (user, client, scope) => {
+    if (typeof scope === 'string') scope = getScopeArray(scope)
     assert_.array(client.scope)
-    if (client.scope.length === 1 && client.scope[0] === scope) return scope
-    else return false
+    if (scope.every(scopePart => client.scope.includes(scopePart))) {
+      return scope
+    } else {
+      return false
+    }
   },
 
   // Spec https://oauth2-server.readthedocs.io/en/latest/model/spec.html#verifyscope-accesstoken-scope-callback
   verifyScope: async (token, acceptedScopes) => {
-    if (typeof token.scope === 'string') token.scope = token.scope.split(' ')
+    if (typeof token.scope === 'string') token.scope = getScopeArray(token.scope)
     assert_.array(acceptedScopes)
     token.matchingScopes = token.scope.filter(scope => acceptedScopes.includes(scope))
     return token.matchingScopes.length > 0
   }
 }
+
+const scopeSeparators = /[+\s]/
+const getScopeArray = scopeStr => scopeStr.split(scopeSeparators)

--- a/server/controllers/auth/lib/oauth/model.js
+++ b/server/controllers/auth/lib/oauth/model.js
@@ -67,5 +67,13 @@ module.exports = {
     assert_.array(client.scope)
     if (client.scope.length === 1 && client.scope[0] === scope) return scope
     else return false
+  },
+
+  // Spec https://oauth2-server.readthedocs.io/en/latest/model/spec.html#verifyscope-accesstoken-scope-callback
+  verifyScope: async (token, acceptedScopes) => {
+    if (typeof token.scope === 'string') token.scope = token.scope.split(' ')
+    assert_.array(acceptedScopes)
+    token.matchingScopes = token.scope.filter(scope => acceptedScopes.includes(scope))
+    return token.matchingScopes.length > 0
   }
 }

--- a/server/controllers/auth/lib/oauth/model.js
+++ b/server/controllers/auth/lib/oauth/model.js
@@ -1,15 +1,14 @@
 // This module implements a model object as expected by express-oauth-server and oauth2-server
 // See specification https://oauth2-server.readthedocs.io/en/latest/model/overview.html
 
-const __ = require('config').universalPath
-const user_ = __.require('controllers', 'user/lib/user')
-const error_ = __.require('lib', 'error/error')
+const user_ = require('controllers/user/lib/user')
+const error_ = require('lib/error/error')
 const { catchNotFound } = error_
-const assert_ = __.require('utils', 'assert_types')
+const assert_ = require('lib/utils/assert_types')
 const clients_ = require('./clients')
 const authorizations_ = require('./authorizations')
 const tokens_ = require('./tokens')
-const { passwords } = __.require('lib', 'crypto')
+const { passwords } = require('lib/crypto')
 const InvalidClientError = require('oauth2-server/lib/errors/invalid-client-error')
 
 module.exports = {

--- a/server/controllers/auth/lib/oauth/scopes.js
+++ b/server/controllers/auth/lib/oauth/scopes.js
@@ -9,6 +9,6 @@ module.exports = {
 
 const scopeByMethodAndRoute = {
   get: {
-    '/api/user': [ 'profile', 'wiki-stable-profile' ]
+    '/api/user': [ 'username', 'stable-username', 'email' ]
   }
 }

--- a/server/controllers/auth/lib/oauth/scopes.js
+++ b/server/controllers/auth/lib/oauth/scopes.js
@@ -1,0 +1,14 @@
+module.exports = {
+  getAcceptedScopes: ({ method, url }) => {
+    method = method.toLowerCase()
+    if (scopeByMethodAndRoute[method] != null) {
+      return scopeByMethodAndRoute[method][url]
+    }
+  }
+}
+
+const scopeByMethodAndRoute = {
+  get: {
+    '/api/user': [ 'profile', 'wiki-stable-profile' ]
+  }
+}

--- a/server/controllers/auth/lib/oauth/scopes.js
+++ b/server/controllers/auth/lib/oauth/scopes.js
@@ -1,14 +1,17 @@
+const _ = require('builders/utils')
+
+const scopeByMethodAndRoute = {
+  get: {
+    '/api/user': [ 'username', 'stable-username', 'email' ]
+  }
+}
+
 module.exports = {
   getAcceptedScopes: ({ method, url }) => {
     method = method.toLowerCase()
     if (scopeByMethodAndRoute[method] != null) {
       return scopeByMethodAndRoute[method][url]
     }
-  }
-}
-
-const scopeByMethodAndRoute = {
-  get: {
-    '/api/user': [ 'username', 'stable-username', 'email' ]
-  }
+  },
+  allScopes: _.flattenDeep(Object.values(scopeByMethodAndRoute).map(Object.values))
 }

--- a/server/controllers/auth/lib/oauth/tokens.js
+++ b/server/controllers/auth/lib/oauth/tokens.js
@@ -1,0 +1,28 @@
+const __ = require('config').universalPath
+const db = __.require('couch', 'base')('oauth_tokens')
+const assert_ = __.require('utils', 'assert_types')
+const { omit } = require('lodash')
+const idAttribute = 'accessToken'
+
+module.exports = {
+  byId: async id => {
+    const doc = await db.get(id)
+    doc[idAttribute] = doc._id
+    doc.accessTokenExpiresAt = new Date(doc.accessTokenExpiresAt)
+    doc.refreshTokenExpiresAt = new Date(doc.refreshTokenExpiresAt)
+    return doc
+  },
+
+  save: async (token, userId, clientId) => {
+    assert_.object(token)
+    assert_.string(userId)
+    assert_.string(clientId)
+
+    const idAttributeValue = token[idAttribute]
+    const doc = omit(token, [ idAttribute ])
+    doc._id = idAttributeValue
+    doc.userId = userId
+    doc.clientId = clientId
+    await db.put(doc)
+  }
+}

--- a/server/controllers/auth/lib/oauth/tokens.js
+++ b/server/controllers/auth/lib/oauth/tokens.js
@@ -1,6 +1,5 @@
-const __ = require('config').universalPath
-const db = __.require('couch', 'base')('oauth_tokens')
-const assert_ = __.require('utils', 'assert_types')
+const db = require('db/couchdb/base')('oauth_tokens')
+const assert_ = require('lib/utils/assert_types')
 const { omit } = require('lodash')
 const idAttribute = 'accessToken'
 

--- a/server/controllers/auth/oauth_clients.js
+++ b/server/controllers/auth/oauth_clients.js
@@ -1,0 +1,10 @@
+const __ = require('config').universalPath
+const ActionsControllers = __.require('lib', 'actions_controllers')
+
+module.exports = {
+  get: ActionsControllers({
+    public: {
+      'by-ids': require('./clients_by_ids'),
+    }
+  })
+}

--- a/server/controllers/auth/oauth_clients.js
+++ b/server/controllers/auth/oauth_clients.js
@@ -1,5 +1,4 @@
-const __ = require('config').universalPath
-const ActionsControllers = __.require('lib', 'actions_controllers')
+const ActionsControllers = require('lib/actions_controllers')
 
 module.exports = {
   get: ActionsControllers({

--- a/server/controllers/auth/oauth_server.js
+++ b/server/controllers/auth/oauth_server.js
@@ -1,0 +1,37 @@
+const OAuthServer = require('express-oauth-server')
+
+const oauthServer = new OAuthServer({
+  useErrorHandler: true,
+  model: require('./lib/oauth/model')
+})
+
+const authorize = oauthServer.authorize({
+  authenticateHandler: {
+    handle: (req, res) => {
+      // TODO: handle when user isn't logged in
+      return req.user
+    }
+  }
+})
+
+// See https://oauth2-server.readthedocs.io/en/latest/api/oauth2-server.html
+module.exports = {
+  // Step 1: the user authorizes a client to get tokens on its behalf, for certain scopes
+  // by doing a GET on the authorize endpoint
+  // Implements https://aaronparecki.com/oauth-2-simplified/#web-server-apps "Authorization"
+  authorize: {
+    get: authorize
+  },
+
+  // Step 2: the client requests a token
+  // by doing a POST on the token endpoint
+  // Implements https://aaronparecki.com/oauth-2-simplified/#web-server-apps "Getting an Access Token"
+  token: {
+    post: oauthServer.token()
+  },
+
+  // Step 3: the client uses a token to access resources within the token authorized scopes
+  // That token is used by the authenticate middleware to accept or decline the access on any endpoint
+  // Implements https://aaronparecki.com/oauth-2-simplified/#making-authenticated-requests
+  authenticate: oauthServer.authenticate()
+}

--- a/server/controllers/auth/oauth_server.js
+++ b/server/controllers/auth/oauth_server.js
@@ -1,6 +1,7 @@
 const __ = require('config').universalPath
 const error_ = __.require('lib', 'error/error')
 const OAuthServer = require('express-oauth-server')
+const { getAcceptedScopes } = require('./lib/oauth/scopes')
 
 const oauthServer = new OAuthServer({
   useErrorHandler: true,
@@ -45,18 +46,5 @@ module.exports = {
     const scope = getAcceptedScopes(req)
     if (scope != null) oauthServer.authenticate({ scope })(req, res, next)
     else return error_.bundle(req, res, 'this resource can not be accessed with an OAuth bearer token', 403)
-  }
-}
-
-const getAcceptedScopes = ({ method, url }) => {
-  method = method.toLowerCase()
-  if (scopeByMethodAndRoute[method] != null) {
-    return scopeByMethodAndRoute[method][url]
-  }
-}
-
-const scopeByMethodAndRoute = {
-  get: {
-    '/api/user': [ 'profile' ]
   }
 }

--- a/server/controllers/auth/oauth_server.js
+++ b/server/controllers/auth/oauth_server.js
@@ -43,7 +43,8 @@ module.exports = {
   // Implements https://aaronparecki.com/oauth-2-simplified/#making-authenticated-requests
   authenticate: (req, res, next) => {
     const scope = getAcceptedScopes(req)
-    oauthServer.authenticate({ scope })(req, res, next)
+    if (scope != null) oauthServer.authenticate({ scope })(req, res, next)
+    else return error_.bundle(req, res, 'this resource can not be accessed with an OAuth bearer token', 403)
   }
 }
 

--- a/server/controllers/auth/oauth_server.js
+++ b/server/controllers/auth/oauth_server.js
@@ -41,5 +41,21 @@ module.exports = {
   // Step 3: the client uses a token to access resources within the token authorized scopes
   // That token is used by the authenticate middleware to accept or decline the access on any endpoint
   // Implements https://aaronparecki.com/oauth-2-simplified/#making-authenticated-requests
-  authenticate: oauthServer.authenticate()
+  authenticate: (req, res, next) => {
+    const scope = getAcceptedScopes(req)
+    oauthServer.authenticate({ scope })(req, res, next)
+  }
+}
+
+const getAcceptedScopes = ({ method, url }) => {
+  method = method.toLowerCase()
+  if (scopeByMethodAndRoute[method] != null) {
+    return scopeByMethodAndRoute[method][url]
+  }
+}
+
+const scopeByMethodAndRoute = {
+  get: {
+    '/api/user': [ 'profile' ]
+  }
 }

--- a/server/controllers/auth/oauth_server.js
+++ b/server/controllers/auth/oauth_server.js
@@ -1,4 +1,6 @@
-const __ = require('config').universalPath
+const CONFIG = require('config')
+const __ = CONFIG.universalPath
+const { authorizationCodeLifetimeMs } = CONFIG.oauthServer
 const error_ = __.require('lib', 'error/error')
 const OAuthServer = require('express-oauth-server')
 const { getAcceptedScopes } = require('./lib/oauth/scopes')
@@ -9,6 +11,7 @@ const oauthServer = new OAuthServer({
 })
 
 const authorize = oauthServer.authorize({
+  authorizationCodeLifetime: authorizationCodeLifetimeMs / 1000,
   authenticateHandler: {
     handle: (req, res) => {
       return req.user

--- a/server/controllers/auth/oauth_server.js
+++ b/server/controllers/auth/oauth_server.js
@@ -1,7 +1,5 @@
-const CONFIG = require('config')
-const __ = CONFIG.universalPath
-const { authorizationCodeLifetimeMs } = CONFIG.oauthServer
-const error_ = __.require('lib', 'error/error')
+const { authorizationCodeLifetimeMs } = require('config').oauthServer
+const error_ = require('lib/error/error')
 const OAuthServer = require('express-oauth-server')
 const { getAcceptedScopes } = require('./lib/oauth/scopes')
 

--- a/server/controllers/auth/oauth_server.js
+++ b/server/controllers/auth/oauth_server.js
@@ -1,7 +1,8 @@
+const { someMatch } = require('builders/utils')
 const { authorizationCodeLifetimeMs } = require('config').oauthServer
 const error_ = require('lib/error/error')
 const OAuthServer = require('express-oauth-server')
-const { getAcceptedScopes } = require('./lib/oauth/scopes')
+const { getAcceptedScopes, allScopes } = require('./lib/oauth/scopes')
 
 const oauthServer = new OAuthServer({
   useErrorHandler: true,
@@ -28,6 +29,10 @@ module.exports = {
 
       const { scope } = req.query
       if (!scope) return error_.bundleMissingQuery(req, res, 'scope')
+      const scopes = scope.split(' ')
+      if (!someMatch(allScopes, scopes)) {
+        return error_.bundle(req, res, `invalid scope. Valid scopes available: ${allScopes.join(', ')}`, 400, scope)
+      }
 
       authorize(req, res, next)
     }

--- a/server/controllers/routes.js
+++ b/server/controllers/routes.js
@@ -2,6 +2,7 @@ const CONFIG = require('config')
 const endpoint = require('./endpoint')
 const extensionsRedirections = require('./extensions_redirections')
 const glob = require('./glob')
+const oauthServer = require('./auth/oauth_server')
 
 // Routes structure:
 // 1 - api is the default prefix for server-side routes
@@ -19,6 +20,8 @@ const routes = module.exports = {
   'api/invitations': endpoint('./invitations/invitations'),
   'api/items': endpoint('./items/items'),
   'api/notifications': endpoint('./notifications/notifications'),
+  'api/oauth/authorize': oauthServer.authorize,
+  'api/oauth/token': oauthServer.token,
   'api/relations': endpoint('./relations/relations'),
   'api/reports': endpoint('./reports/reports'),
   'api/search': endpoint('./search/search'),

--- a/server/controllers/routes.js
+++ b/server/controllers/routes.js
@@ -21,6 +21,7 @@ const routes = module.exports = {
   'api/items': endpoint('./items/items'),
   'api/notifications': endpoint('./notifications/notifications'),
   'api/oauth/authorize': oauthServer.authorize,
+  'api/oauth/clients': endpoint('./auth/oauth_clients'),
   'api/oauth/token': oauthServer.token,
   'api/relations': endpoint('./relations/relations'),
   'api/reports': endpoint('./reports/reports'),

--- a/server/controllers/user/get.js
+++ b/server/controllers/user/get.js
@@ -1,32 +1,40 @@
 const __ = require('config').universalPath
 const _ = __.require('builders', 'utils')
 const error_ = __.require('lib', 'error/error')
+const user_ = __.require('controllers', 'user/lib/user')
 const { ownerSafeData } = require('./lib/authorized_user_data_pickers')
 
 module.exports = (req, res) => {
-  try {
-    const data = getTailoredData(req, res)
-    res.json(data)
-  } catch (err) {
-    error_.handler(req, res, err)
+  getTailoredData(req, res)
+  .then(res.json.bind(res))
+  .catch(error_.Handler(req, res))
+}
+
+const getTailoredData = async (req, res) => {
+  // The logged in user as its document set on req.user by passport.js
+  const userData = ownerSafeData(req.user)
+
+  if (res.locals.scope != null) {
+    const attributesShortlist = getAllowedAttributes(res.locals.scope)
+    // In case there is an authorized request to a scope that includes
+    // the 'stableUsername' attribute, that means that a service now relies
+    // on the hypothesis that we will always return the same username for a given user
+    // This behavior is tailored
+    if (attributesShortlist.includes('stableUsername')) {
+      await user_.setStableUsername(userData)
+    }
+    return _.pick(userData, attributesShortlist)
+  } else {
+    return userData
   }
 }
 
-const getTailoredData = (req, res) => {
-  // The logged in user as its document set on req.user by passport.js
-  const userPrivateData = ownerSafeData(req.user)
-
-  if (res.locals.scope != null) {
-    const scope = res.locals.scope[0]
-    const attributesShortlist = attributesByScope[scope]
-    if (!attributesShortlist) throw error_.new('invalid scope', 500, { scope })
-    return _.pick(userPrivateData, attributesShortlist)
-  } else {
-    return userPrivateData
-  }
+const getAllowedAttributes = scopeNames => {
+  return scopeNames.map(scopeName => attributesByScope[scopeName])
 }
 
 const attributesByScope = {
-  // This scope is tailored to the needs of https://github.com/inventaire/inventaire-mediawiki
-  'wiki-stable-profile': [ '_id', 'email', 'username' ],
+  username: 'username',
+  'stable-username': 'stableUsername',
+  email: 'email',
 }

--- a/server/controllers/user/get.js
+++ b/server/controllers/user/get.js
@@ -1,7 +1,32 @@
+const __ = require('config').universalPath
+const _ = __.require('builders', 'utils')
+const error_ = __.require('lib', 'error/error')
 const { ownerSafeData } = require('./lib/authorized_user_data_pickers')
 
 module.exports = (req, res) => {
+  try {
+    const data = getTailoredData(req, res)
+    res.json(data)
+  } catch (err) {
+    error_.handler(req, res, err)
+  }
+}
+
+const getTailoredData = (req, res) => {
   // The logged in user as its document set on req.user by passport.js
   const userPrivateData = ownerSafeData(req.user)
-  res.json(userPrivateData)
+
+  if (res.locals.scope != null) {
+    const scope = res.locals.scope[0]
+    const attributesShortlist = attributesByScope[scope]
+    if (!attributesShortlist) throw error_.new('invalid scope', 500, { scope })
+    return _.pick(userPrivateData, attributesShortlist)
+  } else {
+    return userPrivateData
+  }
+}
+
+const attributesByScope = {
+  // This scope is tailored to the needs of https://github.com/inventaire/inventaire-mediawiki
+  'wiki-stable-profile': [ '_id', 'email', 'username' ],
 }

--- a/server/controllers/user/get.js
+++ b/server/controllers/user/get.js
@@ -1,7 +1,6 @@
-const __ = require('config').universalPath
-const _ = __.require('builders', 'utils')
-const error_ = __.require('lib', 'error/error')
-const user_ = __.require('controllers', 'user/lib/user')
+const _ = require('builders/utils')
+const error_ = require('lib/error/error')
+const user_ = require('controllers/user/lib/user')
 const { ownerSafeData } = require('./lib/authorized_user_data_pickers')
 
 module.exports = (req, res) => {

--- a/server/controllers/user/lib/user.js
+++ b/server/controllers/user/lib/user.js
@@ -122,6 +122,15 @@ const user_ = module.exports = {
     return db.update(userId, User.setOauthTokens(provider, data))
   },
 
+  setStableUsername: async userData => {
+    const { _id: userId, username, stableUsername } = userData
+    if (stableUsername == null) {
+      await db.update(userId, User.setStableUsername)
+      userData.stableUsername = username
+    }
+    return userData
+  },
+
   nearby: async (userId, meterRange, strict) => {
     const { position } = await user_.byId(userId)
     if (position == null) {

--- a/server/db/couchdb/base.js
+++ b/server/db/couchdb/base.js
@@ -6,9 +6,11 @@ const list = require('./list')
 
 module.exports = (dbBaseName, designDocName) => {
   const dbName = CONFIG.db.name(dbBaseName)
-  // If no designDocName is provided,
-  // assumes it is the same as the dbBaseName
-  designDocName = designDocName || dbBaseName
+  // If no designDocName is provided while there are defined design docs for this database,
+  // assumes that it is the default design doc, which has the same name as the dbBaseName
+  if (list[dbBaseName].length > 0 && designDocName == null) {
+    designDocName = dbBaseName
+  }
   return getHandler(dbBaseName, dbName, designDocName)
 }
 
@@ -25,7 +27,7 @@ const validate = (dbBaseName, designDocName) => {
     throw new Error(`unknown dbBaseName: ${dbBaseName}`)
   }
 
-  if (!(list[dbBaseName].includes(designDocName))) {
+  if (designDocName && !list[dbBaseName].includes(designDocName)) {
     throw new Error(`unknown designDocName: ${designDocName}`)
   }
 }

--- a/server/db/couchdb/design_docs/users.json
+++ b/server/db/couchdb/design_docs/users.json
@@ -6,7 +6,7 @@
       "map": "(doc)->\n  if doc.type is 'user'\n    emit doc.email.toLowerCase(), null"
     },
     "byUsername": {
-      "map": "(doc)->\n  if doc.type is 'user' or doc.special\n    emit doc.username.toLowerCase(), null"
+      "map": "(doc)->\n  if doc.type is 'user' or doc.special\n    emit doc.username.toLowerCase(), null\n    if doc.stableUsername? then emit doc.stableUsername.toLowerCase(), null"
     },
     "byCreation": {
       "map": "(doc)->\n  if doc.type is 'user'\n    emit doc.created, doc.username"

--- a/server/db/couchdb/list.js
+++ b/server/db/couchdb/list.js
@@ -15,6 +15,9 @@ module.exports = {
   patches: [ 'patches' ],
   shelves: [ 'shelves' ],
   tasks: [ 'tasks' ],
+  oauth_authorizations: [],
+  oauth_clients: [],
+  oauth_tokens: [],
   transactions: [ 'transactions' ],
   users: [ 'users', 'relations', 'invited' ],
 }

--- a/server/db/couchdb/list.js
+++ b/server/db/couchdb/list.js
@@ -6,15 +6,15 @@
 // that aren't required to run on production
 
 module.exports = {
-  users: [ 'users', 'relations', 'invited' ],
-  groups: [ 'groups' ],
-  items: [ 'items' ],
-  transactions: [ 'transactions' ],
   comments: [ 'comments' ],
   entities: [ 'entities', 'entities_deduplicate' ],
-  patches: [ 'patches' ],
-  notifications: [ 'notifications' ],
-  tasks: [ 'tasks' ],
-  shelves: [ 'shelves' ],
+  groups: [ 'groups' ],
   images: [ 'images' ],
+  items: [ 'items' ],
+  notifications: [ 'notifications' ],
+  patches: [ 'patches' ],
+  shelves: [ 'shelves' ],
+  tasks: [ 'tasks' ],
+  transactions: [ 'transactions' ],
+  users: [ 'users', 'relations', 'invited' ],
 }

--- a/server/lib/auto_rotated_keys.js
+++ b/server/lib/auto_rotated_keys.js
@@ -11,7 +11,7 @@ const CONFIG = require('config')
 const { cookieMaxAge, autoRotateKeys: leadingServer } = CONFIG
 const __ = CONFIG.universalPath
 const _ = require('builders/utils')
-const { getRandomBytesBuffer } = require('lib/crypto')
+const { getRandomBytes } = require('lib/crypto')
 const { oneDay, msToHumanTime, msToHumanAge } = require('lib/time')
 const error_ = require('lib/error/error')
 const { readFileSync } = require('fs')
@@ -81,7 +81,7 @@ const updateKey = ({ timestamp, key }) => {
 
 const generateNewKey = () => {
   _.info('generating new key')
-  const newKey = getRandomBytesBuffer(64).toString('base64')
+  const newKey = getRandomBytes(64, 'base64')
   keys.unshift(newKey)
   data[Date.now()] = newKey
   cleanupKeysInMemory()

--- a/server/lib/crypto.js
+++ b/server/lib/crypto.js
@@ -39,4 +39,4 @@ exports.sha1 = createHexHash('sha1')
 exports.md5 = createHexHash('md5')
 exports.sha1FromStream = createHexHashFromStream('sha1')
 
-exports.getRandomBytesBuffer = length => crypto.randomBytes(length)
+exports.getRandomBytes = (length, encoding) => crypto.randomBytes(length).toString(encoding)

--- a/server/lib/error/error.js
+++ b/server/lib/error/error.js
@@ -33,7 +33,8 @@ error_.notFound = context => {
 
 error_.catchNotFound = err => {
   // notFound flag is set by: levelup, error_.notFound
-  if (!(err && err.notFound)) throw err
+  if (err && (err.notFound || err.statusCode === 404)) return
+  throw err
 }
 
 error_.addContextToStack = err => {

--- a/server/lib/error/error_handler.js
+++ b/server/lib/error/error_handler.js
@@ -30,6 +30,12 @@ module.exports = (req, res, err, status) => {
     _.error(err, err.message)
   }
 
+  if (err.context) {
+    // Prevent returning authorization headers from an internal requests that would have failed
+    // such as requests to CouchDB
+    delete err.context.headers
+  }
+
   res.status(statusCode)
   responses_.send(res, {
     status: statusCode,

--- a/server/lib/password_hashing.js
+++ b/server/lib/password_hashing.js
@@ -1,20 +1,15 @@
-const { hashPasswords } = require('config')
+const { useSlowPasswordHashFunction } = require('config')
 
-if (hashPasswords) {
+if (useSlowPasswordHashFunction) {
   module.exports = require('credential')()
 } else {
-  // Disabling password hashing can be convenient in test environment
-  // to run tests faster
-  // Disabling hashing is done by mimicking 'credential' API
-  // while not hashing anything, thus storing the password in plain text
-  // in the database: the good old way! \o/
+  // Mimicking 'credential' API, should only be used in test environment
   module.exports = {
-    // Disabling hashing by returning a promise that resolves to the input password
-    hash: async password => password,
-    // Thus verifying the password is simply comparing the input password
-    // with the password set in the database
-    verify: async (hash, password) => hash === password,
+    hash: async password => fastHash(password),
+    verify: async (hash, password) => hash === fastHash(password),
     // In this mode, tokens never expire
     expired: () => false
   }
 }
+
+const fastHash = str => Buffer.from(str).toString('hex')

--- a/server/lib/sanitize/parameters.js
+++ b/server/lib/sanitize/parameters.js
@@ -75,7 +75,7 @@ const arrayOfAType = validation => (values, type) => {
     if (!validation(value)) {
       // approximative way to get singular of a word
       const singularType = type.replace(/s$/, '')
-      const details = `expected ${singularType}, got ${value} (${_.typeOf(values)})`
+      const details = `expected ${singularType}, got ${value} (${_.typeOf(value)})`
       throw error_.new(`invalid ${singularType}: ${details}`, 400, { values })
     }
   }

--- a/server/middlewares/auth.js
+++ b/server/middlewares/auth.js
@@ -69,8 +69,10 @@ module.exports = {
 
 const afterBearerToken = (req, res, next) => err => {
   if (err) return next(err)
-  if (res.locals.oauth && res.locals.oauth.token && typeof res.locals.oauth.token.user === 'object') {
-    req.user = res.locals.oauth.token.user
+  const { oauth } = res.locals
+  if (oauth && oauth.token && typeof oauth.token.user === 'object') {
+    req.user = oauth.token.user
+    res.locals.scope = oauth.token.matchingScopes
   }
   next()
 }

--- a/server/middlewares/content.js
+++ b/server/middlewares/content.js
@@ -5,6 +5,8 @@ const _ = require('builders/utils')
 const error_ = require('lib/error/error')
 const bodyParser = require('body-parser')
 
+const urlencodedBodyParser = bodyParser.urlencoded({ extended: false })
+
 module.exports = {
   // Assume JSON content-type for, among others:
   // - application/json
@@ -15,14 +17,8 @@ module.exports = {
   // Not using '*/*' as this would include multipart/form-data
   // used for image upload
   jsonBodyParser: bodyParser.json({ type: 'application/*', limit: '5mb' }),
-  // server/controllers/auth/fake_submit.js relies on the possibility
-  // to submit a url encoded form data, so it needs to have the body-parser ready for it,
-  // otherwise it throws a 'SyntaxError: Unexpected token # in JSON at position 0' error
-  // This middleware will only apply for requests on the '/api/submit' endpoint
-  fakeSubmitException: [
-    '/api/submit',
-    bodyParser.urlencoded({ extended: false })
-  ],
+
+  acceptUrlencoded: endpoint => [ endpoint, urlencodedBodyParser ],
 
   // Assumes that a requests made twice with the same body within 2 secondes
   // is an erronous request that should be blocked

--- a/server/middlewares/middlewares.js
+++ b/server/middlewares/middlewares.js
@@ -10,7 +10,13 @@ module.exports = [
   // in the middleware are logged
   requestsLogger,
 
-  content.fakeSubmitException,
+  // server/controllers/auth/fake_submit.js relies on the possibility
+  // to submit a url encoded form data, so it needs to have the body-parser ready for it
+  content.acceptUrlencoded('/api/submit'),
+
+  // OAuth clients might send urlencoded content
+  content.acceptUrlencoded('/api/oauth/token'),
+
   content.jsonBodyParser,
   statics.favicon,
 
@@ -24,7 +30,7 @@ module.exports = [
   auth.enforceSessionMaxAge,
   auth.passport.initialize,
   auth.passport.session,
-  auth.basicAuth,
+  auth.authorizationHeader,
 
   content.deduplicateRequests,
 

--- a/server/models/attributes/user.js
+++ b/server/models/attributes/user.js
@@ -6,6 +6,7 @@ attributes.ownerSafe = [
   '_rev',
   'type',
   'username',
+  'stableUsername',
   'created',
   'email',
   'picture',
@@ -58,7 +59,8 @@ attributes.updatable = [
 attributes.critical = [
   '_id',
   '_rev',
-  'username'
+  'username',
+  'stableUsername',
 ]
 
 // Attributes to keep in documents where a stakeholder might loose

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -151,6 +151,13 @@ User.removeRole = role => user => {
   return user
 }
 
+// We need a stable username for services that use the username as unique user id
+// such as wiki.inventaire.io (https://github.com/inventaire/inventaire-mediawiki)
+User.setStableUsername = user => {
+  user.stableUsername = user.stableUsername || user.username
+  return user
+}
+
 User.formatters = {
   position: truncateLatLng
 }

--- a/tests/api/oauth/authenticate.test.js
+++ b/tests/api/oauth/authenticate.test.js
@@ -17,19 +17,19 @@ describe('oauth:authenticate', () => {
   })
 
   it('should accept a request authentified by a bearer token', async () => {
-    const token = await getToken({ scope: [ 'profile' ] })
+    const token = await getToken({ scope: [ 'username' ] })
     const res = await bearerTokenReq(token, 'get', '/api/user')
     res.statusCode.should.equal(200)
   })
 
   it('should accept a request authentified by a bearer token with several scopes', async () => {
-    const token = await getToken({ scope: [ 'foo', 'profile' ] })
+    const token = await getToken({ scope: [ 'email', 'username' ] })
     const res = await bearerTokenReq(token, 'get', '/api/user')
     res.statusCode.should.equal(200)
   })
 
   it('should reject a request to a resource out of the token scope', async () => {
-    const token = await getToken({ scope: [ 'profile' ] })
+    const token = await getToken({ scope: [ 'username' ] })
     await bearerTokenReq(token, 'put', '/api/user', {
       attribute: 'bio',
       value: randomString(10)
@@ -44,7 +44,7 @@ describe('oauth:authenticate', () => {
   // Ideally, we should not return any 'Set-Cookie' header at all
   // to not give the false impression that those cookies have any interest
   it('should not return authentified session cookies', async () => {
-    const token = await getToken({ scope: [ 'profile' ] })
+    const token = await getToken({ scope: [ 'username' ] })
     const res = await bearerTokenReq(token, 'get', '/api/user')
     const [ sessionCookie ] = parseSessionCookies(res.headers['set-cookie'])
     parseBase64EncodedJson(sessionCookie).passport.should.deepEqual({})

--- a/tests/api/oauth/authenticate.test.js
+++ b/tests/api/oauth/authenticate.test.js
@@ -21,6 +21,12 @@ describe('oauth:authenticate', () => {
     res.statusCode.should.equal(200)
   })
 
+  it('should accept a request authentified by a bearer token with several scopes', async () => {
+    const token = await getToken({ scope: [ 'foo', 'profile' ] })
+    const res = await bearerTokenReq(token, 'get', '/api/user')
+    res.statusCode.should.equal(200)
+  })
+
   it('should reject a request to a resource out of the token scope', async () => {
     const token = await getToken({ scope: [ 'profile' ] })
     await bearerTokenReq(token, 'put', '/api/user', {
@@ -30,7 +36,7 @@ describe('oauth:authenticate', () => {
     .then(shouldNotBeCalled)
     .catch(err => {
       err.statusCode.should.equal(403)
-      err.body.status_verbose.should.equal('Insufficient scope: authorized scope is insufficient')
+      err.body.status_verbose.should.equal('this resource can not be accessed with an OAuth bearer token')
     })
   })
 })

--- a/tests/api/oauth/authenticate.test.js
+++ b/tests/api/oauth/authenticate.test.js
@@ -1,0 +1,36 @@
+const __ = require('config').universalPath
+const { shouldNotBeCalled } = require('../utils/utils')
+const { bearerTokenReq } = require('../utils/request')
+const { getToken } = require('../utils/oauth')
+const randomString = __.require('lib', 'utils/random_string')
+
+describe('oauth:authenticate', () => {
+  it('should reject a request authentified by a bearer token with a non existing scope', async () => {
+    const token = await getToken({ scope: [ 'foo' ] })
+    await bearerTokenReq(token, 'get', '/api/user')
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.statusCode.should.equal(403)
+      err.body.status_verbose.should.equal('Insufficient scope: authorized scope is insufficient')
+    })
+  })
+
+  it('should accept a request authentified by a bearer token', async () => {
+    const token = await getToken({ scope: [ 'profile' ] })
+    const res = await bearerTokenReq(token, 'get', '/api/user')
+    res.statusCode.should.equal(200)
+  })
+
+  it('should reject a request to a resource out of the token scope', async () => {
+    const token = await getToken({ scope: [ 'profile' ] })
+    await bearerTokenReq(token, 'put', '/api/user', {
+      attribute: 'bio',
+      value: randomString(10)
+    })
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.statusCode.should.equal(403)
+      err.body.status_verbose.should.equal('Insufficient scope: authorized scope is insufficient')
+    })
+  })
+})

--- a/tests/api/oauth/authenticate.test.js
+++ b/tests/api/oauth/authenticate.test.js
@@ -5,34 +5,28 @@ const randomString = require('lib/utils/random_string')
 const { parseSessionCookies, parseBase64EncodedJson } = require('../utils/auth')
 
 describe('oauth:authenticate', () => {
-  it('should reject a request authentified by a bearer token with a non existing scope', async () => {
-    const token = await getToken({ scope: [ 'foo' ] })
-    await bearerTokenReq(token, 'get', '/api/user')
-    .then(shouldNotBeCalled)
-    .catch(err => {
-      err.statusCode.should.equal(403)
-      err.body.status_verbose.should.equal('Insufficient scope: authorized scope is insufficient')
-    })
-  })
-
   it('should accept a request authentified by a bearer token', async () => {
-    const token = await getToken({ scope: [ 'username' ] })
-    const res = await bearerTokenReq(token, 'get', '/api/user')
-    res.statusCode.should.equal(200)
-  })
-
-  it('should accept a request authentified by a bearer token with several scopes', async () => {
     const token = await getToken({ scope: [ 'email', 'username' ] })
     const res = await bearerTokenReq(token, 'get', '/api/user')
     res.statusCode.should.equal(200)
   })
 
-  it('should reject a request to a resource out of the token scope', async () => {
+  it('should reject a request with an unauthorized method', async () => {
     const token = await getToken({ scope: [ 'username' ] })
     await bearerTokenReq(token, 'put', '/api/user', {
       attribute: 'bio',
       value: randomString(10)
     })
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.statusCode.should.equal(403)
+      err.body.status_verbose.should.equal('this resource can not be accessed with an OAuth bearer token')
+    })
+  })
+
+  it('should reject a request with an unauthorized endpoint', async () => {
+    const token = await getToken({ scope: [ 'username' ] })
+    await bearerTokenReq(token, 'get', '/api/foo')
     .then(shouldNotBeCalled)
     .catch(err => {
       err.statusCode.should.equal(403)

--- a/tests/api/oauth/authenticate.test.js
+++ b/tests/api/oauth/authenticate.test.js
@@ -1,8 +1,7 @@
-const __ = require('config').universalPath
 const { shouldNotBeCalled } = require('../utils/utils')
 const { bearerTokenReq } = require('../utils/request')
 const { getToken } = require('../utils/oauth')
-const randomString = __.require('lib', 'utils/random_string')
+const randomString = require('lib/utils/random_string')
 const { parseSessionCookies, parseBase64EncodedJson } = require('../utils/auth')
 
 describe('oauth:authenticate', () => {

--- a/tests/api/oauth/authorize.test.js
+++ b/tests/api/oauth/authorize.test.js
@@ -1,0 +1,93 @@
+const __ = require('config').universalPath
+const { publicReq, authReq, rawAuthReq, shouldNotBeCalled } = require('../utils/utils')
+const { getClient } = require('../utils/oauth')
+const randomString = __.require('lib', 'utils/random_string')
+const endpoint = '/api/oauth/authorize'
+const { parse: parseQuery } = require('querystring')
+
+describe('oauth:authorize', () => {
+  it('should reject unauthentified requests', async () => {
+    await publicReq('get', endpoint)
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.statusCode.should.equal(401)
+    })
+  })
+
+  it('should reject without a client id', async () => {
+    await authReq('get', `${endpoint}?scope=profile`)
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.statusCode.should.equal(400)
+      err.body.status_verbose.should.equal('Missing parameter: `client_id`')
+    })
+  })
+
+  it('should reject without a state', async () => {
+    const { _id: clientId } = await getClient()
+    await authReq('get', `${endpoint}?client_id=${clientId}&scope=profile`)
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.statusCode.should.equal(400)
+      err.body.status_verbose.should.equal('Missing parameter: `state`')
+    })
+  })
+
+  it('should reject without a response_type', async () => {
+    const { _id: clientId } = await getClient()
+    await authReq('get', `${endpoint}?client_id=${clientId}&state=${randomString(20)}&scope=profile`)
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.statusCode.should.equal(400)
+      err.body.status_verbose.should.equal('Missing parameter: `response_type`')
+    })
+  })
+
+  // Particularity: oauth2-server doesn't check the presence of scope,
+  // so we have to validate it ourselves, thus this the error is in the Inventaire error format
+  it('should reject without a scope', async () => {
+    const { _id: clientId } = await getClient()
+    await authReq('get', `${endpoint}?client_id=${clientId}&state=${randomString(20)}&response_type=code`)
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.statusCode.should.equal(400)
+      err.body.status_verbose.should.equal('missing parameter in query: scope')
+    })
+  })
+
+  it('should reject when passed an invalid client id', async () => {
+    await authReq('get', `${endpoint}?client_id=foo&state=${randomString(20)}&response_type=code&scope=profile`)
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.statusCode.should.equal(400)
+      err.body.status_verbose.should.equal('unknown client')
+    })
+  })
+
+  it('should reject when passed an invalid response_type', async () => {
+    const { _id: clientId } = await getClient()
+    await authReq('get', `${endpoint}?client_id=${clientId}&state=${randomString(20)}&response_type=foo&scope=profile`)
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.statusCode.should.equal(400)
+      err.body.status_verbose.should.startWith('Unsupported response type')
+    })
+  })
+
+  it('should redirect to the client redirect uri', async () => {
+    const { _id: clientId, redirectUris } = await getClient()
+    const state = randomString(20)
+    const url = `${endpoint}?client_id=${clientId}&state=${state}&response_type=code&scope=profile`
+    const { statusCode, headers } = await rawAuthReq('get', url)
+    statusCode.should.equal(302)
+    const { location } = headers
+    const [ pathname, query ] = location.split('?')
+    pathname.should.equal(redirectUris[0])
+    const { code, state: returnedState } = parseQuery(query)
+    code.should.be.a.String()
+    returnedState.should.equal(state)
+  })
+
+  // oauth2-server doesn't do scope validation during authorization
+  // xit('should reject invalid scope', async () => {})
+})

--- a/tests/api/oauth/authorize.test.js
+++ b/tests/api/oauth/authorize.test.js
@@ -15,7 +15,7 @@ describe('oauth:authorize', () => {
   })
 
   it('should reject without a client id', async () => {
-    await authReq('get', `${endpoint}?scope=profile`)
+    await authReq('get', `${endpoint}?scope=username`)
     .then(shouldNotBeCalled)
     .catch(err => {
       err.statusCode.should.equal(400)
@@ -25,7 +25,7 @@ describe('oauth:authorize', () => {
 
   it('should reject without a state', async () => {
     const { _id: clientId } = await getClient()
-    await authReq('get', `${endpoint}?client_id=${clientId}&scope=profile`)
+    await authReq('get', `${endpoint}?client_id=${clientId}&scope=username`)
     .then(shouldNotBeCalled)
     .catch(err => {
       err.statusCode.should.equal(400)
@@ -35,7 +35,7 @@ describe('oauth:authorize', () => {
 
   it('should reject without a response_type', async () => {
     const { _id: clientId } = await getClient()
-    await authReq('get', `${endpoint}?client_id=${clientId}&state=${randomString(20)}&scope=profile`)
+    await authReq('get', `${endpoint}?client_id=${clientId}&state=${randomString(20)}&scope=username`)
     .then(shouldNotBeCalled)
     .catch(err => {
       err.statusCode.should.equal(400)
@@ -56,7 +56,7 @@ describe('oauth:authorize', () => {
   })
 
   it('should reject when passed an invalid client id', async () => {
-    await authReq('get', `${endpoint}?client_id=foo&state=${randomString(20)}&response_type=code&scope=profile`)
+    await authReq('get', `${endpoint}?client_id=foo&state=${randomString(20)}&response_type=code&scope=username`)
     .then(shouldNotBeCalled)
     .catch(err => {
       err.statusCode.should.equal(400)
@@ -66,7 +66,7 @@ describe('oauth:authorize', () => {
 
   it('should reject when passed an invalid response_type', async () => {
     const { _id: clientId } = await getClient()
-    await authReq('get', `${endpoint}?client_id=${clientId}&state=${randomString(20)}&response_type=foo&scope=profile`)
+    await authReq('get', `${endpoint}?client_id=${clientId}&state=${randomString(20)}&response_type=foo&scope=username`)
     .then(shouldNotBeCalled)
     .catch(err => {
       err.statusCode.should.equal(400)
@@ -77,7 +77,7 @@ describe('oauth:authorize', () => {
   it('should redirect to the client redirect uri', async () => {
     const { _id: clientId, redirectUris } = await getClient()
     const state = randomString(20)
-    const url = `${endpoint}?client_id=${clientId}&state=${state}&response_type=code&scope=profile`
+    const url = `${endpoint}?client_id=${clientId}&state=${state}&response_type=code&scope=username`
     const { statusCode, headers } = await rawAuthReq('get', url)
     statusCode.should.equal(302)
     const { location } = headers

--- a/tests/api/oauth/authorize.test.js
+++ b/tests/api/oauth/authorize.test.js
@@ -88,5 +88,15 @@ describe('oauth:authorize', () => {
   })
 
   // oauth2-server doesn't do scope validation during authorization
-  // xit('should reject invalid scope', async () => {})
+  it('should reject invalid scope', async () => {
+    const { _id: clientId } = await getClient()
+    const state = randomString(20)
+    const url = `${endpoint}?client_id=${clientId}&state=${state}&response_type=code&scope=foo`
+    await authReq('get', url)
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.statusCode.should.equal(400)
+      err.body.status_verbose.should.startWith('invalid scope')
+    })
+  })
 })

--- a/tests/api/oauth/authorize.test.js
+++ b/tests/api/oauth/authorize.test.js
@@ -1,7 +1,6 @@
-const __ = require('config').universalPath
 const { publicReq, authReq, rawAuthReq, shouldNotBeCalled } = require('../utils/utils')
 const { getClient } = require('../utils/oauth')
-const randomString = __.require('lib', 'utils/random_string')
+const randomString = require('lib/utils/random_string')
 const endpoint = '/api/oauth/authorize'
 const { parse: parseQuery } = require('querystring')
 
@@ -78,7 +77,7 @@ describe('oauth:authorize', () => {
     const { _id: clientId, redirectUris } = await getClient()
     const state = randomString(20)
     const url = `${endpoint}?client_id=${clientId}&state=${state}&response_type=code&scope=username`
-    const { statusCode, headers } = await rawAuthReq('get', url)
+    const { statusCode, headers } = await rawAuthReq({ method: 'get', url })
     statusCode.should.equal(302)
     const { location } = headers
     const [ pathname, query ] = location.split('?')

--- a/tests/api/oauth/clients_by_ids.test.js
+++ b/tests/api/oauth/clients_by_ids.test.js
@@ -1,0 +1,20 @@
+const should = require('should')
+const { getClient } = require('../utils/oauth')
+const { publicReq } = require('../utils/utils')
+const endpoint = '/api/oauth/clients?action=by-ids'
+
+describe('oauth:clients:get-by-ids', () => {
+  it('should return public client data', async () => {
+    const scope = [ 'username', 'email' ]
+    const { _id: clientId, redirectUris } = await getClient({ scope })
+    const { clients } = await publicReq('get', `${endpoint}&ids=${clientId}`)
+    const client = clients[clientId]
+    client.should.be.an.Object()
+    client._id.should.equal(clientId)
+    client.scope.should.deepEqual(scope)
+    client.redirectUris.should.deepEqual(redirectUris)
+    client.name.should.be.a.String()
+    client.description.should.be.a.String()
+    should(client.secret).not.be.ok()
+  })
+})

--- a/tests/api/oauth/token.test.js
+++ b/tests/api/oauth/token.test.js
@@ -92,4 +92,28 @@ describe('oauth:token', () => {
       err.body.status_verbose.should.equal('Invalid grant: authorization code has expired')
     })
   })
+
+  it('should reject when the authorization has already been used', async () => {
+    const { _id: clientId, secret, code, redirectUris } = await getClientWithAuthorization()
+    const res = await post({
+      client_id: clientId,
+      client_secret: secret,
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: redirectUris[0],
+    })
+    res.statusCode.should.equal(200)
+    await post({
+      client_id: clientId,
+      client_secret: secret,
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: redirectUris[0],
+    })
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.statusCode.should.equal(400)
+      err.body.status_verbose.should.equal('Invalid grant: authorization code is invalid')
+    })
+  })
 })

--- a/tests/api/oauth/token.test.js
+++ b/tests/api/oauth/token.test.js
@@ -1,0 +1,74 @@
+const { shouldNotBeCalled } = require('../utils/utils')
+const { postUrlencoded } = require('../utils/request')
+const { getClient, getClientWithAuthorization } = require('../utils/oauth')
+const post = body => postUrlencoded('/api/oauth/token', body)
+
+describe('oauth:token', () => {
+  it('should reject without a client id', async () => {
+    const { secret } = await getClient()
+    await post({ client_secret: secret })
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.statusCode.should.equal(400)
+      err.body.status_verbose.should.equal('Invalid client: cannot retrieve client credentials')
+    })
+  })
+
+  it('should reject without a client secret', async () => {
+    const { _id: clientId } = await getClient()
+    await post({ client_id: clientId })
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.statusCode.should.equal(400)
+      err.body.status_verbose.should.equal('Invalid client: cannot retrieve client credentials')
+    })
+  })
+
+  it('should reject without a grant type', async () => {
+    const { _id: clientId, secret } = await getClient()
+    await post({ client_id: clientId, client_secret: secret })
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.statusCode.should.equal(400)
+      err.body.status_verbose.should.equal('Missing parameter: `grant_type`')
+    })
+  })
+
+  it('should reject without a code', async () => {
+    const { _id: clientId, secret } = await getClient()
+    await post({ client_id: clientId, client_secret: secret, grant_type: 'authorization_code' })
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.statusCode.should.equal(400)
+      err.body.status_verbose.should.equal('Missing parameter: `code`')
+    })
+  })
+
+  it('should reject without a redirect_uri', async () => {
+    const { _id: clientId, secret, code } = await getClientWithAuthorization()
+    await post({ client_id: clientId, client_secret: secret, grant_type: 'authorization_code', code })
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.statusCode.should.equal(400)
+      err.body.status_verbose.should.equal('Invalid request: `redirect_uri` is not a valid URI')
+    })
+  })
+
+  it('should obtain a token', async () => {
+    const { _id: clientId, secret, code, redirectUris, scope } = await getClientWithAuthorization()
+    const { body } = await post({
+      client_id: clientId,
+      client_secret: secret,
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: redirectUris[0],
+    })
+    body.access_token.should.be.a.String()
+    body.access_token.should.match(/^[0-9a-f]{40}$/)
+    body.token_type.should.equal('Bearer')
+    body.expires_in.should.be.a.Number()
+    body.refresh_token.should.be.a.String()
+    body.refresh_token.should.match(/^[0-9a-f]{40}$/)
+    body.scope.should.equal(scope[0])
+  })
+})

--- a/tests/api/oauth/token.test.js
+++ b/tests/api/oauth/token.test.js
@@ -9,8 +9,8 @@ const post = body => postUrlencoded('/api/oauth/token', body)
 
 describe('oauth:token', () => {
   it('should reject without a client id', async () => {
-    const { secret } = await getClient()
-    await post({ client_secret: secret })
+    const { testsPseudoSecret } = await getClient()
+    await post({ client_secret: testsPseudoSecret })
     .then(shouldNotBeCalled)
     .catch(err => {
       err.statusCode.should.equal(400)
@@ -39,8 +39,8 @@ describe('oauth:token', () => {
   })
 
   it('should reject without a grant type', async () => {
-    const { _id: clientId, secret } = await getClient()
-    await post({ client_id: clientId, client_secret: secret })
+    const { _id: clientId, testsPseudoSecret } = await getClient()
+    await post({ client_id: clientId, client_secret: testsPseudoSecret })
     .then(shouldNotBeCalled)
     .catch(err => {
       err.statusCode.should.equal(400)
@@ -49,8 +49,8 @@ describe('oauth:token', () => {
   })
 
   it('should reject without a code', async () => {
-    const { _id: clientId, secret } = await getClient()
-    await post({ client_id: clientId, client_secret: secret, grant_type: 'authorization_code' })
+    const { _id: clientId, testsPseudoSecret } = await getClient()
+    await post({ client_id: clientId, client_secret: testsPseudoSecret, grant_type: 'authorization_code' })
     .then(shouldNotBeCalled)
     .catch(err => {
       err.statusCode.should.equal(400)
@@ -59,8 +59,8 @@ describe('oauth:token', () => {
   })
 
   it('should reject without a redirect_uri', async () => {
-    const { _id: clientId, secret, code } = await getClientWithAuthorization()
-    await post({ client_id: clientId, client_secret: secret, grant_type: 'authorization_code', code })
+    const { _id: clientId, testsPseudoSecret, code } = await getClientWithAuthorization()
+    await post({ client_id: clientId, client_secret: testsPseudoSecret, grant_type: 'authorization_code', code })
     .then(shouldNotBeCalled)
     .catch(err => {
       err.statusCode.should.equal(400)
@@ -69,10 +69,10 @@ describe('oauth:token', () => {
   })
 
   it('should obtain a token', async () => {
-    const { _id: clientId, secret, code, redirectUris, scope } = await getClientWithAuthorization()
+    const { _id: clientId, testsPseudoSecret, code, redirectUris, scope } = await getClientWithAuthorization()
     const { body } = await post({
       client_id: clientId,
-      client_secret: secret,
+      client_secret: testsPseudoSecret,
       grant_type: 'authorization_code',
       code,
       redirect_uri: redirectUris[0],
@@ -87,11 +87,11 @@ describe('oauth:token', () => {
   })
 
   it('should reject when the authorization expired', async () => {
-    const { _id: clientId, secret, code, redirectUris } = await getClientWithAuthorization()
+    const { _id: clientId, testsPseudoSecret, code, redirectUris } = await getClientWithAuthorization()
     await wait(authorizationCodeLifetimeMs + 10)
     await post({
       client_id: clientId,
-      client_secret: secret,
+      client_secret: testsPseudoSecret,
       grant_type: 'authorization_code',
       code,
       redirect_uri: redirectUris[0],
@@ -104,10 +104,10 @@ describe('oauth:token', () => {
   })
 
   it('should reject when the authorization has already been used', async () => {
-    const { _id: clientId, secret, code, redirectUris } = await getClientWithAuthorization()
+    const { _id: clientId, testsPseudoSecret, code, redirectUris } = await getClientWithAuthorization()
     const res = await post({
       client_id: clientId,
-      client_secret: secret,
+      client_secret: testsPseudoSecret,
       grant_type: 'authorization_code',
       code,
       redirect_uri: redirectUris[0],
@@ -115,7 +115,7 @@ describe('oauth:token', () => {
     res.statusCode.should.equal(200)
     await post({
       client_id: clientId,
-      client_secret: secret,
+      client_secret: testsPseudoSecret,
       grant_type: 'authorization_code',
       code,
       redirect_uri: redirectUris[0],

--- a/tests/api/oauth/token.test.js
+++ b/tests/api/oauth/token.test.js
@@ -28,6 +28,16 @@ describe('oauth:token', () => {
     })
   })
 
+  it('should reject when passed the wrong client secret', async () => {
+    const { _id: clientId } = await getClient()
+    await post({ client_id: clientId, client_secret: 'not_the_secret' })
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.statusCode.should.equal(400)
+      err.body.status_verbose.should.equal('Invalid client: client credentials are invalid')
+    })
+  })
+
   it('should reject without a grant type', async () => {
     const { _id: clientId, secret } = await getClient()
     await post({ client_id: clientId, client_secret: secret })

--- a/tests/api/oauth/token.test.js
+++ b/tests/api/oauth/token.test.js
@@ -1,10 +1,8 @@
-const CONFIG = require('config')
-const __ = CONFIG.universalPath
-const { authorizationCodeLifetimeMs } = CONFIG.oauthServer
+const { authorizationCodeLifetimeMs } = require('config').oauthServer
 const { shouldNotBeCalled } = require('../utils/utils')
 const { postUrlencoded } = require('../utils/request')
 const { getClient, getClientWithAuthorization } = require('../utils/oauth')
-const { wait } = __.require('lib', 'promises')
+const { wait } = require('lib/promises')
 const post = body => postUrlencoded('/api/oauth/token', body)
 
 describe('oauth:token', () => {

--- a/tests/api/user/get.test.js
+++ b/tests/api/user/get.test.js
@@ -1,6 +1,8 @@
 require('should')
 const { dataadminReq, adminReq, authReq, customAuthReq, getReservedUser } = require('../utils/utils')
 const { deleteUser } = require('../utils/users')
+const { getToken } = require('../utils/oauth')
+const { bearerTokenReq } = require('../utils/request')
 const endpoint = '/api/user'
 
 describe('user:get', () => {
@@ -47,5 +49,19 @@ describe('user:get', () => {
     const userData = await dataadminReq('get', endpoint)
     const dataadminAccessLevels = [ 'public', 'authentified', 'dataadmin' ]
     userData.accessLevels.should.deepEqual(dataadminAccessLevels)
+  })
+
+  describe('scope-tailored profile', () => {
+    describe('wiki-stable-profile', () => {
+      it.only('should only return a username and an email', async () => {
+        const token = await getToken({ scope: [ 'wiki-stable-profile' ] })
+        const { body } = await bearerTokenReq(token, 'get', '/api/user')
+        Object.keys(body).sort().should.deepEqual([
+          '_id',
+          'email',
+          'username',
+        ])
+      })
+    })
   })
 })

--- a/tests/api/utils/oauth.js
+++ b/tests/api/utils/oauth.js
@@ -5,6 +5,7 @@ const { rawAuthReq } = require('../utils/utils')
 const randomString = __.require('lib', 'utils/random_string')
 const { parse: parseQuery } = require('querystring')
 const { sha1 } = __.require('lib', 'crypto')
+const { postUrlencoded } = require('./request')
 const assert_ = __.require('utils', 'assert_types')
 
 const getClient = async (params = {}) => {
@@ -43,4 +44,16 @@ const getClientWithAuthorization = async (params = {}) => {
   return Object.assign(authorizationData, client)
 }
 
-module.exports = { getClient, getClientWithAuthorization }
+const getToken = async ({ scope }) => {
+  const { _id: clientId, secret, code, redirectUris } = await getClientWithAuthorization({ scope })
+  const { body } = await postUrlencoded('/api/oauth/token', {
+    client_id: clientId,
+    client_secret: secret,
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: redirectUris[0],
+  })
+  return body
+}
+
+module.exports = { getClient, getClientWithAuthorization, getToken }

--- a/tests/api/utils/oauth.js
+++ b/tests/api/utils/oauth.js
@@ -1,0 +1,46 @@
+const __ = require('config').universalPath
+const _ = __.require('builders', 'utils')
+const clientsDb = __.require('couch', 'base')('oauth_clients')
+const { rawAuthReq } = require('../utils/utils')
+const randomString = __.require('lib', 'utils/random_string')
+const { parse: parseQuery } = require('querystring')
+const { sha1 } = __.require('lib', 'crypto')
+const assert_ = __.require('utils', 'assert_types')
+
+const getClient = async (params = {}) => {
+  const { scope = [ 'profile' ] } = params
+
+  assert_.array(scope)
+
+  const client = {
+    _id: sha1(JSON.stringify(params)),
+    secret: randomString(30),
+    redirectUris: [
+      'http://localhost:8888/wiki/Special:OAuth2Client/callback',
+    ],
+    grants: [ 'authorization_code' ],
+    scope
+  }
+
+  return clientsDb.get(client._id)
+  .catch(err => {
+    if (err.statusCode === 404) return clientsDb.putAndReturn(client)
+    else throw err
+  })
+}
+
+const getClientWithAuthorization = async (params = {}) => {
+  const { scope = [ 'profile' ] } = params
+  const client = await getClient(params)
+  const url = _.buildPath('/api/oauth/authorize', {
+    client_id: client._id,
+    state: randomString(20),
+    response_type: 'code',
+    scope: scope.join('+'),
+  })
+  const { headers } = await rawAuthReq('get', url)
+  const authorizationData = parseQuery(headers.location.split('?')[1])
+  return Object.assign(authorizationData, client)
+}
+
+module.exports = { getClient, getClientWithAuthorization }

--- a/tests/api/utils/oauth.js
+++ b/tests/api/utils/oauth.js
@@ -1,11 +1,11 @@
 const __ = require('config').universalPath
 const _ = __.require('builders', 'utils')
 const clientsDb = __.require('couch', 'base')('oauth_clients')
-const { rawAuthReq } = require('../utils/utils')
 const randomString = __.require('lib', 'utils/random_string')
 const { parse: parseQuery } = require('querystring')
 const { sha1 } = __.require('lib', 'crypto')
-const { postUrlencoded } = require('./request')
+const { postUrlencoded, rawCustomAuthReq } = require('./request')
+const { getUser } = require('./utils')
 const assert_ = __.require('utils', 'assert_types')
 
 const getClient = async (params = {}) => {
@@ -32,7 +32,10 @@ const getClient = async (params = {}) => {
 }
 
 const getClientWithAuthorization = async (params = {}) => {
-  const { scope = [ 'username' ] } = params
+  const {
+    scope = [ 'username' ],
+    user = getUser()
+  } = params
   const client = await getClient(params)
   const url = _.buildPath('/api/oauth/authorize', {
     client_id: client._id,
@@ -40,13 +43,13 @@ const getClientWithAuthorization = async (params = {}) => {
     response_type: 'code',
     scope: scope.join('+'),
   })
-  const { headers } = await rawAuthReq('get', url)
+  const { headers } = await rawCustomAuthReq(user, 'get', url)
   const authorizationData = parseQuery(headers.location.split('?')[1])
   return Object.assign(authorizationData, client)
 }
 
-const getToken = async ({ scope }) => {
-  const { _id: clientId, secret, code, redirectUris } = await getClientWithAuthorization({ scope })
+const getToken = async ({ user, scope }) => {
+  const { _id: clientId, secret, code, redirectUris } = await getClientWithAuthorization({ user, scope })
   const { body } = await postUrlencoded('/api/oauth/token', {
     client_id: clientId,
     client_secret: secret,

--- a/tests/api/utils/oauth.js
+++ b/tests/api/utils/oauth.js
@@ -9,7 +9,8 @@ const { postUrlencoded } = require('./request')
 const assert_ = __.require('utils', 'assert_types')
 
 const getClient = async (params = {}) => {
-  const { scope = [ 'profile' ] } = params
+  params.scope = params.scope || [ 'username' ]
+  const { scope } = params
 
   assert_.array(scope)
 
@@ -31,7 +32,7 @@ const getClient = async (params = {}) => {
 }
 
 const getClientWithAuthorization = async (params = {}) => {
-  const { scope = [ 'profile' ] } = params
+  const { scope = [ 'username' ] } = params
   const client = await getClient(params)
   const url = _.buildPath('/api/oauth/authorize', {
     client_id: client._id,

--- a/tests/api/utils/oauth.js
+++ b/tests/api/utils/oauth.js
@@ -15,13 +15,16 @@ const getClient = async (params = {}) => {
   assert_.array(scope)
 
   const client = {
-    _id: sha1(JSON.stringify(params)),
+    // Generate a deterministic id that looks like a CouchDB-uuid
+    _id: sha1(JSON.stringify(params)).slice(0, 32),
     secret: randomString(30),
     redirectUris: [
       'http://localhost:8888/wiki/Special:OAuth2Client/callback',
     ],
     grants: [ 'authorization_code' ],
-    scope
+    scope,
+    name: 'foo',
+    description: 'bar',
   }
 
   return clientsDb.get(client._id)

--- a/tests/api/utils/oauth.js
+++ b/tests/api/utils/oauth.js
@@ -1,12 +1,11 @@
-const __ = require('config').universalPath
-const _ = __.require('builders', 'utils')
-const clientsDb = __.require('couch', 'base')('oauth_clients')
-const randomString = __.require('lib', 'utils/random_string')
+const _ = require('builders/utils')
+const clientsDb = require('db/couchdb/base')('oauth_clients')
+const randomString = require('lib/utils/random_string')
 const { parse: parseQuery } = require('querystring')
-const { sha1, passwords, getRandomBytes } = __.require('lib', 'crypto')
+const { sha1, passwords, getRandomBytes } = require('lib/crypto')
 const { waitForTestServer, postUrlencoded, rawCustomAuthReq } = require('./request')
 const { getUser } = require('./utils')
-const assert_ = __.require('utils', 'assert_types')
+const assert_ = require('lib/utils/assert_types')
 
 const getClient = async (params = {}) => {
   await waitForTestServer
@@ -53,7 +52,7 @@ const getClientWithAuthorization = async (params = {}) => {
     response_type: 'code',
     scope: scope.join('+'),
   })
-  const { headers } = await rawCustomAuthReq(user, 'get', url)
+  const { headers } = await rawCustomAuthReq({ user, method: 'get', url })
   const authorizationData = parseQuery(headers.location.split('?')[1])
   return Object.assign(authorizationData, client)
 }

--- a/tests/api/utils/request.js
+++ b/tests/api/utils/request.js
@@ -84,4 +84,16 @@ const postUrlencoded = (url, body) => {
   })
 }
 
-module.exports = { request, rawRequest, customAuthReq, rawCustomAuthReq, postUrlencoded }
+const bearerTokenReq = (token, method, endpoint, body) => {
+  assert_.object(token)
+  assert_.string(token.access_token)
+  return rawRequest(method, endpoint, {
+    headers: {
+      authorization: `Bearer ${token.access_token}`
+    },
+    parseJson: true,
+    body
+  })
+}
+
+module.exports = { request, rawRequest, customAuthReq, rawCustomAuthReq, postUrlencoded, bearerTokenReq }

--- a/tests/api/utils/request.js
+++ b/tests/api/utils/request.js
@@ -96,4 +96,12 @@ const bearerTokenReq = (token, method, endpoint, body) => {
   })
 }
 
-module.exports = { request, rawRequest, customAuthReq, rawCustomAuthReq, postUrlencoded, bearerTokenReq }
+module.exports = {
+  waitForTestServer,
+  request,
+  rawRequest,
+  customAuthReq,
+  rawCustomAuthReq,
+  postUrlencoded,
+  bearerTokenReq
+}

--- a/tests/api/utils/users.js
+++ b/tests/api/utils/users.js
@@ -9,6 +9,8 @@ module.exports = {
     return users
   },
 
+  updateUser: (user, attribute, value) => customAuthReq(user, 'put', '/api/user', { attribute, value }),
+
   deleteUser: user => customAuthReq(user, 'delete', '/api/user')
 }
 

--- a/tests/api/utils/utils.js
+++ b/tests/api/utils/utils.js
@@ -1,4 +1,4 @@
-const { request, customAuthReq } = require('./request')
+const { request, customAuthReq, rawCustomAuthReq } = require('./request')
 const randomString = require('lib/utils/random_string')
 const { createUser, getRefreshedUser } = require('../fixtures/users')
 require('should')
@@ -19,6 +19,8 @@ const API = module.exports = {
   authReqC: (...args) => customAuthReq(API.getUserC(), ...args),
   adminReq: (...args) => customAuthReq(API.getAdminUser(), ...args),
   dataadminReq: (...args) => customAuthReq(API.getDataadminUser(), ...args),
+
+  rawAuthReq: (...args) => rawCustomAuthReq(API.getUser(), ...args),
 
   // Create users only if needed by the current test suite
   getUser: getUserGetter('a'),

--- a/tests/api/utils/utils.js
+++ b/tests/api/utils/utils.js
@@ -20,7 +20,7 @@ const API = module.exports = {
   adminReq: (...args) => customAuthReq(API.getAdminUser(), ...args),
   dataadminReq: (...args) => customAuthReq(API.getDataadminUser(), ...args),
 
-  rawAuthReq: (...args) => rawCustomAuthReq(API.getUser(), ...args),
+  rawAuthReq: ({ method, url }) => rawCustomAuthReq({ user: API.getUser(), method, url }),
 
   // Create users only if needed by the current test suite
   getUser: getUserGetter('a'),


### PR DESCRIPTION
This PR does several things:

## OAuth endpoints and middleware
starting to address the needs expressed in #84

- an authorization endpoint ( `/api/oauth/authorize`), letting users signal that they allow a given client to generate an access token in their name for a given scope
- a token endpoint ( `/api/oauth/token`), letting clients use that authorization to retrieve a token
- an authentication middleware, checking the rights of a token-authenticated request (`Authorization: Bearer ${token}` HTTP header)

All of those are based on the [`express-oauth-server`](https://github.com/oauthjs/express-oauth-server/) lib, which itself is based on the [`oauth2-server`](https://github.com/oauthjs/node-oauth2-server) lib ([documentation](https://oauth2-server.readthedocs.io))

## open a stable-username scope to inventaire-mediawiki
To be consumed by `inventaire-mediawiki`, see https://github.com/inventaire/inventaire-mediawiki/pull/7

## associated PRs
- https://github.com/inventaire/inventaire-mediawiki/pull/7
- https://github.com/inventaire/inventaire-client/pull/261

## Test locally
To test locally, you would need to manually add a client document in the `oauth_clients` database, which could look something like this:
```json
{
  "_id": "c4252a3321c1234b0bf82430dd2f7f69",
  "redirectUris": [
    "http://localhost:8888/wiki/Special:OAuth2Client/callback"
  ],
  "grants": [
    "authorization_code"
  ],
  "scope": [
    "stable-username",
    "email"
  ],
  "name": "InventaireWikiLocal",
  "description": "you know, like wiki.inventaire.io but right here on localhost",
  "secret": "{\"hash\":\"yzSHcB0glGBSREiL5QR0TjAGy7/t6iRz1Y1yVq1Or454k+Z9NngDn05R73xuQoYfldtHsdpQ3w9Zlo7U42x5yl8X\",\"salt\":\"ygxTbU8/uv42LKNzfvQJr+VYIMSji0iD5dUEhV+gnYTRTJXk+jGsb4SfzTUTXLwv1qlhD13rv4N9rOOnF68rHN4q\",\"keyLength\":66,\"hashMethod\":\"pbkdf2\",\"iterations\":1646797}"
}
```
If your config uses `useSlowPasswordHashFunction=false`, then replace `secret` value by `323432613663313938366537303764343635616330363139373330666133363663313562356534323763` instead

and then in `inventaire-mediawiki` `.mw_env`:
```sh
# Assuming the local inventaire server is running on port 3006 and that that port is accessible from a local docker container (no firewall blocking the access)
INV_HOST=http://172.17.0.1:3006
OAUTH_CLIENT_ID=c4252a3321c1234b0bf82430dd2f7f69
OAUTH_CLIENT_SECRET=242a6c1986e707d465ac0619730fa366c15b5e427c
```