### PR TITLE
Add webfingers

### DIFF
--- a/server/controllers/activitypub/webfinger.js
+++ b/server/controllers/activitypub/webfinger.js
@@ -1,0 +1,50 @@
+const CONFIG = require('config')
+const __ = require('config').universalPath
+const error_ = __.require('lib', 'error/error')
+const assert_ = __.require('utils', 'assert_types')
+const user_ = __.require('controllers', 'user/lib/user')
+const couch_ = __.require('lib', 'couch')
+
+module.exports = {
+  get: (req, res) => {
+    const params = customSanitize(req, res)
+    const { resource } = params
+    findUser(resource)
+    .then(user => {
+      if (!user) throw error_.new('unknown actor', 400, resource)
+    })
+    .catch(error_.Handler(req, res))
+  }
+}
+
+const customSanitize = (req, res) => {
+  if (req.query.resource === null) {
+    throw error_.new('missing parameter in query: resource', 400)
+  }
+  const { resource } = req.query
+  if (!isValid(resource)) {
+    throw error_.new('invalid resource', 400, resource)
+  }
+  return req.query
+}
+
+const isValid = resource => {
+  assert_.string(resource)
+  if (resource.startsWith('acct:') === false) return false
+  const actorParts = getActorParts(resource)
+  if (actorParts.length !== 2) return false
+
+  const host = actorParts[1]
+  return host === CONFIG.publicHost
+}
+
+const getActorParts = resource => {
+  const actorWithHost = resource.substr(5)
+  return actorWithHost.split('@')
+}
+
+const findUser = async resource => {
+  const username = getActorParts(resource)[0]
+  return user_.byUsername(username)
+  .then(couch_.firstDoc)
+}

--- a/server/controllers/activitypub/webfinger.js
+++ b/server/controllers/activitypub/webfinger.js
@@ -12,6 +12,8 @@ module.exports = {
     findUser(resource)
     .then(user => {
       if (!user) throw error_.new('unknown actor', 400, resource)
+      const { username } = user
+      res.json(formatWebfinger(username, resource))
     })
     .catch(error_.Handler(req, res))
   }
@@ -47,4 +49,21 @@ const findUser = async resource => {
   const username = getActorParts(resource)[0]
   return user_.byUsername(username)
   .then(couch_.firstDoc)
+}
+
+const formatWebfinger = (username, resource) => {
+  const publicHost = `${CONFIG.publicProtocol}://${CONFIG.publicHost}`
+  const inventoryUrl = `${publicHost}/users/${username}`
+
+  return {
+    subject: resource,
+    aliases: [ inventoryUrl ],
+    links: [
+      {
+        rel: 'self',
+        type: 'application/activity+json',
+        href: inventoryUrl
+      }
+    ]
+  }
 }

--- a/server/controllers/routes.js
+++ b/server/controllers/routes.js
@@ -30,7 +30,8 @@ const routes = module.exports = {
   'api/transactions': endpoint('./transactions/transactions'),
   'api/user': endpoint('./user/user'),
   'api/users': endpoint('./users/users'),
-  'img/*': endpoint('./images/resize')
+  'img/*': endpoint('./images/resize'),
+  '.well-known/webfinger': endpoint('./activitypub/webfinger')
 }
 
 if (CONFIG.logMissingI18nKeys) {

--- a/tests/api/activitypub/webfinger.js
+++ b/tests/api/activitypub/webfinger.js
@@ -1,0 +1,45 @@
+const CONFIG = require('config')
+const __ = CONFIG.universalPath
+require('should')
+const { publicReq } = require('../utils/utils')
+const { shouldNotBeCalled, rethrowShouldNotBeCalledErrors } = __.require('apiTests', 'utils/utils')
+const { createUsername } = require('../fixtures/users')
+
+const endpoint = '/.well-known/webfinger?resource='
+
+describe('activitypub:webfinger', () => {
+  it('should reject invalid host', async () => {
+    try {
+      const invalidResource = 'bar.org'
+      invalidResource.should.not.equal(CONFIG.host)
+      const actor = `acct:foo@${invalidResource}`
+      await publicReq('get', `${endpoint}${actor}`).then(shouldNotBeCalled)
+    } catch (err) {
+      rethrowShouldNotBeCalledErrors(err)
+      err.statusCode.should.equal(400)
+      err.body.status_verbose.should.startWith('invalid resource')
+    }
+  })
+
+  it('should reject invalid actor', async () => {
+    try {
+      const invalidActorResource = 'acct:foobar.org'
+      await publicReq('get', `${endpoint}${invalidActorResource}`).then(shouldNotBeCalled)
+    } catch (err) {
+      rethrowShouldNotBeCalledErrors(err)
+      err.statusCode.should.equal(400)
+      err.body.status_verbose.should.startWith('invalid resource')
+    }
+  })
+
+  it('should reject unknown actor', async () => {
+    try {
+      const unknownLocalActorResource = `acct:${createUsername()}@${CONFIG.publicHost}`
+      await publicReq('get', `${endpoint}${unknownLocalActorResource}`).then(shouldNotBeCalled)
+    } catch (err) {
+      rethrowShouldNotBeCalledErrors(err)
+      err.statusCode.should.equal(400)
+      err.body.status_verbose.should.equal('unknown actor')
+    }
+  })
+})


### PR DESCRIPTION
Translate `adamsberg@inventaire.io` mentions to user profile url `https://inventaire.io/user/adamsberg`.
Thanks to a `.well-known/webfinger?resource=acct:adamsberg@inventaire.io` request.
related to #187 