### PR TITLE
entities indexation: fix flattened terms query

### DIFF
--- a/server/controllers/search/lib/entities_query_builder.js
+++ b/server/controllers/search/lib/entities_query_builder.js
@@ -64,6 +64,17 @@ const matchEntities = (search, userLang, exact) => {
         analyzer: 'standard_truncated',
       }
     })
+    // Flattened terms have been indexes with the 'standard' analyzer
+    // and would thus give poor results if queried with the 'standard_truncated' analyzer
+    // thus this additionnal query. Once they are reindexed with the autocomplete analyzer
+    // those fields could be queries as the other fields, and the query below could then be removed
+    queries.push({
+      multi_match: {
+        query: search,
+        fields: entitiesFlattenedFields,
+        analyzer: 'standard',
+      }
+    })
   }
 
   return queries
@@ -82,12 +93,15 @@ const entitiesFields = (userLang, exact) => {
   }
   if (!exact) {
     fields.push(
-      'flattenedLabels^0.25',
-      'flattenedAliases^0.25',
-      'descriptions.*^0.25',
-      'flattenedDescriptions^0.25'
+      'descriptions.*^0.25'
     )
   }
 
   return fields
 }
+
+const entitiesFlattenedFields = [
+  'flattenedLabels^0.25',
+  'flattenedAliases^0.25',
+  'flattenedDescriptions^0.1'
+]

--- a/server/controllers/search/lib/entities_query_builder.js
+++ b/server/controllers/search/lib/entities_query_builder.js
@@ -60,8 +60,10 @@ const matchEntities = (search, userLang, exact) => {
     queries.push({
       multi_match: {
         query: search,
+        operator: 'or',
         fields,
         analyzer: 'standard_truncated',
+        type: 'cross_fields',
       }
     })
     // Flattened terms have been indexes with the 'standard' analyzer
@@ -71,8 +73,10 @@ const matchEntities = (search, userLang, exact) => {
     queries.push({
       multi_match: {
         query: search,
+        operator: 'or',
         fields: entitiesFlattenedFields,
         analyzer: 'standard',
+        type: 'cross_fields',
       }
     })
   }

--- a/tests/api/search/entities.test.js
+++ b/tests/api/search/entities.test.js
@@ -6,7 +6,7 @@ const { createWork, createHuman, createSerie, createCollection, createPublisher,
 const { randomLongWord, randomWords } = require('../fixtures/text')
 const { getByUris } = require('../utils/entities')
 const { shouldNotBeCalled } = require('../utils/utils')
-const { search, waitForIndexation } = require('../utils/search')
+const { search, waitForIndexation, getIndexedDoc } = require('../utils/search')
 const wikidataUris = [ 'wd:Q184226', 'wd:Q180736', 'wd:Q8337', 'wd:Q225946', 'wd:Q3409094', 'wd:Q3236382' ]
 const { max_gram: maxGram } = __.require('db', 'elasticsearch/settings/settings').analysis.filter.autocomplete_filter
 
@@ -113,7 +113,9 @@ describe('search:entities', () => {
 
     describe('not exact', () => {
       it('should match flattened terms', async () => {
-        const results = await search({ types: 'series', search: 'ဟယ်ရီပေါ်တာ' })
+        const doc = await getIndexedDoc('wikidata', 'Q8337')
+        const firstTwoFlattenedLabelsWords = doc._source.flattenedLabels.split(' ').slice(0, 2).join(' ')
+        const results = await search({ types: 'series', search: firstTwoFlattenedLabelsWords })
         _.map(results, 'uri').should.containEql('wd:Q8337')
       })
     })

--- a/tests/api/search/entities.test.js
+++ b/tests/api/search/entities.test.js
@@ -21,8 +21,8 @@ describe('search:entities', () => {
       createSerie(),
       createPublisher(),
       createCollection(),
-      // Ensure wikidata uris are indexed
-      getByUris(wikidataUris, null, false),
+      // Ensure wikidata uris are indexed in the current format
+      getByUris(wikidataUris, null, true),
     ])
 
     await Promise.all([
@@ -108,6 +108,13 @@ describe('search:entities', () => {
         await waitForIndexation('entities', work._id)
         const results = await search({ types: 'works', search: label, lang: 'de', exact: true })
         _.map(results, 'uri').should.containEql(work.uri)
+      })
+    })
+
+    describe('not exact', () => {
+      it('should match flattened terms', async () => {
+        const results = await search({ types: 'series', search: 'ဟယ်ရီပေါ်တာ' })
+        _.map(results, 'uri').should.containEql('wd:Q8337')
       })
     })
   })

--- a/tests/api/utils/search.js
+++ b/tests/api/utils/search.js
@@ -47,11 +47,12 @@ const waitForIndexation = async (indexBaseName, id) => {
 
 module.exports = {
   search: async (...args) => {
-    let types, search, lang, filter, limit, exact = false
+    let types, search, lang, filter, limit, exact
     if (args.length === 1) ({ types, search, lang, filter, limit, exact } = args[0])
     else [ types, search, lang, filter ] = args
     lang = lang || 'en'
     limit = limit || 10
+    exact = exact || false
     if (_.isArray(types)) types = types.join('|')
     search = encodeURIComponent(search)
     let url = `${endpoint}?types=${types}&lang=${lang}&search=${search}&limit=${limit}&exact=${exact}`

--- a/tests/unit/indexation/entity_formatter.js
+++ b/tests/unit/indexation/entity_formatter.js
@@ -1,0 +1,36 @@
+const CONFIG = require('config')
+const __ = CONFIG.universalPath
+const _ = __.require('builders', 'utils')
+const Q535 = require('./fixtures/Q535.customized.json')
+require('should')
+const entityFormatter = __.require('db', 'elasticsearch/formatters/entity')
+
+describe('indexation: entity formatter', () => {
+  describe('flatten fields', () => {
+    it('should include words from inactive languages', async () => {
+      const doc = await entityFormatter(_.cloneDeep(Q535), { quick: true })
+      doc.flattenedLabels.includes('rdtfgexupo').should.be.true()
+      doc.flattenedAliases.includes('bbcpsptnhh').should.be.true()
+      doc.flattenedAliases.includes('ebnkwspgrw').should.be.true()
+      doc.flattenedAliases.includes('depfrznqhb').should.be.true()
+      doc.flattenedDescriptions.includes('tstnhvhwvv').should.be.true()
+    })
+
+    it('should not duplicate main fields words', async () => {
+      const doc = await entityFormatter(_.cloneDeep(Q535), { quick: true })
+      const flattenedLabelsWords = doc.flattenedLabels.split(' ')
+      const flattenedAliasesWords = doc.flattenedAliases.split(' ')
+      const flattenedDescriptionsWords = doc.flattenedDescriptions.split(' ')
+      const mainFieldsTerms = Object.values(doc.labels)
+        .concat(Object.values(doc.descriptions))
+        .concat(_.flatten(Object.values(doc.aliases)))
+      mainFieldsTerms.forEach(term => {
+        term.split(' ').forEach(termWord => {
+          flattenedLabelsWords.should.not.containEql(termWord)
+          flattenedAliasesWords.should.not.containEql(termWord)
+          flattenedDescriptionsWords.should.not.containEql(termWord)
+        })
+      })
+    })
+  })
+})

--- a/tests/unit/indexation/fixtures/Q535.customized.json
+++ b/tests/unit/indexation/fixtures/Q535.customized.json
@@ -1,0 +1,217 @@
+{
+  "pageid": 794,
+  "ns": 0,
+  "title": "Q535",
+  "lastrevid": 1361680964,
+  "modified": "2021-02-15T10:38:27Z",
+  "type": "item",
+  "id": "Q535",
+  "labels": {
+    "en": {
+      "language": "en",
+      "value": "Victor Hugo"
+    },
+    "ru": {
+      "language": "ru",
+      "value": "Виктор Гюго"
+    },
+    "fr": {
+      "language": "fr",
+      "value": "Victor Hugo"
+    },
+    "it": {
+      "language": "it",
+      "value": "Victor Hugo"
+    },
+    "ca": {
+      "language": "ca",
+      "value": "Victor Hugo"
+    },
+    "nb": {
+      "language": "nb",
+      "value": "Victor Hugo"
+    },
+    "ilo": {
+      "language": "ilo",
+      "value": "Victor Hugo"
+    },
+    "de": {
+      "language": "de",
+      "value": "Victor Hugo"
+    },
+    "es": {
+      "language": "es",
+      "value": "Victor Hugo"
+    },
+    "an": {
+      "language": "an",
+      "value": "Victor Hugo"
+    },
+    "fake": {
+      "language": "fake",
+      "value": "Victor rdtfgexupo Hugo"
+    }
+  },
+  "descriptions": {
+    "en": {
+      "language": "en",
+      "value": "French poet, novelist, and dramatist (1802-1885)"
+    },
+    "fr": {
+      "language": "fr",
+      "value": "écrivain, poète et homme politique français"
+    },
+    "it": {
+      "language": "it",
+      "value": "scrittore francese"
+    },
+    "ca": {
+      "language": "ca",
+      "value": "Escriptor francès"
+    },
+    "nb": {
+      "language": "nb",
+      "value": "fransk forfatter"
+    },
+    "ilo": {
+      "language": "ilo",
+      "value": "Pranses a mannaniw, nobelista, ken dramatista"
+    },
+    "de": {
+      "language": "de",
+      "value": "französischer Poet und Autor (1802-1885)"
+    },
+    "fake": {
+      "language": "fake",
+      "value": "tstnhvhwvv"
+    }
+  },
+  "aliases": {
+    "es": [
+      {
+        "language": "es",
+        "value": "Víctor Marie Hugo"
+      },
+      {
+        "language": "es",
+        "value": "Victor Marie Hugo"
+      },
+      {
+        "language": "es",
+        "value": "Victor-Marie Hugo"
+      }
+    ],
+    "en": [
+      {
+        "language": "en",
+        "value": "Victor Marie Hugo"
+      },
+      {
+        "language": "en",
+        "value": "Victor-Marie Hugo"
+      },
+      {
+        "language": "en",
+        "value": "Victor Marie, Comte Hugo"
+      }
+    ],
+    "fr": [
+      {
+        "language": "fr",
+        "value": "L'Homme océan"
+      },
+      {
+        "language": "fr",
+        "value": "Victor Marie Hugo"
+      },
+      {
+        "language": "fr",
+        "value": "Victor, Marie Hugo"
+      }
+    ],
+    "zh": [
+      {
+        "language": "zh",
+        "value": "雨果"
+      },
+      {
+        "language": "zh",
+        "value": "維克多•雨果"
+      }
+    ],
+    "he": [
+      {
+        "language": "he",
+        "value": "הוגא, וויקטאר"
+      }
+    ],
+    "ru": [
+      {
+        "language": "ru",
+        "value": "Гюго, Виктор"
+      },
+      {
+        "language": "ru",
+        "value": "Гюго, Виктор Мари"
+      },
+      {
+        "language": "ru",
+        "value": "Виктор Мари Гюго"
+      }
+    ],
+    "fake": [
+      {
+        "language": "fake",
+        "value": "Victor bbcpsptnhh"
+      },
+      {
+        "language": "fake",
+        "value": "ebnkwspgrw Hugo"
+      },
+      {
+        "language": "fake",
+        "value": "Victor depfrznqhb Hugo"
+      }
+    ]
+  },
+  "claims": {
+    "P31": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P31",
+          "hash": "ad7d38a03cdd40cdc373de0dc4e7b7fcbccb31d9",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 5,
+              "id": "Q5"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q535$98CA28BF-453B-4594-BE44-3C684183F734",
+        "rank": "normal"
+      }
+    ]
+  },
+  "sitelinks": {
+    "afwiki": {
+      "site": "afwiki",
+      "title": "Victor Hugo",
+      "badges": []
+    },
+    "afwikiquote": {
+      "site": "afwikiquote",
+      "title": "Victor Hugo",
+      "badges": []
+    },
+    "alswiki": {
+      "site": "alswiki",
+      "title": "Victor Hugo",
+      "badges": []
+    }
+  }
+}


### PR DESCRIPTION
Flattened terms currently don't help much for matching due to the different analyzer used during indexation (which you can see with the test added in d71208f3), this PR fixes that by adding a dedicated query with the query-time analyzer matching the index-time analyzer. I also created [a branch to track changes we would like to do before the next full reindexation of entities](https://github.com/inventaire/inventaire/tree/entities-reindexation), which would align the analyzers, allowing to remove that new query.

This PR also proposes to remove terms already in the main fields from the flattened terms, as those are just dead weight 
76f3896 