### PR TITLE
Opt-out from Google FLoC

### DIFF
--- a/server/controllers/glob.js
+++ b/server/controllers/glob.js
@@ -4,7 +4,9 @@ const publicFolder = __.path('client', 'public')
 const indexOptions = {
   root: publicFolder,
   headers: {
-    'Cache-Control': 'no-cache, no-store, must-revalidate'
+    'Cache-Control': 'no-cache, no-store, must-revalidate',
+    // Opt-out from Google FLoC, see https://plausible.io/blog/google-floc
+    'Permissions-Policy': 'interest-cohort=()',
   }
 }
 


### PR DESCRIPTION
see https://plausible.io/blog/google-floc

This would need to be applied in [Nginx config](https://github.com/inventaire/inventaire-deploy/blob/master/nginx/inventaire.original.nginx#L291) too to be effective in production