### PR TITLE
find entities with terms longer than autocomplete max ngram

### DIFF
--- a/server/controllers/entities/lib/find_author_from_works_labels.js
+++ b/server/controllers/entities/lib/find_author_from_works_labels.js
@@ -28,7 +28,7 @@ module.exports = async (authorStr, worksLabels, worksLabelsLangs) => {
   })
 }
 
-const searchHumans = authorStr => typeSearch({ search: authorStr, types: [ 'humans' ], filter: 'wd', minScore: 1 })
+const searchHumans = authorStr => typeSearch({ search: authorStr, types: [ 'humans' ], filter: 'wd', exact: true })
 
 const parseWdUris = hits => hits.map(hit => hit._source.uri)
 

--- a/server/controllers/entities/lib/resolver/resolve_on_terms.js
+++ b/server/controllers/entities/lib/resolver/resolve_on_terms.js
@@ -34,7 +34,7 @@ const searchUrisByAuthorTerms = terms => {
 const types = [ 'humans' ]
 
 const searchUrisByAuthorLabel = async term => {
-  const hits = await typeSearch({ types, search: term })
+  const hits = await typeSearch({ types, search: term, exact: true })
   return hits
   // Exact match on normalized author terms
   .filter(hit => getEntityNormalizedTerms(hit._source).includes(term))

--- a/server/controllers/entities/lib/scaffold_entity_from_seed/search_work_entity_by_title_and_authors.js
+++ b/server/controllers/entities/lib/scaffold_entity_from_seed/search_work_entity_by_title_and_authors.js
@@ -22,7 +22,7 @@ module.exports = async seed => {
   const cachedWorkPromise = workEntitiesCache.get(seed)
   if (cachedWorkPromise != null) return cachedWorkPromise
 
-  const results = await typeSearch({ search: title, types: [ 'works' ], lang })
+  const results = await typeSearch({ search: title, types: [ 'works' ], lang, exact: true })
   const uris = results.map(result => result._source.uri)
   let entities = await getEntitiesByUris({ uris, list: true })
 

--- a/server/controllers/search/lib/entities_query_builder.js
+++ b/server/controllers/search/lib/entities_query_builder.js
@@ -55,7 +55,7 @@ const matchEntities = (search, userLang, exact) => {
         query: search,
         operator: 'and',
         fields,
-        analyzer: 'standard',
+        analyzer: 'standard_truncated',
         type: 'best_fields',
         boost: 3
       }
@@ -67,7 +67,7 @@ const matchEntities = (search, userLang, exact) => {
       multi_match: {
         query: search,
         fields,
-        analyzer: 'standard',
+        analyzer: 'standard_truncated',
       }
     })
   }

--- a/server/controllers/search/lib/entities_query_builder.js
+++ b/server/controllers/search/lib/entities_query_builder.js
@@ -12,9 +12,9 @@ module.exports = params => {
         query: {
           bool: {
             filter: [
-              // at least one type should match
-              // this is basically an 'or' operator
-              { bool: { should: matchType(types) } },
+              // At least one type should match
+              // See https://www.elastic.co/guide/en/elasticsearch/reference/7.10/query-dsl-terms-query.html
+              { terms: { type: types } }
             ],
             must: [
               // Because most of the work has been done at index time (indexing terms by ngrams)
@@ -41,8 +41,6 @@ module.exports = params => {
     min_score: minScore
   }
 }
-
-const matchType = types => types.map(type => ({ term: { type } }))
 
 const matchEntities = (search, userLang, exact) => {
   const fields = entitiesFields(userLang, exact)

--- a/server/controllers/search/lib/entities_query_builder.js
+++ b/server/controllers/search/lib/entities_query_builder.js
@@ -24,17 +24,13 @@ module.exports = params => {
             [boolMode]: matchEntities(search, userLang, exact)
           }
         },
-        functions: [
-          {
-            // See: https://www.elastic.co/guide/en/elasticsearch/reference/7.10/query-dsl-function-score-query.html#function-field-value-factor
-            field_value_factor: {
-              field: 'popularity',
-              // Inspired by https://www.elastic.co/guide/en/elasticsearch/guide/current/boosting-by-popularity.html
-              modifier: 'ln2p',
-              missing: 1
-            },
-          }
-        ],
+        // See: https://www.elastic.co/guide/en/elasticsearch/reference/7.10/query-dsl-function-score-query.html#function-field-value-factor
+        field_value_factor: {
+          field: 'popularity',
+          // Inspired by https://www.elastic.co/guide/en/elasticsearch/guide/current/boosting-by-popularity.html
+          modifier: 'ln2p',
+          missing: 1
+        },
       },
     },
     size,

--- a/server/controllers/tasks/lib/get_new_tasks.js
+++ b/server/controllers/tasks/lib/get_new_tasks.js
@@ -83,9 +83,6 @@ const getAuthorWorksData = authorId => {
 
 const getLangs = work => Object.keys(work.labels)
 
-// Arbitrarily set, can be changed to better fit the changes in results scores
-const lowestSuggestionMatchScore = 4
-
 const searchEntityDuplicatesSuggestions = async entity => {
   const name = _.values(entity.labels)[0]
   if (!_.isNonEmptyString(name)) return []
@@ -95,7 +92,6 @@ const searchEntityDuplicatesSuggestions = async entity => {
     types: [ 'humans' ],
     filter: 'wd',
     exact: true,
-    minScore: lowestSuggestionMatchScore
   })
 
   return results.map(formatResult)

--- a/server/db/elasticsearch/mappings/mappings_datatypes.js
+++ b/server/db/elasticsearch/mappings/mappings_datatypes.js
@@ -6,8 +6,9 @@ const langProperty = {
   type: 'text',
   analyzer: 'autocomplete',
   // Set a different default analyzer for search time,
+  // as recommanded in https://www.elastic.co/guide/en/elasticsearch/reference/7.10/analysis-edgengram-tokenizer.html#max-gram-limits
   // See: https://www.elastic.co/guide/en/elasticsearch/reference/7.10/search-analyzer.html
-  search_analyzer: 'standard'
+  search_analyzer: 'standard_truncated'
   // To be considered for next reindexation: set norms.enabled=false as in our use case,
   // the kind of term (label, alias, or description) is more important than it's length
   // See https://www.elastic.co/guide/en/elasticsearch/guide/current/scoring-theory.html

--- a/server/db/elasticsearch/mappings/mappings_datatypes.js
+++ b/server/db/elasticsearch/mappings/mappings_datatypes.js
@@ -5,9 +5,9 @@ const { activeI18nLangs } = require('../helpers')
 const langProperty = {
   type: 'text',
   analyzer: 'autocomplete',
-  // adding a 'search_analyzer' key to use a different analyzer at search time,
+  // Set a different default analyzer for search time,
   // See: https://www.elastic.co/guide/en/elasticsearch/reference/7.10/search-analyzer.html
-  search_analyzer: 'simple'
+  search_analyzer: 'standard'
   // To be considered for next reindexation: set norms.enabled=false as in our use case,
   // the kind of term (label, alias, or description) is more important than it's length
   // See https://www.elastic.co/guide/en/elasticsearch/guide/current/scoring-theory.html

--- a/server/db/elasticsearch/settings/settings.js
+++ b/server/db/elasticsearch/settings/settings.js
@@ -1,5 +1,14 @@
 // See: https://www.elastic.co/guide/en/elasticsearch/reference/7.10/search-analyzer.html
 
+// To update the settings of an existing index:
+// - Close index
+//   curl -XPOST ${elastic_host}/${index_name}/_close
+// - Update index settings:
+//   settings_json=$(node -p 'JSON.stringify(require("./server/db/elasticsearch/settings/settings.js"))')
+//   curl -XPUT ${elastic_host}/${index_name}/_settings -d "$settings_json"
+// - Reopen index
+//   curl -XPOST ${elastic_host}/${index_name}/_open
+
 const maxGram = 10
 
 module.exports = {

--- a/server/db/elasticsearch/settings/settings.js
+++ b/server/db/elasticsearch/settings/settings.js
@@ -21,6 +21,10 @@ module.exports = {
         // See https://www.elastic.co/guide/en/elasticsearch/reference/7.10/analysis-standard-tokenizer.html
         tokenizer: 'standard',
         filter: [
+          // The 'standard' tokenizer does not imply lowercase
+          // https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-tokenizer.html
+          // not to be confused with the 'standard' analyzer, which does
+          // https://www.elastic.co/guide/en/elasticsearch/reference/7.10/analysis-standard-analyzer.html
           'lowercase',
           'autocomplete_filter'
         ]

--- a/server/db/elasticsearch/settings/settings.js
+++ b/server/db/elasticsearch/settings/settings.js
@@ -1,5 +1,7 @@
 // See: https://www.elastic.co/guide/en/elasticsearch/reference/7.10/search-analyzer.html
 
+const maxGram = 10
+
 module.exports = {
   // use number_of_shards in testing environment only
   // See: https://www.elastic.co/guide/en/elasticsearch/guide/current/relevance-is-broken.html
@@ -11,7 +13,13 @@ module.exports = {
       autocomplete_filter: {
         type: 'edge_ngram',
         min_gram: 2,
-        max_gram: 10
+        max_gram: maxGram
+      },
+      // An analyzer to apply at search time to match the autocomplete analyzer used at index time
+      // See: https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-truncate-tokenfilter.html
+      truncate_to_max_gram: {
+        type: 'truncate',
+        length: maxGram
       }
     },
     analyzer: {
@@ -28,7 +36,17 @@ module.exports = {
           'lowercase',
           'autocomplete_filter'
         ]
-      }
+      },
+      standard_truncated: {
+        type: 'custom',
+        // define standard stop words
+        // See https://www.elastic.co/guide/en/elasticsearch/reference/7.10/analysis-standard-tokenizer.html
+        tokenizer: 'standard',
+        filter: [
+          'lowercase',
+          'truncate_to_max_gram'
+        ]
+      },
     }
   }
 }

--- a/tests/api/fixtures/entities.js
+++ b/tests/api/fixtures/entities.js
@@ -7,6 +7,7 @@ const wdLang = require('wikidata-lang')
 const { getByUri, addClaim } = require('../utils/entities')
 const faker = require('faker')
 const someImageHash = 'aaaaaaaaaabbbbbbbbbbccccccccccdddddddddd'
+const { humanName, randomWords } = require('./text')
 
 const createEntity = (P31, options = {}) => (params = {}) => {
   const { canHaveLabels = true, defaultClaims } = options
@@ -22,9 +23,6 @@ const createEntity = (P31, options = {}) => (params = {}) => {
   return customAuthReq(user, 'post', '/api/entities?action=create', { labels, claims })
 }
 
-const humanName = () => faker.fake('{{name.firstName}} {{name.lastName}}')
-const randomWords = length => faker.random.words(length)
-
 const API = module.exports = {
   createEntity,
   createHuman: createEntity('wd:Q5'),
@@ -38,7 +36,8 @@ const API = module.exports = {
       'wdt:P1476': [ randomWords(4) ]
     }
   }),
-  randomLabel: (length = 5) => randomWords(length),
+
+  randomLabel: randomWords,
   humanName,
 
   createEdition: async (params = {}) => {

--- a/tests/api/fixtures/text.js
+++ b/tests/api/fixtures/text.js
@@ -1,7 +1,16 @@
 const faker = require('faker')
 
+const capitalize = word => word[0].toUpperCase() + word.slice(1).toLowerCase()
+
+const randomWords = (numberOfWords = 5) => faker.random.words(numberOfWords)
+
 module.exports = {
   humanName: () => faker.fake('{{name.firstName}} {{name.lastName}}'),
 
-  randomWords: (numberOfWords = 5) => faker.random.words(numberOfWords),
+  randomWords,
+
+  randomLongWord: wordLength => {
+    const longWord = randomWords(wordLength).replace(/ /g, '').slice(0, wordLength + 10)
+    return capitalize(longWord)
+  },
 }

--- a/tests/api/fixtures/text.js
+++ b/tests/api/fixtures/text.js
@@ -1,0 +1,7 @@
+const faker = require('faker')
+
+module.exports = {
+  humanName: () => faker.fake('{{name.firstName}} {{name.lastName}}'),
+
+  randomWords: (numberOfWords = 5) => faker.random.words(numberOfWords),
+}

--- a/tests/api/search/entities.test.js
+++ b/tests/api/search/entities.test.js
@@ -84,18 +84,12 @@ describe('search:entities', () => {
         _.map(results, 'uri').should.containEql(work.uri)
       })
 
-      // FIX: The reason this test fails seems to be that we use
-      // the autocomplete analyzer with a max_gram lower those terms, as you can
-      // see by searching 'Metaphysis Anfangsgrü der Naturwisse' instead.
-      // The test also passes when search_analyzer is let unspecified at indexation
-      // letting the search query use the autocomplete tokenizer
-      xit('should find a label containing long terms', async () => {
+      it('should find a label containing terms longer than the autocomplete max ngram', async () => {
+        // Current max_ngram=10
         const label = 'Metaphysische Anfangsgründe der Naturwissenschaft'
         const work = await createWork({ labels: { de: label } })
-        console.log({ work })
         await waitForIndexation('entities', work._id)
         const results = await search({ types: 'works', search: label, lang: 'de', exact: true })
-        console.log({ results })
         _.map(results, 'uri').should.containEql(work.uri)
       })
     })

--- a/tests/api/search/entities.test.js
+++ b/tests/api/search/entities.test.js
@@ -193,4 +193,13 @@ describe('search:entities', () => {
       _.map(results, 'id').includes('Q3236382').should.be.true()
     })
   })
+
+  describe('multi-types', () => {
+    it('should accept several types', async () => {
+      const types = [ 'works', 'series' ]
+      const results = await search({ types, search: serie.labels.en, limit: 20 })
+      results.forEach(result => types.should.containEql(result.type))
+      _.map(results, 'id').includes(serie._id).should.be.true()
+    })
+  })
 })

--- a/tests/api/search/entities.test.js
+++ b/tests/api/search/entities.test.js
@@ -84,6 +84,14 @@ describe('search:entities', () => {
         _.map(results, 'uri').should.containEql(work.uri)
       })
 
+      it('should ignore the case', async () => {
+        const label = "L'EAU DOUCE EN PÉRIL"
+        const work = await createWork({ labels: { fr: label.toLowerCase() } })
+        await waitForIndexation('entities', work._id)
+        const results = await search({ types: 'works', search: label, lang: 'fr', exact: true })
+        _.map(results, 'uri').should.containEql(work.uri)
+      })
+
       it('should find a label containing terms longer than the autocomplete max ngram', async () => {
         // Current max_ngram=10
         const label = 'Metaphysische Anfangsgründe der Naturwissenschaft'

--- a/tests/api/search/entities.test.js
+++ b/tests/api/search/entities.test.js
@@ -3,11 +3,12 @@ const __ = CONFIG.universalPath
 const _ = __.require('builders', 'utils')
 require('should')
 const { createWork, createHuman, createSerie, createCollection, createPublisher, sameFirstNameLabel } = require('../fixtures/entities')
-const { randomWords } = require('../fixtures/text')
+const { randomLongWord, randomWords } = require('../fixtures/text')
 const { getByUris } = require('../utils/entities')
 const { shouldNotBeCalled } = require('../utils/utils')
 const { search, waitForIndexation } = require('../utils/search')
 const wikidataUris = [ 'wd:Q184226', 'wd:Q180736', 'wd:Q8337', 'wd:Q225946', 'wd:Q3409094', 'wd:Q3236382' ]
+const { max_gram: maxGram } = __.require('db', 'elasticsearch/settings/settings').analysis.filter.autocomplete_filter
 
 describe('search:entities', () => {
   let human, work, serie, collection, publisher
@@ -101,8 +102,8 @@ describe('search:entities', () => {
       })
 
       it('should find a label containing terms longer than the autocomplete max ngram', async () => {
-        // Current max_ngram=10
-        const label = 'Metaphysische Anfangsgründe der Naturwissenschaft'
+        const wordLength = maxGram + 5
+        const label = `${randomLongWord(wordLength)} ${randomLongWord(wordLength)} ${randomLongWord(wordLength)}`
         const work = await createWork({ labels: { de: label } })
         await waitForIndexation('entities', work._id)
         const results = await search({ types: 'works', search: label, lang: 'de', exact: true })

--- a/tests/api/search/entities.test.js
+++ b/tests/api/search/entities.test.js
@@ -3,6 +3,7 @@ const __ = CONFIG.universalPath
 const _ = __.require('builders', 'utils')
 require('should')
 const { createWork, createHuman, createSerie, createCollection, createPublisher, sameFirstNameLabel } = require('../fixtures/entities')
+const { randomWords } = require('../fixtures/text')
 const { getByUris } = require('../utils/entities')
 const { shouldNotBeCalled } = require('../utils/utils')
 const { search, waitForIndexation } = require('../utils/search')
@@ -80,7 +81,9 @@ describe('search:entities', () => {
       })
 
       it('should find a label with special characters', async () => {
-        const label = "L'eau douce en péril !"
+        // Insert random words in the middle to mitigate a too low score due to a high term frequency
+        // when running the tests several times without emptying the database
+        const label = `L'eau ${randomWords(2)} en péril !`
         const work = await createWork({ labels: { fr: label } })
         await waitForIndexation('entities', work._id)
         const results = await search({ types: 'works', search: label, lang: 'fr', exact: true })
@@ -88,7 +91,9 @@ describe('search:entities', () => {
       })
 
       it('should ignore the case', async () => {
-        const label = "L'EAU DOUCE EN PÉRIL"
+        // Insert random words in the middle to mitigate a too low score due to a high term frequency
+        // when running the tests several times without emptying the database
+        const label = `L'EAU DOUCE ${randomWords(2).toUpperCase()} EN PÉRIL`
         const work = await createWork({ labels: { fr: label.toLowerCase() } })
         await waitForIndexation('entities', work._id)
         const results = await search({ types: 'works', search: label, lang: 'fr', exact: true })

--- a/tests/api/search/entities.test.js
+++ b/tests/api/search/entities.test.js
@@ -72,8 +72,11 @@ describe('search:entities', () => {
       })
 
       it('should not match on descriptions', async () => {
-        const results = await search({ types: 'humans', search: 'philosopher', lang: 'en', exact: true })
-        results.length.should.equal(0)
+        const description = 'french philosopher'
+        const results = await search({ types: 'humans', search: description, lang: 'en' })
+        results.length.should.be.aboveOrEqual(0)
+        const exactResults = await search({ types: 'humans', search: description, lang: 'en', exact: true })
+        exactResults.length.should.equal(0)
       })
 
       it('should find a label with special characters', async () => {

--- a/tests/api/utils/search.js
+++ b/tests/api/utils/search.js
@@ -47,13 +47,14 @@ const waitForIndexation = async (indexBaseName, id) => {
 
 module.exports = {
   search: async (...args) => {
-    let types, search, lang, filter, exact = false
-    if (args.length === 1) ({ types, search, lang, filter, exact } = args[0])
+    let types, search, lang, filter, limit, exact = false
+    if (args.length === 1) ({ types, search, lang, filter, limit, exact } = args[0])
     else [ types, search, lang, filter ] = args
     lang = lang || 'en'
+    limit = limit || 10
     if (_.isArray(types)) types = types.join('|')
     search = encodeURIComponent(search)
-    let url = `${endpoint}?types=${types}&lang=${lang}&search=${search}&exact=${exact}`
+    let url = `${endpoint}?types=${types}&lang=${lang}&search=${search}&limit=${limit}&exact=${exact}`
     if (filter) url += `&filter=${filter}`
     const { results } = await publicReq('get', url)
     return results


### PR DESCRIPTION
fix #485 last issue, or at least makes the last failing test pass (without adding any new field or requiring a reindexation \o/)

We could still imagine cases where the exact match would have false positives, when terms are longer than 10 characters. For instance searching "Naturwissenschaft" would consider the following as exact matches:
- "Naturwissenschaftler"
- "Naturwissenschaftlerin"
- "naturwissenschaftlich"
- or just any term that matches `/naturwisse\w*/i`

But that looks like an acceptable compromise, as most `exact` requests involve several words (ex: "Metaphysische Anfangsgründe der Naturwissenschaft") that all have to be found in the field

TODO after merge:
- [update prod Elasticsearch indexes with the new settings](https://github.com/inventaire/inventaire/blob/4ebe2ae/server/db/elasticsearch/settings/settings.js#L3-L10)