### PR TITLE
item busy state: replace derived data by query to the primary data

### DIFF
--- a/server/controllers/items/lib/queries_commons.js
+++ b/server/controllers/items/lib/queries_commons.js
@@ -1,5 +1,6 @@
 const _ = require('builders/utils')
 const user_ = require('controllers/user/lib/user')
+const transactions_ = require('controllers/transactions/lib/transactions')
 const snapshot_ = require('./snapshot/snapshot')
 
 const filters = {
@@ -13,12 +14,13 @@ const validFilters = Object.keys(filters)
 const queriesCommons = module.exports = {
   validFilters,
 
-  addAssociatedData: page => {
-    return Promise.all([
+  addAssociatedData: async page => {
+    await Promise.all([
       queriesCommons.addItemsSnapshots(page.items),
-      queriesCommons.addUsersData(page)
+      queriesCommons.addUsersData(page),
+      transactions_.setItemsBusyFlag(page.items),
     ])
-    .then(() => page)
+    return page
   },
 
   addUsersData: page => {

--- a/server/controllers/transactions/lib/rights_verification.js
+++ b/server/controllers/transactions/lib/rights_verification.js
@@ -22,9 +22,10 @@ const verifyNoExistingTransaction = (requester, item) => {
 }
 
 module.exports = {
-  verifyRightToRequest: (requester, item) => {
-    if (item.busy) {
-      throw error_.new('this item is busy', 403, item)
+  verifyRightToRequest: async (requester, item) => {
+    const itemIsBusy = await transactions_.itemIsBusy(item._id)
+    if (itemIsBusy) {
+      throw error_.new('item already busy', 403, item)
     }
 
     // the owner of the item isnt allowed to request it

--- a/server/controllers/transactions/lib/rights_verification.js
+++ b/server/controllers/transactions/lib/rights_verification.js
@@ -37,27 +37,21 @@ module.exports = {
 
   verifyRightToInteract: (userId, transaction) => {
     const { owner, requester } = transaction
-    if (userId === owner || userId === requester) {
-      return transaction
-    } else {
+    if (!(userId === owner || userId === requester)) {
       throw error_.new('wrong user', 403, userId, transaction)
     }
   },
 
   verifyIsOwner: (userId, transaction) => {
     const { owner } = transaction
-    if (userId === owner) {
-      return transaction
-    } else {
+    if (userId !== owner) {
       throw error_.new('wrong user', 403, userId, transaction)
     }
   },
 
   verifyIsRequester: (userId, transaction) => {
     const { requester } = transaction
-    if (userId === requester) {
-      return transaction
-    } else {
+    if (userId !== requester) {
       throw error_.new('wrong user', 403, userId, transaction)
     }
   }

--- a/server/controllers/transactions/lib/side_effects.js
+++ b/server/controllers/transactions/lib/side_effects.js
@@ -14,13 +14,6 @@ const applySideEffects = (transacDoc, newState) => {
   return sideEffects[newState](transacDoc, newState)
 }
 
-const setItemBusyness = (busy, transacDoc) => {
-  _.log({ busy, transacDoc }, 'setItemBusyness')
-  const { item } = transacDoc
-  return items_.setBusyness(item, busy)
-  .catch(_.Error('setItemBusyness'))
-}
-
 const changeOwnerIfOneWay = transacDoc => {
   if (Transaction.isOneWay(transacDoc)) {
     _.log({ transacDoc }, 'changeOwner')
@@ -29,13 +22,10 @@ const changeOwnerIfOneWay = transacDoc => {
   }
 }
 
-const setItemToBusy = _.partial(setItemBusyness, true)
-const setItemToNotBusy = _.partial(setItemBusyness, false)
-
 const sideEffects = {
-  accepted: setItemToBusy,
+  accepted: _.noop,
   declined: _.noop,
   confirmed: changeOwnerIfOneWay,
-  returned: setItemToNotBusy,
-  cancelled: setItemToNotBusy
+  returned: _.noop,
+  cancelled: _.noop,
 }

--- a/server/controllers/transactions/lib/transactions.js
+++ b/server/controllers/transactions/lib/transactions.js
@@ -74,10 +74,10 @@ const transactions_ = module.exports = {
     }))
   },
 
-  getItemBusyTransactions: async itemId => {
+  itemIsBusy: async itemId => {
     assert_.string(itemId)
     const rows = await getBusyItems([ itemId ])
-    return _.map(rows, 'id')
+    return rows.length > 0
   },
 
   setItemsBusyFlag: async items => {

--- a/server/controllers/transactions/lib/transactions.js
+++ b/server/controllers/transactions/lib/transactions.js
@@ -41,10 +41,10 @@ const transactions_ = module.exports = {
     }
   },
 
-  updateState: (newState, userId, transaction) => {
+  updateState: async (transaction, newState, userId) => {
     Transaction.validatePossibleState(transaction, newState)
-    return db.update(transaction._id, stateUpdater(newState, userId, transaction))
-    .then(() => radio.emit('transaction:update', transaction, newState))
+    await db.update(transaction._id, stateUpdater(newState, userId, transaction))
+    await radio.emit('transaction:update', transaction, newState)
   },
 
   markAsRead: (userId, transaction) => {

--- a/server/controllers/transactions/lib/transactions.js
+++ b/server/controllers/transactions/lib/transactions.js
@@ -72,6 +72,17 @@ const transactions_ = module.exports = {
     return Promise.all(activeTransactions.map(transaction => {
       return transactions_.updateState('cancelled', userId, transaction)
     }))
+  },
+
+  setItemsBusyFlag: async items => {
+    if (items.length === 0) return items
+    const itemsIds = _.map(items, '_id')
+    const { rows } = await db.view('transactions', 'byBusyItem', { keys: itemsIds })
+    const busyItemsIds = new Set(_.map(rows, 'key'))
+    return items.map(item => {
+      item.busy = busyItemsIds.has(item._id)
+      return item
+    })
   }
 }
 

--- a/server/controllers/transactions/mark_as_read.js
+++ b/server/controllers/transactions/mark_as_read.js
@@ -12,12 +12,13 @@ const sanitization = {
 
 module.exports = (req, res) => {
   sanitize(req, res, sanitization)
-  .then(params => {
-    const { id, reqUserId } = params
-    return transactions_.byId(id)
-    .then(verifyRightToInteract.bind(null, reqUserId))
-    .then(transactions_.markAsRead.bind(null, reqUserId))
-    .then(responses_.Ok(res))
-  })
+  .then(markAsRead)
+  .then(responses_.Ok(res))
   .catch(error_.Handler(req, res))
+}
+
+const markAsRead = async ({ id, reqUserId }) => {
+  const transaction = await transactions_.byId(id)
+  verifyRightToInteract(reqUserId, transaction)
+  await transactions_.markAsRead(reqUserId, transaction)
 }

--- a/server/controllers/transactions/update_state.js
+++ b/server/controllers/transactions/update_state.js
@@ -25,17 +25,17 @@ module.exports = (req, res) => {
 
 const updateState = async ({ transactionId, state, reqUserId }) => {
   const transaction = await transactions_.byId(transactionId)
-  verifyRights(transaction, state, reqUserId)
+  validateRights(transaction, state, reqUserId)
   await checkForConcurrentTransactions(transaction, state)
   return transactions_.updateState(transaction, state, reqUserId)
 }
 
-const verifyRights = (transaction, state, reqUserId) => {
+const validateRights = (transaction, state, reqUserId) => {
   const { actor } = states[state]
-  verifyRightsFunctionByAllowedActor[actor](reqUserId, transaction)
+  validateRightsFunctionByAllowedActor[actor](reqUserId, transaction)
 }
 
-const verifyRightsFunctionByAllowedActor = {
+const validateRightsFunctionByAllowedActor = {
   requester: verifyIsRequester,
   owner: verifyIsOwner,
   both: verifyRightToInteract,

--- a/server/controllers/transactions/update_state.js
+++ b/server/controllers/transactions/update_state.js
@@ -43,12 +43,12 @@ const verifyRightsFunctionByAllowedActor = {
 
 const checkForConcurrentTransactions = async (transaction, requestedState) => {
   if (requestedState === 'accepted') {
-    const { item: itemId } = transaction
-    const itemBusyTransactions = await transactions_.getItemBusyTransactions(itemId)
     // No need to check that the transaction holding the item busy is not the updated transaction
-    // as only accepting
-    if (itemBusyTransactions.length > 0) {
-      throw error_.new('item already busy', 400, { transaction, itemBusyTransactions, requestedState })
+    // as the requested state is 'accepted', which, to be valid, needs to be done on a transaction
+    // in a 'requested' state
+    const itemIsBusy = await transactions_.itemIsBusy(transaction.item)
+    if (itemIsBusy) {
+      throw error_.new('item already busy', 403, { transaction, requestedState })
     }
   }
 }

--- a/server/db/couchdb/design_docs/transactions.json
+++ b/server/db/couchdb/design_docs/transactions.json
@@ -4,6 +4,9 @@
   "views": {
     "byUserAndItem": {
       "map": "(doc)->\n  emit [doc.owner, doc.item], null\n  emit [doc.requester, doc.item], null"
+    },
+    "byBusyItem": {
+      "map": "(doc)->\n  lastAction = doc.actions.slice(-1)[0].action\n  if lastAction is 'accepted' or (doc.transaction is 'lending' and lastAction is 'confirmed')\n    emit doc.item, null"
     }
   }
 }

--- a/server/models/attributes/item.js
+++ b/server/models/attributes/item.js
@@ -31,7 +31,6 @@ attributes.notUpdatable = [
   'updated',
 
   // Updated as side effects of transactions
-  'busy',
   'owner',
   'history',
 
@@ -50,7 +49,6 @@ attributes.private = [
 // Attribute to reset on owner change
 attributes.reset = attributes.private.concat([
   'details',
-  'busy'
 ])
 
 const allowTransaction = [ 'giving', 'lending', 'selling' ]

--- a/tests/api/fixtures/transactions.js
+++ b/tests/api/fixtures/transactions.js
@@ -5,15 +5,13 @@ const { createItem } = require('./items')
 const { getById: getRefreshedItem } = require('../utils/items')
 
 const createTransaction = async (params = {}) => {
-  let {
-    userA = getUser(),
-    userB = getUserB(),
-    itemData
-  } = params
-  userA = await userA
-  userB = await userB
-  itemData = itemData || { listing: 'public', transaction: 'giving' }
-  const item = await createItem(userB, itemData)
+  const userA = await (params.userA || getUser())
+  const userB = await (params.userB || getUserB())
+  let { item, itemData } = params
+  if (!item) {
+    itemData = itemData || { listing: 'public', transaction: 'giving' }
+    item = await createItem(userB, itemData)
+  }
   await wait(100)
   const refreshedItem = await getRefreshedItem(item)
   const res = await customAuthReq(userA, 'post', '/api/transactions?action=request', {

--- a/tests/api/transactions/update-state.test.js
+++ b/tests/api/transactions/update-state.test.js
@@ -1,11 +1,15 @@
 require('should')
+const _ = require('builders/utils')
 const { authReqB, authReqC, shouldNotBeCalled } = require('apiTests/utils/utils')
 const { createTransaction, getSomeTransaction } = require('../fixtures/transactions')
+const { updateTransaction } = require('../utils/transactions')
+const { getById: getItem } = require('../utils/items')
+const { wait } = require('lib/promises')
 
 const endpoint = '/api/transactions?action=update-state'
 
 describe('transactions:update-state', () => {
-  it('should update state and apply side effects', async () => {
+  it('should update state', async () => {
     const { transaction } = await createTransaction()
     const updateRes = await authReqB('put', endpoint, {
       transaction: transaction._id,
@@ -35,6 +39,107 @@ describe('transactions:update-state', () => {
     .then(shouldNotBeCalled)
     .catch(err => {
       err.body.status_verbose.should.equal('wrong user')
+    })
+  })
+
+  describe('side effects', () => {
+    describe('one way transactions', () => {
+      const itemData = { transaction: _.sample([ 'giving', 'selling' ]), listing: 'public' }
+
+      it('should set item.busy=false when the transaction is just requested', async () => {
+        const { userBItem } = await createTransaction({ itemData })
+        userBItem.busy.should.be.false()
+      })
+
+      it('should set item.busy=true when the transaction is accepted', async () => {
+        const { transaction, userBItem, userB } = await createTransaction({ itemData })
+        await updateTransaction(userB, transaction, 'accepted')
+        await wait(100)
+        const updatedItem = await getItem(userBItem)
+        updatedItem.busy.should.be.true()
+      })
+
+      it('should set item.busy=false when the transaction is just declined', async () => {
+        const { transaction, userBItem, userB } = await createTransaction({ itemData })
+        await updateTransaction(userB, transaction, 'declined')
+        await wait(100)
+        const updatedItem = await getItem(userBItem)
+        updatedItem.busy.should.be.false()
+      })
+
+      it('should set item.busy=false when the transaction is confirmed and change owner', async () => {
+        const { transaction, userBItem, userA, userB } = await createTransaction({ itemData })
+        userBItem.owner.should.equal(userB._id)
+        await updateTransaction(userB, transaction, 'accepted')
+        await updateTransaction(userA, transaction, 'confirmed')
+        await wait(100)
+        const updatedItem = await getItem(userBItem)
+        updatedItem.owner.should.equal(userA._id)
+        updatedItem.busy.should.be.false()
+      })
+
+      it('should set item.busy=false when the transaction is cancelled', async () => {
+        const { transaction, userBItem, userA, userB } = await createTransaction({ itemData })
+        await updateTransaction(userB, transaction, 'accepted')
+        await updateTransaction(userA, transaction, 'cancelled')
+        await wait(100)
+        const updatedItem = await getItem(userBItem)
+        updatedItem.busy.should.be.false()
+      })
+    })
+
+    describe('two way transactions', () => {
+      const itemData = { transaction: 'lending', listing: 'public' }
+
+      it('should set item.busy=false when the transaction is just requested', async () => {
+        const { userBItem } = await createTransaction({ itemData })
+        userBItem.busy.should.be.false()
+      })
+
+      it('should set item.busy=true when the transaction is accepted', async () => {
+        const { transaction, userBItem, userB } = await createTransaction({ itemData })
+        await updateTransaction(userB, transaction, 'accepted')
+        await wait(100)
+        const updatedItem = await getItem(userBItem)
+        updatedItem.busy.should.be.true()
+      })
+
+      it('should set item.busy=false when the transaction is just declined', async () => {
+        const { transaction, userBItem, userB } = await createTransaction({ itemData })
+        await updateTransaction(userB, transaction, 'declined')
+        await wait(100)
+        const updatedItem = await getItem(userBItem)
+        updatedItem.busy.should.be.false()
+      })
+
+      it('should set item.busy=true when the transaction is confirmed', async () => {
+        const { transaction, userBItem, userA, userB } = await createTransaction({ itemData })
+        await updateTransaction(userB, transaction, 'accepted')
+        await updateTransaction(userA, transaction, 'confirmed')
+        await wait(100)
+        const updatedItem = await getItem(userBItem)
+        updatedItem.busy.should.be.true()
+      })
+
+      it('should set item.busy=false when the transaction is returned', async () => {
+        const { transaction, userBItem, userA, userB } = await createTransaction({ itemData })
+        await updateTransaction(userB, transaction, 'accepted')
+        await updateTransaction(userA, transaction, 'confirmed')
+        await updateTransaction(userB, transaction, 'returned')
+        await wait(100)
+        const updatedItem = await getItem(userBItem)
+        updatedItem.busy.should.be.false()
+      })
+
+      it('should set item.busy=false when the transaction is cancelled', async () => {
+        const { transaction, userBItem, userA, userB } = await createTransaction({ itemData })
+        await updateTransaction(userB, transaction, 'accepted')
+        await updateTransaction(userA, transaction, 'confirmed')
+        await updateTransaction(userA, transaction, 'cancelled')
+        await wait(1000)
+        const updatedItem = await getItem(userBItem)
+        updatedItem.busy.should.be.false()
+      })
     })
   })
 })

--- a/tests/api/transactions/update-state.test.js
+++ b/tests/api/transactions/update-state.test.js
@@ -153,7 +153,7 @@ describe('transactions:update-state', () => {
       await updateTransaction(userB, transactionY, 'accepted')
       .then(shouldNotBeCalled)
       .catch(err => {
-        err.statusCode.should.equal(400)
+        err.statusCode.should.equal(403)
         err.body.status_verbose.should.equal('item already busy')
       })
     })

--- a/tests/api/transactions/update-state.test.js
+++ b/tests/api/transactions/update-state.test.js
@@ -43,16 +43,16 @@ describe('transactions:update-state', () => {
     })
   })
 
-  describe('side effects', () => {
-    describe('one way transactions', () => {
+  describe('side effects: item.busy flag', () => {
+    describe('giving and selling transactions', () => {
       const itemData = { transaction: _.sample([ 'giving', 'selling' ]), listing: 'public' }
 
-      it('should set item.busy=false when the transaction is just requested', async () => {
+      it('should be false when the transaction is just requested', async () => {
         const { userBItem } = await createTransaction({ itemData })
         userBItem.busy.should.be.false()
       })
 
-      it('should set item.busy=true when the transaction is accepted', async () => {
+      it('should be true when the transaction is accepted', async () => {
         const { transaction, userBItem, userB } = await createTransaction({ itemData })
         await updateTransaction(userB, transaction, 'accepted')
         await wait(100)
@@ -60,7 +60,7 @@ describe('transactions:update-state', () => {
         updatedItem.busy.should.be.true()
       })
 
-      it('should set item.busy=false when the transaction is just declined', async () => {
+      it('should be false when the transaction is just declined', async () => {
         const { transaction, userBItem, userB } = await createTransaction({ itemData })
         await updateTransaction(userB, transaction, 'declined')
         await wait(100)
@@ -68,7 +68,7 @@ describe('transactions:update-state', () => {
         updatedItem.busy.should.be.false()
       })
 
-      it('should set item.busy=false when the transaction is confirmed and change owner', async () => {
+      it('should be false when the transaction is confirmed and change owner', async () => {
         const { transaction, userBItem, userA, userB } = await createTransaction({ itemData })
         userBItem.owner.should.equal(userB._id)
         await updateTransaction(userB, transaction, 'accepted')
@@ -79,7 +79,7 @@ describe('transactions:update-state', () => {
         updatedItem.busy.should.be.false()
       })
 
-      it('should set item.busy=false when the transaction is cancelled', async () => {
+      it('should be false when the transaction is cancelled', async () => {
         const { transaction, userBItem, userA, userB } = await createTransaction({ itemData })
         await updateTransaction(userB, transaction, 'accepted')
         await updateTransaction(userA, transaction, 'cancelled')
@@ -89,15 +89,15 @@ describe('transactions:update-state', () => {
       })
     })
 
-    describe('two way transactions', () => {
+    describe('lending transactions', () => {
       const itemData = { transaction: 'lending', listing: 'public' }
 
-      it('should set item.busy=false when the transaction is just requested', async () => {
+      it('should be false when the transaction is just requested', async () => {
         const { userBItem } = await createTransaction({ itemData })
         userBItem.busy.should.be.false()
       })
 
-      it('should set item.busy=true when the transaction is accepted', async () => {
+      it('should be true when the transaction is accepted', async () => {
         const { transaction, userBItem, userB } = await createTransaction({ itemData })
         await updateTransaction(userB, transaction, 'accepted')
         await wait(100)
@@ -105,7 +105,7 @@ describe('transactions:update-state', () => {
         updatedItem.busy.should.be.true()
       })
 
-      it('should set item.busy=false when the transaction is just declined', async () => {
+      it('should be false when the transaction is just declined', async () => {
         const { transaction, userBItem, userB } = await createTransaction({ itemData })
         await updateTransaction(userB, transaction, 'declined')
         await wait(100)
@@ -113,7 +113,7 @@ describe('transactions:update-state', () => {
         updatedItem.busy.should.be.false()
       })
 
-      it('should set item.busy=true when the transaction is confirmed', async () => {
+      it('should be true when the transaction is confirmed', async () => {
         const { transaction, userBItem, userA, userB } = await createTransaction({ itemData })
         await updateTransaction(userB, transaction, 'accepted')
         await updateTransaction(userA, transaction, 'confirmed')
@@ -122,7 +122,7 @@ describe('transactions:update-state', () => {
         updatedItem.busy.should.be.true()
       })
 
-      it('should set item.busy=false when the transaction is returned', async () => {
+      it('should be false when the transaction is returned', async () => {
         const { transaction, userBItem, userA, userB } = await createTransaction({ itemData })
         await updateTransaction(userB, transaction, 'accepted')
         await updateTransaction(userA, transaction, 'confirmed')
@@ -132,7 +132,7 @@ describe('transactions:update-state', () => {
         updatedItem.busy.should.be.false()
       })
 
-      it('should set item.busy=false when the transaction is cancelled', async () => {
+      it('should be false when the transaction is cancelled', async () => {
         const { transaction, userBItem, userA, userB } = await createTransaction({ itemData })
         await updateTransaction(userB, transaction, 'accepted')
         await updateTransaction(userA, transaction, 'confirmed')

--- a/tests/api/utils/transactions.js
+++ b/tests/api/utils/transactions.js
@@ -13,6 +13,7 @@ module.exports = {
   },
 
   updateTransaction: async (user, transactionId, state) => {
+    transactionId = transactionId._id || transactionId
     return customAuthReq(user, 'put', `${endpoint}?action=update-state`, {
       transaction: transactionId,
       state


### PR DESCRIPTION
fix #492 by querying the transactions database to determine the state of `item.busy`

This PR is meant to not require any changes on the client: items requests will still return items with a `busy` flag.

But this also opens new possibilities for the future, such as setting the `busy` flag only when explicitly requested, or implementing a `include-transactions` flag (like the `include-users`)