### PR TITLE
add GND as a data source to match authors works titles

### DIFF
--- a/server/controllers/entities/lib/get_occurrences_from_external_sources.js
+++ b/server/controllers/entities/lib/get_occurrences_from_external_sources.js
@@ -96,7 +96,7 @@ const createOccurrencesFromUnstructuredArticle = worksLabels => {
 
 const createOccurrencesFromExactTitles = worksLabels => result => {
   const title = normalizeTerm(result.title)
-  if (worksLabels.includes(title)) {
+  if (worksLabels.map(normalizeTerm).includes(title)) {
     return {
       url: result.url,
       matchedTitles: [ title ],

--- a/server/controllers/entities/lib/get_occurrences_from_external_sources.js
+++ b/server/controllers/entities/lib/get_occurrences_from_external_sources.js
@@ -5,6 +5,7 @@ const getWikipediaArticle = require('data/wikipedia/get_article')
 const getBnfAuthorWorksTitles = require('data/bnf/get_bnf_author_works_titles')
 const getBnbAuthorWorksTitles = require('data/bnb/get_bnb_author_works_titles')
 const getBneAuthorWorksTitles = require('data/bne/get_bne_author_works_titles')
+const getGndAuthorWorksTitles = require('data/gnd/get_gnd_author_works_titles')
 const getSelibrAuthorWorksTitle = require('data/selibr/get_selibr_author_works_titles')
 const getKjkAuthorWorksTitle = require('data/kjk/get_kjk_author_works_titles')
 const getNdlAuthorWorksTitle = require('data/ndl/get_ndl_author_works_titles')
@@ -34,6 +35,7 @@ module.exports = (wdAuthorUri, worksLabels, worksLabelsLangs) => {
       getOpenLibraryOccurrences(authorEntity, worksLabels),
       getBnbOccurrences(authorEntity, worksLabels),
       getBneOccurrences(authorEntity, worksLabels),
+      getGndOccurrences(authorEntity, worksLabels),
       getSelibrOccurrences(authorEntity, worksLabels),
       getKjkOccurrences(authorEntity, worksLabels),
       getNdlOccurrences(authorEntity, worksLabels)
@@ -78,6 +80,7 @@ const getBnfOccurrences = getAndCreateOccurrencesFromIds('wdt:P268', getBnfAutho
 const getOpenLibraryOccurrences = getAndCreateOccurrencesFromIds('wdt:P648', getOlAuthorWorksTitles)
 const getBnbOccurrences = getAndCreateOccurrencesFromIds('wdt:P5361', getBnbAuthorWorksTitles)
 const getBneOccurrences = getAndCreateOccurrencesFromIds('wdt:P950', getBneAuthorWorksTitles)
+const getGndOccurrences = getAndCreateOccurrencesFromIds('wdt:P227', getGndAuthorWorksTitles)
 const getSelibrOccurrences = getAndCreateOccurrencesFromIds('wdt:P906', getSelibrAuthorWorksTitle)
 const getKjkOccurrences = getAndCreateOccurrencesFromIds('wdt:P1006', getKjkAuthorWorksTitle)
 const getNdlOccurrences = getAndCreateOccurrencesFromIds('wdt:P349', getNdlAuthorWorksTitle)

--- a/server/controllers/entities/lib/properties/properties_per_type.js
+++ b/server/controllers/entities/lib/properties/properties_per_type.js
@@ -3,6 +3,7 @@
 
 const all = [
   'wdt:P31', // instance of
+  'wdt:P227', // GND ID
   'wdt:P243', // OCLC control number
   'wdt:P268', // BNF ID
 ]
@@ -71,7 +72,6 @@ module.exports = {
     'wdt:P135', // movement
     'wdt:P213', // ISNI
     'wdt:P214', // VIAF ID
-    'wdt:P227', // GND ID
     'wdt:P269', // SUDOC authorities ID
     'wdt:P349', // NDL of Japan Auth ID
     'wdt:P496', // ORCID ID

--- a/server/controllers/entities/lib/terms_normalization.js
+++ b/server/controllers/entities/lib/terms_normalization.js
@@ -17,6 +17,8 @@ const normalizeTerm = term => {
   .replace(/\./g, ' ')
   // - Replace all groups of spaces that might have emerged above by a single space
   .replace(/\s+/g, ' ')
+
+  .trim()
 }
 
 const getEntityNormalizedTerms = entity => {

--- a/server/data/gnd/get_gnd_author_works_titles.js
+++ b/server/data/gnd/get_gnd_author_works_titles.js
@@ -1,0 +1,11 @@
+const fetchExternalAuthorWorksTitles = require('data/lib/fetch_external_author_works_titles')
+
+// Unofficial endpoint
+const endpoint = 'https://zbw.eu/beta/sparql/gnd/query'
+
+const getQuery = gndId => `SELECT ?work ?title WHERE {
+  ?work <https://d-nb.info/standards/elementset/gnd#firstAuthor> <https://d-nb.info/gnd/${gndId}> .
+  ?work <https://d-nb.info/standards/elementset/gnd#preferredNameForTheWork> ?title .
+}`
+
+module.exports = fetchExternalAuthorWorksTitles('gnd', endpoint, getQuery)

--- a/server/lib/wikidata/allowlisted_properties.js
+++ b/server/lib/wikidata/allowlisted_properties.js
@@ -31,6 +31,7 @@ module.exports = [
   'P212', // isbn 13
   'P213', // ISNI
   'P214', // VIAF ID
+  'P227', // GND ID
   'P268', // BnF ID
   'P269', // SUDOC authorities ID
   'P279', // subclass of


### PR DESCRIPTION
[GND is the database with the most ids known by Wikidata (around 1228395 at the moment)](https://query.wikidata.org/#%23%20Databases%20with%20a%20SPARQL%20endpoint%2C%20sorted%20by%20number%20of%20ids%20known%20by%20Wikidata%0ASELECT%20%3Fservice%20%3FserviceLabel%20%3Fproperty%20%3FpropertyLabel%20%3Fendpoint%20(COUNT(%3Fid)%20AS%20%3Fids_count)%20%20%7B%0A%20%20%3Fservice%20wdt%3AP5305%20%3Fendpoint%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20wdt%3AP1687%20%3Fproperty%20.%0A%20%20%3Fproperty%20wikibase%3AdirectClaim%20%3Fprop%20.%0A%20%20%3Fentity%20%3Fprop%20%3Fid%20.%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22%5BAUTO_LANGUAGE%5D%2Cen%22.%20%7D%0A%7D%0AGROUP%20BY%20%3Fservice%20%3FserviceLabel%20%3Fproperty%20%3FpropertyLabel%20%3Fendpoint%0AORDER%20BY%20DESC(%3Fids_count)), so we might be able to use it to match a good amount of additional authors' works titles with existing Wikidata entities