### PR TITLE
allow non-dataadmin to request merges

### DIFF
--- a/server/controllers/entities/entities.js
+++ b/server/controllers/entities/entities.js
@@ -39,10 +39,10 @@ module.exports = {
       'update-label': require('./update_label'),
       'revert-edit': require('./revert_edit'),
       'restore-version': require('./restore_version'),
+      merge: require('./merge'),
       'move-to-wikidata': require('./move_to_wikidata')
     },
     dataadmin: {
-      merge: require('./merge'),
       'revert-merge': require('./revert_merge')
     }
   })

--- a/server/controllers/tasks/lib/deduplicate_works.js
+++ b/server/controllers/tasks/lib/deduplicate_works.js
@@ -50,7 +50,7 @@ const filterNewTasks = (existingTasks, suggestions) => {
 }
 
 const addToSuggestion = (userId, isbn) => suggestion => {
-  suggestion.reporter = userId
+  suggestion.reporters = [ userId ]
   suggestion.clue = isbn
   return suggestion
 }

--- a/server/controllers/tasks/lib/request_entities_merge.js
+++ b/server/controllers/tasks/lib/request_entities_merge.js
@@ -1,9 +1,27 @@
 const tasks_ = require('./tasks')
 
 module.exports = async ({ fromUri, toUri, entityType, userId }) => {
+  const task = await tasks_.bySuspectUriAndSuggestionUri(fromUri, toUri)
+  if (task) return addReporter(task, userId)
+  else return createTask({ fromUri, toUri, entityType, userId })
+}
+
+const addReporter = async (task, userId) => {
+  task.reporters = task.reporters || []
+  if (!task.reporters.includes(userId)) {
+    await tasks_.update({
+      ids: [ task._id ],
+      attribute: 'reporters',
+      newValue: task.reporters.concat([ userId ])
+    })
+  }
+  return tasks_.byId(task._id)
+}
+
+const createTask = async ({ fromUri, toUri, entityType, userId }) => {
   const suggestion = {
     uri: toUri,
-    reporter: userId,
+    reporters: [ userId ],
   }
   const [ { id: taskId } ] = await tasks_.create(fromUri, 'deduplicate', entityType, [ suggestion ])
   return tasks_.byId(taskId)

--- a/server/controllers/tasks/lib/request_entities_merge.js
+++ b/server/controllers/tasks/lib/request_entities_merge.js
@@ -1,0 +1,10 @@
+const tasks_ = require('./tasks')
+
+module.exports = async ({ fromUri, toUri, entityType, userId }) => {
+  const suggestion = {
+    uri: toUri,
+    reporter: userId,
+  }
+  const [ { id: taskId } ] = await tasks_.create(fromUri, 'deduplicate', entityType, [ suggestion ])
+  return tasks_.byId(taskId)
+}

--- a/server/controllers/tasks/lib/tasks.js
+++ b/server/controllers/tasks/lib/tasks.js
@@ -8,13 +8,13 @@ const tasks_ = module.exports = {
   create: async (suspectUri, type, entitiesType, suggestions) => {
     // suggestions may only be an array of objects with a 'uri' key
     const newTasksObjects = suggestions.map(suggestion => {
-      const { _score, uri: suggestionUri, occurrences, reporter, clue } = suggestion
+      const { _score, uri: suggestionUri, occurrences, reporters, clue } = suggestion
 
       const newTask = { type, suspectUri, suggestionUri }
 
       assignKeyIfExists(newTask, 'entitiesType', entitiesType)
       assignKeyIfExists(newTask, 'lexicalScore', _score)
-      assignKeyIfExists(newTask, 'reporter', reporter)
+      assignKeyIfExists(newTask, 'reporters', reporters)
       assignKeyIfExists(newTask, 'externalSourcesOccurrences', occurrences)
       assignKeyIfExists(newTask, 'clue', clue)
       return newTask
@@ -27,8 +27,7 @@ const tasks_ = module.exports = {
     return db.bulk(tasks)
   },
 
-  update: async options => {
-    const { ids, attribute, newValue } = options
+  update: async ({ ids, attribute, newValue }) => {
     if (ids.length === 0) return []
 
     return tasks_.byIds(ids)
@@ -93,6 +92,11 @@ const tasks_ = module.exports = {
       const tasksBySuggestionUris = _.groupBy(tasks, 'suggestionUri')
       return completeWithEmptyArrays(tasksBySuggestionUris, suggestionUris)
     })
+  },
+
+  bySuspectUriAndSuggestionUri: async (suspectUri, suggestionUri) => {
+    const tasks = await tasks_.bySuspectUris([ suspectUri ], { includeArchived: true })
+    return tasks.filter(task => task.suggestionUri === suggestionUri)[0]
   }
 }
 

--- a/server/models/attributes/task.js
+++ b/server/models/attributes/task.js
@@ -1,7 +1,11 @@
+const { 'wdt:P31': invP31Values } = require('controllers/entities/lib/properties/allowed_values_per_type_per_property')
+const { getSingularTypes } = require('lib/wikidata/aliases')
+const invEntitiesTypes = getSingularTypes(Object.keys(invP31Values))
+
 module.exports = {
   type: [ 'deduplicate' ],
 
-  entitiesType: [ 'work', 'human' ],
+  entitiesType: invEntitiesTypes,
 
   state: [ undefined, 'merged', 'dismissed' ],
 

--- a/server/models/attributes/task.js
+++ b/server/models/attributes/task.js
@@ -3,11 +3,15 @@ const { getSingularTypes } = require('lib/wikidata/aliases')
 const invEntitiesTypes = getSingularTypes(Object.keys(invP31Values))
 
 module.exports = {
-  type: [ 'deduplicate' ],
+  allowedValues: {
+    type: [ 'deduplicate' ],
+    entitiesType: invEntitiesTypes,
+    state: [ undefined, 'merged', 'dismissed' ],
+  },
 
-  entitiesType: invEntitiesTypes,
-
-  state: [ undefined, 'merged', 'dismissed' ],
-
-  relationScore: []
+  updatable: [
+    'state',
+    'relationScore',
+    'reporters',
+  ]
 }

--- a/server/models/task.js
+++ b/server/models/task.js
@@ -5,7 +5,7 @@ const validations = require('./validations/task')
 module.exports = {
   create: newTask => {
     assert_.object(newTask)
-    const { type, entitiesType, suspectUri, suggestionUri, externalSourcesOccurrences, reporter, clue } = newTask
+    const { type, entitiesType, suspectUri, suggestionUri, externalSourcesOccurrences, reporters, clue } = newTask
     let { lexicalScore } = newTask
 
     validations.pass('type', type)
@@ -23,7 +23,7 @@ module.exports = {
     validateAndAssign(task, 'entitiesType', entitiesType)
     validateAndAssign(task, 'lexicalScore', lexicalScore)
     validateAndAssign(task, 'externalSourcesOccurrences', externalSourcesOccurrences)
-    validateAndAssign(task, 'reporter', reporter)
+    validateAndAssign(task, 'reporters', reporters)
     validateAndAssign(task, 'clue', clue)
     return task
   },
@@ -31,12 +31,8 @@ module.exports = {
   update: (task, attribute, value) => {
     assert_.object(task)
     assert_.string(attribute)
-    // Accept an undefined state value as that's the default state
-    if (value || attribute !== 'state') assert_.type('string|number', value)
-
     validations.pass('attribute', attribute)
     validations.pass(attribute, value)
-
     const now = Date.now()
 
     task[attribute] = value

--- a/server/models/validations/task.js
+++ b/server/models/validations/task.js
@@ -1,20 +1,17 @@
 const _ = require('builders/utils')
-const { pass, entityUri, userId, BoundedString } = require('./common')
-
-const attributes = require('../attributes/task')
+const { pass, entityUri, BoundedString } = require('./common')
+const { allowedValues, updatable } = require('../attributes/task')
 
 module.exports = {
   pass,
-  // in attributes/task.js, attributes keys should match
-  // db keys to verify if attribute is updatable
-  attribute: attribute => Object.keys(attributes).includes(attribute),
-  type: taskType => attributes.type.includes(taskType),
-  entitiesType: entitiesType => attributes.entitiesType.includes(entitiesType),
-  state: taskState => attributes.state.includes(taskState),
+  attribute: attribute => updatable.includes(attribute),
+  type: taskType => allowedValues.type.includes(taskType),
+  entitiesType: entitiesType => allowedValues.entitiesType.includes(entitiesType),
+  state: taskState => allowedValues.state.includes(taskState),
   suspectUri: entityUri,
   lexicalScore: _.isNumber,
   relationScore: _.isNumber,
   externalSourcesOccurrences: _.isArray,
-  reporter: userId,
+  reporters: reporters => _.isNonEmptyArray(reporters) && reporters.every(_.isUserId),
   clue: BoundedString(0, 500)
 }

--- a/tests/api/entities/merge.test.js
+++ b/tests/api/entities/merge.test.js
@@ -65,9 +65,7 @@ describe('entities:merge', () => {
       createWork()
     ])
     await merge(workA.uri, workB.uri)
-    const { entities, redirects } = await getByUris(workA.uri)
-    redirects[workA.uri].should.equal(workB.uri)
-    entities[workB.uri].should.be.ok()
+    await shouldBeMerged(workA, workB)
   })
 
   it('should merge entities with inv and isbn URIs', async () => {
@@ -78,13 +76,7 @@ describe('entities:merge', () => {
     const item = await createItemFromEntityUri({ uri: editionA.uri })
     item.entity.should.equal(editionA.uri)
     await merge(editionA.uri, editionB.uri)
-    const [ { entities, redirects }, { items } ] = await Promise.all([
-      getByUris(editionA.uri),
-      getItemsByIds(item._id)
-    ])
-    redirects[editionA.uri].should.equal(editionB.uri)
-    entities[editionB.uri].should.be.ok()
-    items[0].entity.should.equal(editionB.uri)
+    await shouldBeMerged(editionA, editionB, item)
   })
 
   it('should merge an entity with an ISBN', async () => {
@@ -268,3 +260,13 @@ describe('entities:merge', () => {
     })
   })
 })
+
+const shouldBeMerged = async (entityA, entityB, item) => {
+  const { entities, redirects } = await getByUris(entityA.uri)
+  redirects[entityA.uri].should.equal(entityB.uri)
+  entities[entityB.uri].should.be.ok()
+  if (item) {
+    const { items } = await getItemsByIds(item._id)
+    items[0].entity.should.equal(entityB.uri)
+  }
+}

--- a/tests/api/fixtures/tasks.js
+++ b/tests/api/fixtures/tasks.js
@@ -1,27 +1,10 @@
-const _ = require('builders/utils')
 const { createHuman, createWork } = require('./entities')
-const { checkEntities } = require('../utils/tasks')
 const { createInBulk } = require('controllers/tasks/lib/tasks')
-const promises = {}
 
 module.exports = {
-  createSomeTasks: humanLabel => {
-    if (promises[humanLabel] != null) return promises[humanLabel]
-
-    const human = { labels: { en: humanLabel } }
-
-    promises[humanLabel] = Promise.all([ createHuman(human), createHuman(human) ])
-      .then(humans => {
-        return checkEntities(_.map(humans, 'uri'))
-        .then(tasks => ({ tasks, humans }))
-      })
-
-    return promises[humanLabel]
-  },
-
   createTask: async params => {
     const taskDoc = await createTaskDoc(params)
-    return createTasks([ taskDoc ])
+    return createInBulk([ taskDoc ])
     .then(tasks => tasks[0])
   }
 }
@@ -47,8 +30,4 @@ const createTaskDoc = async (params = {}) => {
     relationScore: 0.1,
     externalSourcesOccurrences: []
   }
-}
-
-const createTasks = taskDocs => {
-  return createInBulk(taskDocs)
 }

--- a/tests/api/tasks/deduplicate_works.test.js
+++ b/tests/api/tasks/deduplicate_works.test.js
@@ -60,7 +60,7 @@ describe('tasks:deduplicate:works', () => {
     newTask.entitiesType.should.equal('work')
     newTask.suggestionUri.should.equal(editionWorkUri)
     const user = await getUser()
-    newTask.reporter.should.equal(user._id)
+    newTask.reporters.should.deepEqual([ user._id ])
     newTask.clue.should.equal(isbn)
   })
 


### PR DESCRIPTION
addressing #491 and #91 

by opening the `/api/entities?action=merge` endpoint to all authentified users. The current PR is limited to requesting merges by creating a task, but in the future, the merge could be done directly after some checks of what's at stake, just like it's done for `/api/entities?action=delete`

~WIP status: this PR depends depends on the `reqUserHasDataadminAccess` flag introduced in #513~

TODO:
- [ ] explore the possibility to use the task automerge (as suggested by https://github.com/inventaire/inventaire/issues/491#issuecomment-766925495)