### PR TITLE
fix popularity boost in entities search

### DIFF
--- a/server/controllers/search/lib/entities_query_builder.js
+++ b/server/controllers/search/lib/entities_query_builder.js
@@ -29,14 +29,12 @@ module.exports = params => {
             // See: https://www.elastic.co/guide/en/elasticsearch/reference/7.10/query-dsl-function-score-query.html#function-field-value-factor
             field_value_factor: {
               field: 'popularity',
-              modifier: 'sqrt',
-              missing: 0
+              // Inspired by https://www.elastic.co/guide/en/elasticsearch/guide/current/boosting-by-popularity.html
+              modifier: 'ln2p',
+              missing: 1
             },
           }
         ],
-        // add the function result to the _score (instead of multiplying by default)
-        // which is drastically decreasing popularity boosting compared to default
-        boost_mode: 'sum'
       },
     },
     size,


### PR DESCRIPTION
Due to the `boost_mode=sum`, entities that have a high popularity some how pop up in results despite there lexical match being very low. Example: when searching "Jean Baudrillard", wd:Q182847 should arrive first, and certainly not arrive after the (glorious but irrelevant) René Goscinny (wd:Q192214) ahead of him

This PR proposes to come back to `modifier=ln2p` and the default `boost_mode=multiply`

