### PR TITLE
make entities history publicly accessible, while keeping contributors data private by default

### DIFF
--- a/server/controllers/entities/entities.js
+++ b/server/controllers/entities/entities.js
@@ -10,15 +10,15 @@ module.exports = {
       'serie-parts': serieParts,
       'publisher-publications': publisherPublications,
       images: require('./images'),
-      popularity: require('./popularity')
+      popularity: require('./popularity'),
+      history: require('./history')
     },
     dataadmin: {
       duplicates: require('./duplicates')
     },
     admin: {
       activity: require('./activity'),
-      contributions: require('./contributions'),
-      history: require('./history')
+      contributions: require('./contributions')
     }
   }),
 

--- a/server/controllers/entities/history.js
+++ b/server/controllers/entities/history.js
@@ -1,7 +1,11 @@
 // An endpoint to get entities history as snapshots and diffs
+const _ = require('builders/utils')
+const error_ = require('lib/error/error')
+const responses_ = require('lib/responses')
 const patches_ = require('./lib/patches')
 const { hasAdminAccess } = require('lib/user_access_levels')
 const { _id: anonymizedId } = require('db/couchdb/hard_coded_documents').users.anonymized
+const user_ = require('controllers/user/lib/user')
 
 const sanitization = {
   id: {}
@@ -10,10 +14,30 @@ const sanitization = {
 const controller = async (params, req) => {
   const { id } = params
   const patches = await patches_.getWithSnapshots(id)
-  if (!hasAdminAccess(req.user)) patches.forEach(anonymizePatch)
+  if (!hasAdminAccess(req.user)) await anonymizePatches(patches)
   return { patches }
 }
 
-module.exports = { sanitization, controller }
+const anonymizePatches = async patches => {
+  const usersIds = _.uniq(_.map(patches, 'user'))
+  const users = await user_.byIds(usersIds)
+  const anonymizedUserIdsByUserIds = buildAnonymizedUserIdsMap(users)
+  patches.forEach(patch => {
+    patch.user = anonymizedUserIdsByUserIds[patch.user]
+  })
+}
 
-const anonymizePatch = patch => { patch.user = anonymizedId }
+const buildAnonymizedUserIdsMap = users => {
+  const anonymizedUserIdsByUserIds = {}
+  for (const user of users) {
+    const userSetting = _.get(user, 'settings.contributions.anonymize')
+    if (userSetting === false) {
+      anonymizedUserIdsByUserIds[user._id] = user._id
+    } else {
+      anonymizedUserIdsByUserIds[user._id] = anonymizedId
+    }
+  }
+  return anonymizedUserIdsByUserIds
+}
+
+module.exports = { sanitization, controller }

--- a/server/controllers/entities/history.js
+++ b/server/controllers/entities/history.js
@@ -1,13 +1,19 @@
 // An endpoint to get entities history as snapshots and diffs
 const patches_ = require('./lib/patches')
+const { hasAdminAccess } = require('lib/user_access_levels')
+const { _id: anonymizedId } = require('db/couchdb/hard_coded_documents').users.anonymized
 
 const sanitization = {
   id: {}
 }
 
-const controller = async ({ id }) => {
+const controller = async (params, req) => {
+  const { id } = params
   const patches = await patches_.getWithSnapshots(id)
+  if (!hasAdminAccess(req.user)) patches.forEach(anonymizePatch)
   return { patches }
 }
 
 module.exports = { sanitization, controller }
+
+const anonymizePatch = patch => { patch.user = anonymizedId }

--- a/server/controllers/user/lib/authorized_user_data_pickers.js
+++ b/server/controllers/user/lib/authorized_user_data_pickers.js
@@ -1,6 +1,6 @@
 const _ = require('builders/utils')
 const User = require('models/user')
-const { getUserAccessLevels } = require('lib/get_user_access_levels')
+const { getUserAccessLevels } = require('lib/user_access_levels')
 
 const ownerSafeData = user => {
   const safeUserDoc = _.pick(user, User.attributes.ownerSafe)

--- a/server/controllers/user/update.js
+++ b/server/controllers/user/update.js
@@ -22,16 +22,18 @@ const controller = async (params, req) => {
   return { ok: true }
 }
 
+// This function update the document and should thus
+// rather be in the User model, but async checks make it a bit hard
 const update = async (user, attribute, value) => {
   if (value == null && !acceptNullValue.includes(attribute)) {
     throw error_.newMissingBody('value')
   }
 
-  // doesnt change anything for normal attribute
+  // Doesn't change anything for normal attribute
   // returns the root object for deep attributes such as settings
   const rootAttribute = attribute.split('.')[0]
 
-  // support deep objects
+  // Support deep objects
   const currentValue = _.get(user, attribute)
 
   if (value === currentValue) {
@@ -59,13 +61,12 @@ const update = async (user, attribute, value) => {
   }
 
   if (concurrencial.includes(attribute)) {
-    // checks for validity and availability (+ reserve words for username)
+    // Checks for validity and availability (+ reserve words for username)
     await availability_[attribute](value, currentValue)
-    await updateAttribute(user, attribute, value)
-    return
+    return updateAttribute(user, attribute, value)
   }
 
-  throw error_.new(`forbidden update: ${attribute} - ${value}`, 403)
+  throw error_.new('forbidden update', 403, { attribute, value })
 }
 
 const updateAttribute = (user, attribute, value) => {

--- a/server/db/couchdb/hard_coded_documents.js
+++ b/server/db/couchdb/hard_coded_documents.js
@@ -15,6 +15,7 @@ module.exports = {
     hook: userDoc('hook', '001'),
     reconciler: userDoc('reconciler', '002'),
     // used by scripts/update_entities.js
-    updater: userDoc('updater', '003')
+    updater: userDoc('updater', '003'),
+    anonymized: userDoc('anonymized', '004')
   }
 }

--- a/server/db/couchdb/hard_coded_documents.js
+++ b/server/db/couchdb/hard_coded_documents.js
@@ -3,7 +3,12 @@ const userDoc = (username, idLastCharacters) => ({
   username,
   special: true,
   // Data required to avoid crashing users logic
-  snapshot: {}
+  snapshot: {},
+  settings: {
+    contributions: {
+      anonymize: false
+    }
+  },
 })
 
 module.exports = {

--- a/server/db/couchdb/hard_coded_documents.js
+++ b/server/db/couchdb/hard_coded_documents.js
@@ -21,6 +21,5 @@ module.exports = {
     reconciler: userDoc('reconciler', '002'),
     // used by scripts/update_entities.js
     updater: userDoc('updater', '003'),
-    anonymized: userDoc('anonymized', '004')
   }
 }

--- a/server/lib/actions_controllers.js
+++ b/server/lib/actions_controllers.js
@@ -1,7 +1,7 @@
 const { someMatch } = require('builders/utils')
 const error_ = require('lib/error/error')
 const validateObject = require('lib/validate_object')
-const { rolesByAccess } = require('./get_user_access_levels')
+const { rolesByAccess } = require('./user_access_levels')
 const { send } = require('./responses')
 const { sanitize } = require('./sanitize/sanitize')
 const { track } = require('./track')

--- a/server/lib/user_access_levels.js
+++ b/server/lib/user_access_levels.js
@@ -1,9 +1,5 @@
 const _ = require('lodash')
 
-const getUserAccessLevels = ({ roles: userRoles = [] }) => {
-  return _.uniq(_.flatten(userRoles.map(role => accessByRoles[role])))
-}
-
 const rolesByAccess = {
   public: [ 'public', 'authentified', 'dataadmin', 'admin' ],
   authentified: [ 'authentified', 'dataadmin', 'admin' ],
@@ -21,4 +17,14 @@ for (const access in rolesByAccess) {
   }
 }
 
-module.exports = { rolesByAccess, getUserAccessLevels }
+const getUserAccessLevels = user => {
+  if (!user) return []
+  const { roles: userRoles } = user
+  if (!userRoles || userRoles.length === 0) return []
+  if (userRoles.length === 1) return accessByRoles[userRoles[0]]
+  return _.uniq(_.flatten(userRoles.map(role => accessByRoles[role])))
+}
+
+const hasAdminAccess = user => getUserAccessLevels(user).includes('admin')
+
+module.exports = { rolesByAccess, getUserAccessLevels, hasAdminAccess }

--- a/server/models/attributes/user.js
+++ b/server/models/attributes/user.js
@@ -80,24 +80,29 @@ attributes.acceptNullValue = [
 
 attributes.creationStrategies = [ 'local' ]
 
-attributes.notificationsSettings = [
-  // GLOBAL
-  'global',
+attributes.settings = {
+  notifications: [
+    // GLOBAL
+    'global',
 
-  // NEWS
-  // 'newsletters'
-  'inventories_activity_summary',
+    // NEWS
+    // 'newsletters'
+    'inventories_activity_summary',
 
-  // NETWORK
-  'friend_accepted_request',
-  'friendship_request',
-  'group_invite',
-  'group_acceptRequest',
+    // NETWORK
+    'friend_accepted_request',
+    'friendship_request',
+    'group_invite',
+    'group_acceptRequest',
 
-  // TRANSACTIONS
-  'your_item_was_requested',
-  'update_on_your_item',
-  'update_on_item_you_requested'
-]
+    // TRANSACTIONS
+    'your_item_was_requested',
+    'update_on_your_item',
+    'update_on_item_you_requested'
+  ],
+  contributions: [
+    'anonymize'
+  ]
+}
 
 attributes.roles = [ 'admin', 'dataadmin' ]

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -32,7 +32,7 @@ User._create = (username, email, creationStrategy, language, password) => {
     created: Date.now(),
     creationStrategy,
     language,
-    settings: { notifications: {} },
+    settings: {},
     // A token that, when combined with the right user id,
     // gives access to all the resources the user can read
     // Use case:

--- a/server/models/validations/user.js
+++ b/server/models/validations/user.js
@@ -1,7 +1,7 @@
 const _ = require('builders/utils')
 
 const { pass, userId, username, email, userImg, boolean, position, BoundedString } = require('./common')
-const { creationStrategies, notificationsSettings } = require('../attributes/user')
+const { creationStrategies, settings } = require('../attributes/user')
 
 const validations = module.exports = {
   pass,
@@ -20,13 +20,14 @@ const validations = module.exports = {
 }
 
 const deepAttributes = {
-  settings: {
-    notifications: {}
-  }
+  settings: {}
 }
 
-for (const setting of notificationsSettings) {
-  deepAttributes.settings.notifications[setting] = true
+for (const settingCategory in settings) {
+  deepAttributes.settings[settingCategory] = {}
+  for (const settingName of settings[settingCategory]) {
+    deepAttributes.settings[settingCategory][settingName] = true
+  }
 }
 
 validations.deepAttributesExistance = attribute => _.get(deepAttributes, attribute) != null

--- a/tests/api/entities/history.test.js
+++ b/tests/api/entities/history.test.js
@@ -1,9 +1,8 @@
-require('should')
+const should = require('should')
 const { adminReq, dataadminReq, publicReq, authReq, shouldNotBeCalled } = require('../utils/utils')
 const { createHuman } = require('../fixtures/entities')
 const { getDeanonymizedUser, customAuthReq } = require('../utils/utils')
 const endpoint = '/api/entities?action=history'
-const { _id: anonymizedId } = require('db/couchdb/hard_coded_documents').users.anonymized
 
 describe('entities:history', () => {
   it('should reject without uri', async () => {
@@ -33,31 +32,27 @@ describe('entities:history', () => {
     const { patches } = await adminReq('get', `${endpoint}&id=${human._id}`)
     const patch = patches[0]
     patch.user.should.be.a.String()
-    patch.user.should.not.equal(anonymizedId)
   })
 
   it('should anonymize patches for dataadmins', async () => {
     const human = await createHuman()
     const { patches } = await dataadminReq('get', `${endpoint}&id=${human._id}`)
     const patch = patches[0]
-    patch.user.should.be.a.String()
-    patch.user.should.equal(anonymizedId)
+    should(patch.user).not.be.ok()
   })
 
   it('should anonymize patches for authentified users', async () => {
     const human = await createHuman()
     const { patches } = await authReq('get', `${endpoint}&id=${human._id}`)
     const patch = patches[0]
-    patch.user.should.be.a.String()
-    patch.user.should.equal(anonymizedId)
+    should(patch.user).not.be.ok()
   })
 
   it('should anonymize patches for public users', async () => {
     const human = await createHuman()
     const { patches } = await publicReq('get', `${endpoint}&id=${human._id}`)
     const patch = patches[0]
-    patch.user.should.be.a.String()
-    patch.user.should.equal(anonymizedId)
+    should(patch.user).not.be.ok()
   })
 
   it('should not anonymize patches from users that disabled anonymization', async () => {
@@ -71,7 +66,7 @@ describe('entities:history', () => {
       value: 'foo'
     })
     const { patches } = await publicReq('get', `${endpoint}&id=${human._id}`)
-    patches[0].user.should.equal(anonymizedId)
+    should(patches[0].user).not.be.ok()
     patches[1].user.should.equal(user._id)
   })
 })

--- a/tests/api/entities/history.test.js
+++ b/tests/api/entities/history.test.js
@@ -1,11 +1,12 @@
 require('should')
-const { adminReq, shouldNotBeCalled } = require('../utils/utils')
+const { adminReq, dataadminReq, publicReq, authReq, shouldNotBeCalled } = require('../utils/utils')
 const { createHuman } = require('../fixtures/entities')
 const endpoint = '/api/entities?action=history'
+const { _id: anonymizedId } = require('db/couchdb/hard_coded_documents').users.anonymized
 
 describe('entities:history', () => {
   it('should reject without uri', async () => {
-    await adminReq('get', endpoint)
+    await publicReq('get', endpoint)
     .then(shouldNotBeCalled)
     .catch(err => {
       err.body.status_verbose.should.equal('missing parameter in query: id')
@@ -13,7 +14,7 @@ describe('entities:history', () => {
   })
 
   it('should throw when passed an invalid id', async () => {
-    await adminReq('get', `${endpoint}&id=foo`)
+    await publicReq('get', `${endpoint}&id=foo`)
     .then(shouldNotBeCalled)
     .catch(err => {
       err.body.error_name.should.equal('invalid_id')
@@ -22,7 +23,39 @@ describe('entities:history', () => {
 
   it('should return entity patches', async () => {
     const human = await createHuman()
-    const { patches } = await adminReq('get', `${endpoint}&id=${human._id}`)
+    const { patches } = await publicReq('get', `${endpoint}&id=${human._id}`)
     patches[0].snapshot.labels.should.deepEqual(human.labels)
+  })
+
+  it('should not anonymize patches for admins', async () => {
+    const human = await createHuman()
+    const { patches } = await adminReq('get', `${endpoint}&id=${human._id}`)
+    const patch = patches[0]
+    patch.user.should.be.a.String()
+    patch.user.should.not.equal(anonymizedId)
+  })
+
+  it('should anonymize patches for dataadmins', async () => {
+    const human = await createHuman()
+    const { patches } = await dataadminReq('get', `${endpoint}&id=${human._id}`)
+    const patch = patches[0]
+    patch.user.should.be.a.String()
+    patch.user.should.equal(anonymizedId)
+  })
+
+  it('should anonymize patches for authentified users', async () => {
+    const human = await createHuman()
+    const { patches } = await authReq('get', `${endpoint}&id=${human._id}`)
+    const patch = patches[0]
+    patch.user.should.be.a.String()
+    patch.user.should.equal(anonymizedId)
+  })
+
+  it('should anonymize patches for public users', async () => {
+    const human = await createHuman()
+    const { patches } = await publicReq('get', `${endpoint}&id=${human._id}`)
+    const patch = patches[0]
+    patch.user.should.be.a.String()
+    patch.user.should.equal(anonymizedId)
   })
 })

--- a/tests/api/fixtures/users.js
+++ b/tests/api/fixtures/users.js
@@ -11,9 +11,10 @@ const { makeFriends } = require('../utils/relations')
 const randomString = require('lib/utils/random_string')
 let twoFriendsPromise
 
-let getUser, getReservedUser
+let getUser, getReservedUser, updateUser
 const requireCircularDependencies = () => {
-  ({ getUser, getReservedUser } = require('../utils/utils'))
+  ;({ getUser, getReservedUser } = require('../utils/utils'))
+  ;({ updateUser } = require('../utils/users'))
 }
 setImmediate(requireCircularDependencies)
 
@@ -114,12 +115,12 @@ const setCustomData = async (user, customData) => {
   delete customData.username
   for (const attribute in customData) {
     const value = customData[attribute]
-    await setUserAttribute(user, attribute, value)
+    if (_.isPlainObject(value)) {
+      // ex: 'settings.contributions.anonymize': false
+      throw new Error('use object path syntax')
+    }
+    await updateUser({ user, attribute, value })
   }
-}
-
-const setUserAttribute = (user, attribute, value) => {
-  return request('put', '/api/user', { attribute, value }, user.cookie)
 }
 
 const refreshUser = API.getUserWithCookie

--- a/tests/api/user/update.test.js
+++ b/tests/api/user/update.test.js
@@ -101,9 +101,17 @@ describe('user:update', () => {
   })
 
   describe('settings', () => {
-    it('should allow to update a setting', async () => {
+    it('should update a setting', async () => {
       const user = await getReservedUser()
       const attribute = 'settings.notifications.global'
+      await customAuthReq(user, 'put', endpoint, { attribute, value: false })
+      const updatedUser = await getRefreshedUser(user)
+      _.get(updatedUser, attribute).should.be.false()
+    })
+
+    it('should update anonymize setting', async () => {
+      const user = await getReservedUser()
+      const attribute = 'settings.contributions.anonymize'
       await customAuthReq(user, 'put', endpoint, { attribute, value: false })
       const updatedUser = await getRefreshedUser(user)
       _.get(updatedUser, attribute).should.be.false()

--- a/tests/api/user/update.test.js
+++ b/tests/api/user/update.test.js
@@ -1,4 +1,5 @@
 const should = require('should')
+const _ = require('lodash')
 const { customAuthReq, getReservedUser, getUser, getUserB } = require('../utils/utils')
 const { getRefreshedUser } = require('../fixtures/users')
 const { getToken } = require('../utils/oauth')
@@ -96,6 +97,16 @@ describe('user:update', () => {
         err.statusCode.should.equal(400)
         err.body.status_verbose.should.equal('this username is already used')
       })
+    })
+  })
+
+  describe('settings', () => {
+    it('should allow to update a setting', async () => {
+      const user = await getReservedUser()
+      const attribute = 'settings.notifications.global'
+      await customAuthReq(user, 'put', endpoint, { attribute, value: false })
+      const updatedUser = await getRefreshedUser(user)
+      _.get(updatedUser, attribute).should.be.false()
     })
   })
 })

--- a/tests/api/utils/utils.js
+++ b/tests/api/utils/utils.js
@@ -31,7 +31,10 @@ const API = module.exports = {
   getDataadminUser: getUserGetter('dataadmin', 'dataadmin'),
   getUserGetter,
   // To be used when you need a user not used by any other tests
-  getReservedUser: customData => getUserGetter(randomString(8), null, customData)()
+  getReservedUser: customData => getUserGetter(randomString(8), null, customData)(),
+  getDeanonymizedUser: getUserGetter('deanonymized', null, {
+    'settings.contributions.anonymize': false
+  })
 }
 
 Object.assign(API, require('../../unit/utils'))


### PR DESCRIPTION
Currently, entities history is only accessible by admins. This PR propose to open it to all, while keeping the data of the user that made the edit (a.k.a. contributor) private by default. The reasoning being that we want to preserve privacy by default, and that users might not know that when they add a subject to a work, they are actually editing a public wiki. This PR also allows to opt-in for public contributions by updating a setting on the user document. We could then recommend to regular contributors to opt-in, via the Wiki documentation and/or directly on the editor.

Client PR: #275