### PR TITLE
more sophisticated invalidation of Wikidata Query Service cached results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,11 +81,6 @@
       "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-0.3.2.tgz",
       "integrity": "sha1-WYc/Nej89sc2HBAjkmHXbhU0i7I="
     },
-    "after": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
-      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
-    },
     "ansi-escapes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
@@ -2135,7 +2130,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isbn-groups": {
       "version": "2.0.1",
@@ -2570,17 +2566,6 @@
         }
       }
     },
-    "level-ttl": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/level-ttl/-/level-ttl-3.1.1.tgz",
-      "integrity": "sha1-REOkn+n0nWNNPD8x57nffI1HfRQ=",
-      "requires": {
-        "after": ">=0.8.1 <0.9.0-0",
-        "list-stream": ">=1.0.0 <1.1.0-0",
-        "lock": "~0.1.2",
-        "xtend": ">=4.0.0 <4.1.0-0"
-      }
-    },
     "level-write-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/level-write-stream/-/level-write-stream-1.0.0.tgz",
@@ -2646,40 +2631,6 @@
       "resolved": "https://registry.npmjs.org/libqp/-/libqp-1.1.0.tgz",
       "integrity": "sha1-9ebgatdLeU+1tbZpiL9yjvHe2+g="
     },
-    "list-stream": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/list-stream/-/list-stream-1.0.1.tgz",
-      "integrity": "sha1-40SSrdzNGhZbAorW15WjbE/ZXSk=",
-      "requires": {
-        "readable-stream": "~2.0.5",
-        "xtend": "~4.0.1"
-      },
-      "dependencies": {
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-        },
-        "readable-stream": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
-      }
-    },
     "load-json-file": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
@@ -2709,11 +2660,6 @@
           "dev": true
         }
       }
-    },
-    "lock": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/lock/-/lock-0.1.4.tgz",
-      "integrity": "sha1-/sfervF+fDoKVeHaBCgD4l2RdF0="
     },
     "lodash": {
       "version": "4.17.15",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "level-geospatial": "git+https://github.com/maxlath/level-geospatial.git#5001a8f",
     "level-jobs": "^2.1.0",
     "level-party": "^4.0.0",
-    "level-ttl": "^3.1.1",
     "leven": "^2.1.0",
     "lodash": "^4.17.15",
     "moment": "^2.21.0",

--- a/server/controllers/entities/lib/entities_relations_temporary_cache.js
+++ b/server/controllers/entities/lib/entities_relations_temporary_cache.js
@@ -2,14 +2,8 @@ const CONFIG = require('config')
 const __ = CONFIG.universalPath
 const _ = __.require('builders', 'utils')
 const error_ = __.require('lib', 'error/error')
-const { promisify } = require('util')
-const levelTtl = require('level-ttl')
 const { checkFrequency, ttl } = CONFIG.entitiesRelationsTemporaryCache
-
 const db = __.require('level', 'get_sub_db')('entities-relations', 'utf8')
-const ttlDb = levelTtl(db, { checkFrequency, defaultTTL: ttl })
-const put = promisify(ttlDb.put).bind(ttlDb)
-const del = promisify(ttlDb.del).bind(ttlDb)
 
 module.exports = {
   get: async (property, valueUri) => {
@@ -17,19 +11,37 @@ module.exports = {
     return keys.map(getSubject)
   },
 
-  set: async (subjectUri, property, valueUri) => put(buildKey(subjectUri, property, valueUri), ''),
+  set: async (subjectUri, property, valueUri) => {
+    const key = buildKey(subjectUri, property, valueUri)
+    const expireTimeKey = buildExpireTimeKey(key)
+    return db.batch([
+      { type: 'put', key, value: expireTimeKey },
+      { type: 'put', key: expireTimeKey, value: '' },
+    ])
+  },
 
-  del: async (subjectUri, property, valueUri) => del(buildKey(subjectUri, property, valueUri))
+  del: async (subjectUri, property, valueUri) => {
+    const key = buildKey(subjectUri, property, valueUri)
+    const expireTimeKey = await db.get(key)
+    return db.batch([
+      { type: 'del', key },
+      { type: 'del', key: expireTimeKey },
+    ])
+  }
 }
 
 const getKeyRange = (property, object) => {
-  const keys = []
   const keyBase = `${property}-${object}-`
+  return getKeys({
+    gte: keyBase,
+    lt: keyBase + 'z'
+  })
+}
+
+const getKeys = params => {
+  const keys = []
   return new Promise((resolve, reject) => {
-    db.createKeyStream({
-      gte: keyBase,
-      lt: keyBase + 'z'
-    })
+    db.createKeyStream(params)
     .on('data', key => keys.push(key))
     .on('close', () => resolve(keys))
     .on('error', reject)
@@ -44,3 +56,27 @@ const buildKey = (subjectUri, property, valueUri) => {
   if (!_.isEntityUri(valueUri)) throw error_.new('invalid value', { valueUri })
   return `${property}-${valueUri}-${subjectUri}`
 }
+
+const buildExpireTimeKey = key => {
+  const expireTime = Date.now() + ttl
+  return `expire!${expireTime}!${key}`
+}
+
+const checkExpiredCache = async () => {
+  const expiredTimeKeys = await getKeys({
+    gt: 'expire!',
+    lt: `expire!${Date.now()}`
+  })
+
+  if (expiredTimeKeys.length === 0) return
+
+  const batch = []
+  expiredTimeKeys.forEach(expiredTimeKey => {
+    const key = expiredTimeKey.split('!')[2]
+    batch.push({ type: 'del', key })
+    batch.push({ type: 'del', key: expiredTimeKeys })
+  })
+  await db.batch(batch)
+}
+
+setInterval(checkExpiredCache, checkFrequency)

--- a/server/data/wikidata/queries/author_works.js
+++ b/server/data/wikidata/queries/author_works.js
@@ -1,14 +1,24 @@
+const relationProperties = [
+  'wdt:P50',
+  'wdt:P58',
+  'wdt:P110',
+  'wdt:P6338',
+]
+
 module.exports = {
   parameters: [ 'qid' ],
+
+  relationProperties,
+
   query: params => {
     const { qid: authorQid } = params
     return `SELECT ?work ?type ?date ?serie WHERE {
-  ?work wdt:P50|wdt:P58|wdt:P110|wdt:P6338 wd:${authorQid} .
+  ?work ${relationProperties.join('|')} wd:${authorQid} .
   ?work wdt:P31 ?type .
   FILTER NOT EXISTS { ?work wdt:P31 wd:Q3331189 }
   OPTIONAL { ?work wdt:P577 ?date . }
   OPTIONAL { ?work wdt:P179 ?serie . }
   OPTIONAL { ?work wdt:P361 ?serie . }
 }`
-  }
+  },
 }

--- a/server/data/wikidata/queries/editions_reverse_claims.js
+++ b/server/data/wikidata/queries/editions_reverse_claims.js
@@ -1,5 +1,8 @@
 module.exports = {
   parameters: [ 'pid', 'qid' ],
+
+  relationProperties: [ '*' ],
+
   query: params => {
     const { pid, qid } = params
     return `SELECT DISTINCT ?item WHERE {

--- a/server/data/wikidata/queries/humans_reverse_claims.js
+++ b/server/data/wikidata/queries/humans_reverse_claims.js
@@ -1,5 +1,8 @@
 module.exports = {
   parameters: [ 'pid', 'qid' ],
+
+  relationProperties: [ '*' ],
+
   query: params => {
     const { pid, qid } = params
     return `SELECT DISTINCT ?item WHERE {

--- a/server/data/wikidata/queries/publisher_collections.js
+++ b/server/data/wikidata/queries/publisher_collections.js
@@ -1,10 +1,15 @@
+const relationProperty = 'wdt:P123'
+
 module.exports = {
   parameters: [ 'qid' ],
+
+  relationProperties: [ relationProperty ],
+
   query: ({ qid: publisherId }) => {
     return `SELECT ?collection WHERE {
   VALUES (?collection_type) { (wd:Q20655472) (wd:Q1700470) (wd:Q2668072) } .
   ?collection wdt:P31 ?collection_type .
-  ?collection wdt:P123 wd:${publisherId} .
+  ?collection ${relationProperty} wd:${publisherId} .
   OPTIONAL { ?collection wdt:P577|wdt:P580 ?starting_date }
 }
 ORDER BY DESC(?starting_date)`

--- a/server/data/wikidata/queries/queries.js
+++ b/server/data/wikidata/queries/queries.js
@@ -1,4 +1,4 @@
-module.exports = {
+const queries = {
   author_works: require('./author_works'),
   serie_parts: require('./serie_parts'),
   publisher_collections: require('./publisher_collections'),
@@ -7,3 +7,17 @@ module.exports = {
   humans_reverse_claims: require('./humans_reverse_claims'),
   resolve_external_ids: require('./resolve_external_ids')
 }
+
+const queriesPerProperty = {}
+
+for (const queryName in queries) {
+  const { relationProperties } = queries[queryName]
+  if (relationProperties) {
+    relationProperties.forEach(property => {
+      queriesPerProperty[property] = queriesPerProperty[property] || []
+      queriesPerProperty[property].push(queryName)
+    })
+  }
+}
+
+module.exports = { queries, queriesPerProperty }

--- a/server/data/wikidata/queries/serie_parts.js
+++ b/server/data/wikidata/queries/serie_parts.js
@@ -1,5 +1,11 @@
 module.exports = {
   parameters: [ 'qid' ],
+
+  relationProperties: [
+    'wdt:P179',
+    'wdt:P361',
+  ],
+
   query: params => {
     const { qid: serieQid } = params
 

--- a/server/data/wikidata/queries/works_reverse_claims.js
+++ b/server/data/wikidata/queries/works_reverse_claims.js
@@ -1,5 +1,8 @@
 module.exports = {
   parameters: [ 'pid', 'qid' ],
+
+  relationProperties: [ '*' ],
+
   query: params => {
     const { pid, qid } = params
     return `SELECT DISTINCT ?item WHERE {

--- a/server/lib/cache.js
+++ b/server/lib/cache.js
@@ -61,6 +61,11 @@ module.exports = {
     if (!_.isNonEmptyString(key)) throw error_.new('invalid key', 500)
     if (value == null) throw error_.new('missing value', 500)
     return putResponseInCache(key, value)
+  },
+
+  batchDelete: keys => {
+    const batch = _.forceArray(keys).map(key => ({ type: 'del', key }))
+    return db.batch(batch)
   }
 }
 

--- a/tests/api/entities/temporarily_cache_relations.test.js
+++ b/tests/api/entities/temporarily_cache_relations.test.js
@@ -11,17 +11,14 @@ const { wait } = __.require('lib', 'promises')
 // so the following tests try to reproduce conditions as close as possible to the real use-cases
 const { cacheEntityRelations, getCachedRelations } = __.require('controllers', 'entities/lib/temporarily_cache_relations')
 
-const assertLeveldbDiskBackend = () => {
-  if (CONFIG.leveldbMemoryBackend) {
-    throw new Error(`this test requires ${CONFIG.env} config to have CONFIG.leveldbMemoryBackend=false`)
-  }
+if (CONFIG.leveldbMemoryBackend) {
+  throw new Error(`this test requires ${CONFIG.env} config to have CONFIG.leveldbMemoryBackend=false`)
 }
 
 // Due to this feature being primarily used to keep data after edits on Wikidata,
 // and due to the revalidation on primary data, it's quite hard to test from the API itself.
 describe('temporarily cache relations', () => {
   it('should add author relation to cache', async () => {
-    assertLeveldbDiskBackend()
     const someAuthorUri = 'wd:Q1345582'
     const { uri } = await createWorkWithAuthor({ uri: someAuthorUri })
     await cacheEntityRelations(uri)
@@ -30,7 +27,6 @@ describe('temporarily cache relations', () => {
   })
 
   it('should add serie relation to cache', async () => {
-    assertLeveldbDiskBackend()
     const someSerieUri = 'wd:Q3656893'
     const { uri } = await createWorkWithSerie({ uri: someSerieUri })
     await cacheEntityRelations(uri)
@@ -39,7 +35,6 @@ describe('temporarily cache relations', () => {
   })
 
   it('should check the primary data', async () => {
-    assertLeveldbDiskBackend()
     const someSerieUri = 'wd:Q3656893'
     const someUnrelatedWorkUri = 'wd:Q187655'
     const workWithSerie = await createWorkWithSerie({ uri: someSerieUri })

--- a/tests/integration/entities_relations_temporary_cache.js
+++ b/tests/integration/entities_relations_temporary_cache.js
@@ -3,6 +3,7 @@ const __ = CONFIG.universalPath
 const { wait } = __.require('lib', 'promises')
 require('should')
 const { checkFrequency, ttl } = CONFIG.entitiesRelationsTemporaryCache
+const { catchNotFound } = __.require('lib', 'error/error')
 
 const { someFakeUri } = __.require('apiTests', 'fixtures/entities')
 const { shouldNotBeCalled } = __.require('apiTests', 'utils/utils')
@@ -13,7 +14,7 @@ const targetEntityUri = 'wd:Q1'
 
 describe('entities relations temporary cache', () => {
   beforeEach(async () => {
-    await del(someFakeUri, property, targetEntityUri)
+    await del(someFakeUri, property, targetEntityUri).catch(catchNotFound)
   })
 
   it('should reject missing subject', async () => {


### PR DESCRIPTION
In the current situation:
- a user sets a P50 on a Wikidata entity from the Inventaire entity editor
- the [entities relations temporary cache](https://github.com/inventaire/inventaire/blob/a85f27d/server/controllers/entities/lib/temporarily_cache_relations.js) keeps that relation in memory for a certain time, so that when some user requests the entities having a P50 claim pointing to that same target entity, we can add to the result the value we are aware of, before the Query Service update
- after that time (4h by default), the relation is removed from the temporary cache **but** cached queries pre-dating the initial update might still be in the cache (can be seen with `lev ./db/level-tests --prefix '!cache!wdQuery'`), returning results we know to be out-dated

This PR makes sure that those cached results are invalidated once the temporary cache expired, that is, after we can reasonably expect that the Query Service is now up-to-date

[centralizing issue on the topic: #313 ]