### PR TITLE
entities: delete: accept isbn uris

### DIFF
--- a/server/controllers/entities/delete.js
+++ b/server/controllers/entities/delete.js
@@ -4,6 +4,7 @@ const responses_ = require('lib/responses')
 const sanitize = require('lib/sanitize/sanitize')
 const verifyThatEntitiesCanBeRemoved = require('./lib/verify_that_entities_can_be_removed')
 const removeEntitiesByInvId = require('./lib/remove_entities_by_inv_id')
+const entities_ = require('./lib/entities')
 
 const sanitization = {
   uris: {}
@@ -11,23 +12,37 @@ const sanitization = {
 
 module.exports = (req, res) => {
   sanitize(req, res, sanitization)
-  .then(params => {
-    const { user } = req
-    const uris = _.uniq(params.uris)
-    validateInvUris(uris)
-    return verifyThatEntitiesCanBeRemoved(uris)
-    .then(() => removeEntitiesByInvId(user, uris))
-  })
+  .then(deleteEntities(req.user))
   .then(responses_.Ok(res))
   .catch(error_.Handler(req, res))
 }
 
-const validateInvUris = uris => {
+const deleteEntities = user => async params => {
+  let uris = _.uniq(params.uris)
+  validateUris(uris)
+  uris = await replaceIsbnUrisByInvUris(uris)
+  await verifyThatEntitiesCanBeRemoved(uris)
+  return removeEntitiesByInvId(user, uris)
+}
+
+const validateUris = uris => {
   for (const uri of uris) {
     // Wikidata entities can't be delete
-    // and neither can editions entities with an ISBN: they should be fixed
-    if (!_.isInvEntityUri(uri)) {
-      throw error_.newInvalid('uri', uri)
-    }
+    if (_.isWdEntityUri(uri)) throw error_.newInvalid('uri', uri)
   }
+}
+
+const replaceIsbnUrisByInvUris = async uris => {
+  const invUris = uris.filter(_.isInvEntityUri)
+  const isbnUris = uris.filter(_.isIsbnEntityUri)
+  if (isbnUris.length === 0) return invUris
+
+  const substitutedUris = await getInvUrisFromIsbnUris(isbnUris)
+  return invUris.concat(substitutedUris)
+}
+
+const getInvUrisFromIsbnUris = async uris => {
+  const isbns = uris.map(uri => uri.split(':')[1])
+  const entities = await entities_.byIsbns(isbns)
+  return entities.map(entity => `inv:${entity._id}`)
 }

--- a/server/lib/boolean_validations.js
+++ b/server/lib/boolean_validations.js
@@ -2,6 +2,7 @@
 const _ = require('lodash')
 const wdk = require('wikidata-sdk')
 const regex_ = require('lib/regex')
+const { isNormalizedIsbn } = require('./isbn/isbn')
 const { PositiveInteger: PositiveIntegerPattern } = regex_
 
 const bindedTest = regexName => regex_[regexName].test.bind(regex_[regexName])
@@ -21,6 +22,11 @@ const tests = module.exports = {
     if (!isNonEmptyString(uri)) return false
     const [ prefix, id ] = uri && uri.split(':')
     return (prefix === 'inv') && isCouchUuid(id)
+  },
+  isIsbnEntityUri: uri => {
+    if (!isNonEmptyString(uri)) return false
+    const [ prefix, id ] = uri && uri.split(':')
+    return (prefix === 'isbn') && isNormalizedIsbn(id)
   },
   isWdEntityUri: uri => {
     if (!isNonEmptyString(uri)) return false

--- a/server/lib/isbn/isbn.js
+++ b/server/lib/isbn/isbn.js
@@ -16,6 +16,7 @@ const isNormalizedIsbn = text => /^(97(8|9))?\d{9}(\d|X)$/.test(text)
 module.exports = {
   parse,
   normalizeIsbn,
+  isNormalizedIsbn,
   looksLikeAnIsbn: text => {
     if (typeof text !== 'string') return false
     const cleanedText = normalizeIsbn(text)

--- a/tests/api/entities/delete.test.js
+++ b/tests/api/entities/delete.test.js
@@ -100,9 +100,14 @@ describe('entities:delete', () => {
     await deleteByUris(invUri)
   })
 
-  it('should remove edition entities with an ISBN', async () => {
+  it('should remove edition entities with an ISBN from its inv uri', async () => {
     const { invUri } = await createEditionWithIsbn()
     await deleteByUris(invUri)
+  })
+
+  it('should remove edition entities with an ISBN from its isbn uri', async () => {
+    const { uri } = await createEditionWithIsbn()
+    await deleteByUris(uri)
   })
 
   it('should refuse to delete a work that is depend on by an edition', async () => {


### PR DESCRIPTION
the current limitation to delete entities from inv uris only seems obsolete (the idea that when an entity has an ISBN it shouldn't be deleted but fixed (ac8bf2d) proved to be unpractical, as we actually still delete edition entities with ISBN, just by passing by the inv id), this PR proposes to remove this limitation for isbn uris by resolving them ahead of the existing logic