### PR TITLE
search: entities: fix exact match for terms containing single letters

### DIFF
--- a/server/db/elasticsearch/settings/settings.js
+++ b/server/db/elasticsearch/settings/settings.js
@@ -21,7 +21,7 @@ module.exports = {
       // See: https://www.elastic.co/guide/en/elasticsearch/reference/7.10/analysis-edgengram-tokenizer.html
       autocomplete_filter: {
         type: 'edge_ngram',
-        min_gram: 2,
+        min_gram: 1,
         max_gram: maxGram
       },
       // An analyzer to apply at search time to match the autocomplete analyzer used at index time

--- a/tests/api/search/search_entities.test.js
+++ b/tests/api/search/search_entities.test.js
@@ -97,6 +97,16 @@ describe('search:entities', () => {
         _.map(results, 'uri').should.containEql(work.uri)
       })
 
+      it('should find a label with single letter words', async () => {
+        // Insert random words in the middle to mitigate a too low score due to a high term frequency
+        // when running the tests several times without emptying the database
+        const label = `a ${randomWords(3)}`
+        const work = await createWork({ labels: { en: label } })
+        await waitForIndexation('entities', work._id)
+        const results = await search({ types: 'works', search: label, lang: 'en', exact: true })
+        _.map(results, 'uri').should.containEql(work.uri)
+      })
+
       it('should ignore the case', async () => {
         // Insert random words in the middle to mitigate a too low score due to a high term frequency
         // when running the tests several times without emptying the database


### PR DESCRIPTION
example of a false negative match:
- [L'homme qui murmurait à l'oreille des chevaux](https://inventaire.io/api/search?types=works&search=L%27homme%20qui%20murmurait%20%C3%A0%20l%27oreille%20des%20chevaux&lang=fr&limit=100&exact=true) doesn't find wd:Q1448153
- [L'homme qui murmurait l'oreille des chevaux](https://inventaire.io/api/search?types=works&search=L%27homme%20qui%20murmurait%20%C3%A0%20l%27oreille%20des%20chevaux&lang=fr&limit=100&exact=true) does find wd:Q1448153

This can be fixed by making the autocomplete filter use `min_gram=1`: updating the prod Elasticsearch index settings won't be enough this time, a reindexation is required to fully benefit from the fix.

In case we go for a reindexation, we could also consider including the [commit on the `entities-reindexation` branch](https://github.com/inventaire/inventaire/compare/entities-reindexation)