### PR TITLE
move_to_wikidata: add context to the redirection patch

### DIFF
--- a/server/controllers/entities/lib/merge_entities.js
+++ b/server/controllers/entities/lib/merge_entities.js
@@ -7,7 +7,7 @@ const Entity = __.require('models', 'entity')
 const turnIntoRedirection = require('./turn_into_redirection')
 const getInvEntityCanonicalUri = require('./get_inv_entity_canonical_uri')
 
-module.exports = ({ userId, fromUri, toUri }) => {
+module.exports = ({ userId, fromUri, toUri, context }) => {
   let [ fromPrefix, fromId ] = fromUri.split(':')
   let [ toPrefix, toId ] = toUri.split(':')
 
@@ -22,11 +22,11 @@ module.exports = ({ userId, fromUri, toUri }) => {
 
   if (toPrefix === 'wd') {
     // no merge to do for Wikidata entities, simply creating a redirection
-    return turnIntoRedirection({ userId, fromId, toUri })
+    return turnIntoRedirection({ userId, fromId, toUri, context })
   } else {
     // TODO: invert fromId and toId if the merged entity is more popular
     // to reduce the amount of documents that need to be updated
-    return mergeInvEntities(userId, fromId, toId)
+    return mergeInvEntities(userId, fromId, toId, context)
   }
 }
 

--- a/server/controllers/entities/lib/move_to_wikidata.js
+++ b/server/controllers/entities/lib/move_to_wikidata.js
@@ -21,7 +21,14 @@ module.exports = async (user, invEntityUri) => {
   // by the absence of the entity they just moved to Wikidata in lists generated with the help of the WQS
   await cacheEntityRelations(invEntityUri)
 
-  await mergeEntities({ userId: reqUserId, fromUri: invEntityUri, toUri: wdEntityUri })
+  await mergeEntities({
+    userId: reqUserId,
+    fromUri: invEntityUri,
+    toUri: wdEntityUri,
+    context: {
+      action: 'move-to-wikidata'
+    }
+  })
 
   return { uri: wdEntityUri }
 }

--- a/server/controllers/entities/lib/turn_into_redirection.js
+++ b/server/controllers/entities/lib/turn_into_redirection.js
@@ -6,7 +6,7 @@ const Entity = __.require('models', 'entity')
 const placeholders_ = require('./placeholders')
 const propagateRedirection = require('./propagate_redirection')
 
-module.exports = async ({ userId, fromId, toUri, previousToUri }) => {
+module.exports = async ({ userId, fromId, toUri, previousToUri, context }) => {
   assert_.strings([ userId, fromId, toUri ])
   if (previousToUri != null) assert_.string(previousToUri)
 
@@ -20,7 +20,8 @@ module.exports = async ({ userId, fromId, toUri, previousToUri }) => {
   await entities_.putUpdate({
     userId,
     currentDoc: currentFromDoc,
-    updatedDoc: updatedFromDoc
+    updatedDoc: updatedFromDoc,
+    context
   })
   return propagateRedirection(userId, fromUri, toUri, previousToUri)
 }


### PR DESCRIPTION
to not be surprised each time a non-dataadmin user makes a merge this way

To fully complete its purpose, we would also need to have the client display patches context in history views