### PR TITLE
search: allow to search entities with their relative entities labels

### DIFF
--- a/server/controllers/search/lib/entities_query_builder.js
+++ b/server/controllers/search/lib/entities_query_builder.js
@@ -89,7 +89,8 @@ const entitiesFields = (userLang, exact) => {
       'flattenedLabels^0.25',
       'flattenedAliases^0.25',
       'descriptions.*^0.25',
-      'flattenedDescriptions^0.25'
+      'flattenedDescriptions^0.25',
+      'relationsTerms^0.25'
     )
   }
 

--- a/server/controllers/search/lib/entities_query_builder.js
+++ b/server/controllers/search/lib/entities_query_builder.js
@@ -68,19 +68,6 @@ const matchEntities = (search, userLang, exact) => {
         type: 'best_fields',
       }
     })
-    // Flattened terms have been indexes with the 'standard' analyzer
-    // and would thus give poor results if queried with the 'standard_truncated' analyzer
-    // thus this additionnal query. Once they are reindexed with the autocomplete analyzer
-    // those fields could be queries as the other fields, and the query below could then be removed
-    queries.push({
-      multi_match: {
-        query: search,
-        operator: 'or',
-        fields: entitiesFlattenedFields,
-        analyzer: 'standard',
-        type: 'best_fields',
-      }
-    })
   }
 
   return queries
@@ -99,15 +86,12 @@ const entitiesFields = (userLang, exact) => {
   }
   if (!exact) {
     fields.push(
-      'descriptions.*^0.25'
+      'flattenedLabels^0.25',
+      'flattenedAliases^0.25',
+      'descriptions.*^0.25',
+      'flattenedDescriptions^0.25'
     )
   }
 
   return fields
 }
-
-const entitiesFlattenedFields = [
-  'flattenedLabels^0.25',
-  'flattenedAliases^0.25',
-  'flattenedDescriptions^0.1'
-]

--- a/server/db/elasticsearch/formatters/entity.js
+++ b/server/db/elasticsearch/formatters/entity.js
@@ -192,6 +192,7 @@ const authorProperties = [
 
 const indexedRelationsPerType = {
   work: authorProperties,
+  serie: authorProperties,
 }
 
 // Not including descriptions

--- a/server/db/elasticsearch/formatters/entity.js
+++ b/server/db/elasticsearch/formatters/entity.js
@@ -183,10 +183,11 @@ const getRelationsTerms = async ({ type, claims }) => {
   return _.flatten(relationsEntities.map(getEntityTerms)).join(' ')
 }
 
-const authorProperties = [
+const worksAndSeriesProperties = [
   'wdt:P50', // author
   'wdt:P58', // scenarist
   'wdt:P110', // illustrator
+  'wdt:P179', // serie
   'wdt:P6338', // colorist
 ]
 
@@ -194,8 +195,8 @@ const indexedRelationsPerType = {
   collection: [
     'wdt:P123', // publisher
   ],
-  serie: authorProperties,
-  work: authorProperties,
+  serie: worksAndSeriesProperties,
+  work: worksAndSeriesProperties,
 }
 
 // Not including descriptions

--- a/server/db/elasticsearch/formatters/entity.js
+++ b/server/db/elasticsearch/formatters/entity.js
@@ -191,8 +191,11 @@ const authorProperties = [
 ]
 
 const indexedRelationsPerType = {
-  work: authorProperties,
+  collection: [
+    'wdt:P123', // publisher
+  ],
   serie: authorProperties,
+  work: authorProperties,
 }
 
 // Not including descriptions

--- a/server/db/elasticsearch/formatters/entity.js
+++ b/server/db/elasticsearch/formatters/entity.js
@@ -183,8 +183,15 @@ const getRelationsTerms = async ({ type, claims }) => {
   return _.flatten(relationsEntities.map(getEntityTerms)).join(' ')
 }
 
+const authorProperties = [
+  'wdt:P50', // author
+  'wdt:P58', // scenarist
+  'wdt:P110', // illustrator
+  'wdt:P6338', // colorist
+]
+
 const indexedRelationsPerType = {
-  work: [ 'wdt:P50' ]
+  work: authorProperties,
 }
 
 // Not including descriptions

--- a/server/db/elasticsearch/mappings/entities.js
+++ b/server/db/elasticsearch/mappings/entities.js
@@ -1,4 +1,4 @@
-const { text, integer, keyword, date, nested, terms } = require('./mappings_datatypes')
+const { flattenedTerms, integer, keyword, date, nested, terms } = require('./mappings_datatypes')
 
 module.exports = {
   properties: {
@@ -6,9 +6,9 @@ module.exports = {
     labels: terms,
     aliases: terms,
     descriptions: terms,
-    flattenedLabels: text,
-    flattenedAliases: text,
-    flattenedDescriptions: text,
+    flattenedLabels: flattenedTerms,
+    flattenedAliases: flattenedTerms,
+    flattenedDescriptions: flattenedTerms,
     uri: keyword,
     images: nested,
     created: date,

--- a/server/db/elasticsearch/mappings/entities.js
+++ b/server/db/elasticsearch/mappings/entities.js
@@ -9,6 +9,7 @@ module.exports = {
     flattenedLabels: flattenedTerms,
     flattenedAliases: flattenedTerms,
     flattenedDescriptions: flattenedTerms,
+    relationsTerms: flattenedTerms,
     uri: keyword,
     images: nested,
     created: date,

--- a/server/db/elasticsearch/mappings/mappings_datatypes.js
+++ b/server/db/elasticsearch/mappings/mappings_datatypes.js
@@ -2,7 +2,7 @@ const { activeI18nLangs } = require('../helpers')
 
 // See https://www.elastic.co/guide/en/elasticsearch/reference/7.10/mapping-types.html
 
-const langProperty = {
+const autocompleteText = {
   type: 'text',
   analyzer: 'autocomplete',
   // Set a different default analyzer for search time,
@@ -17,9 +17,9 @@ const langProperty = {
 const getTermsProperties = () => {
   const properties = {}
   activeI18nLangs.forEach(lang => {
-    properties[lang] = langProperty
+    properties[lang] = autocompleteText
   })
-  properties.fromclaims = langProperty
+  properties.fromclaims = autocompleteText
   return properties
 }
 
@@ -33,4 +33,5 @@ module.exports = {
   nested: { type: 'nested' },
   terms: { properties: getTermsProperties() },
   text: { type: 'text' },
+  flattenedTerms: autocompleteText,
 }

--- a/tests/api/fixtures/entities.js
+++ b/tests/api/fixtures/entities.js
@@ -89,9 +89,7 @@ const API = module.exports = {
 
   createWorkWithAuthor: async (human, label) => {
     label = label || API.randomLabel()
-    const humanPromise = human ? Promise.resolve(human) : API.createHuman()
-
-    human = await humanPromise
+    human = await (human || API.createHuman())
     return authReq('post', '/api/entities?action=create', {
       labels: { en: label },
       claims: {
@@ -99,6 +97,14 @@ const API = module.exports = {
         'wdt:P50': [ human.uri ]
       }
     })
+  },
+
+  createSerieWithAuthor: async params => {
+    let { human } = params
+    human = await (human || API.createHuman())
+    const serie = await API.createSerie(params)
+    await API.addAuthor(serie, human)
+    return serie
   },
 
   createEditionFromWorkWithAuthor: async () => {

--- a/tests/api/search/entities.test.js
+++ b/tests/api/search/entities.test.js
@@ -1,6 +1,6 @@
 const _ = require('builders/utils')
 require('should')
-const { createWork, createHuman, createSerie, createCollection, createPublisher, sameFirstNameLabel, createWorkWithAuthor, createSerieWithAuthor, humanName } = require('../fixtures/entities')
+const { createWork, createHuman, createSerie, createCollection, createPublisher, sameFirstNameLabel, createWorkWithAuthor, createSerieWithAuthor, createWorkWithSerie, humanName } = require('../fixtures/entities')
 const { randomLongWord, randomWords } = require('../fixtures/text')
 const { getByUris } = require('../utils/entities')
 const { shouldNotBeCalled } = require('../utils/utils')
@@ -181,6 +181,18 @@ describe('search:entities', () => {
       const label = humanName()
       const human = await createHuman({ labels: { en: label } })
       const work = await createWorkWithAuthor(human)
+
+      await waitForIndexation('entities', work._id)
+
+      const results = await search({ types: 'works', search: label, lang: 'en', filter: 'inv' })
+      const foundIds = _.map(results, 'id')
+      foundIds.should.containEql(work._id)
+    })
+
+    it('should find a work by its serie name', async () => {
+      const label = randomWords()
+      const serie = await createSerie({ labels: { en: label } })
+      const work = await createWorkWithSerie(serie)
 
       await waitForIndexation('entities', work._id)
 

--- a/tests/api/search/entities.test.js
+++ b/tests/api/search/entities.test.js
@@ -1,6 +1,6 @@
 const _ = require('builders/utils')
 require('should')
-const { createWork, createHuman, createSerie, createCollection, createPublisher, sameFirstNameLabel, createWorkWithAuthor, humanName } = require('../fixtures/entities')
+const { createWork, createHuman, createSerie, createCollection, createPublisher, sameFirstNameLabel, createWorkWithAuthor, createSerieWithAuthor, humanName } = require('../fixtures/entities')
 const { randomLongWord, randomWords } = require('../fixtures/text')
 const { getByUris } = require('../utils/entities')
 const { shouldNotBeCalled } = require('../utils/utils')
@@ -204,6 +204,19 @@ describe('search:entities', () => {
       results.should.be.an.Array()
       results.forEach(result => result.type.should.equal('series'))
       _.map(results, 'id').includes('Q8337').should.be.true()
+    })
+
+    it('should find a serie by its author name', async () => {
+      const label = humanName()
+      const human = await createHuman({ labels: { en: label } })
+      const serie = await createSerieWithAuthor({ human })
+      console.log({ human, serie })
+
+      await waitForIndexation('entities', serie._id)
+
+      const results = await search({ types: 'series', search: label, lang: 'en', filter: 'inv' })
+      const foundIds = _.map(results, 'id')
+      foundIds.should.containEql(serie._id)
     })
   })
 

--- a/tests/api/search/entities.test.js
+++ b/tests/api/search/entities.test.js
@@ -1,6 +1,6 @@
 const _ = require('builders/utils')
 require('should')
-const { createWork, createHuman, createSerie, createCollection, createPublisher, sameFirstNameLabel } = require('../fixtures/entities')
+const { createWork, createHuman, createSerie, createCollection, createPublisher, sameFirstNameLabel, createWorkWithAuthor, humanName } = require('../fixtures/entities')
 const { randomLongWord, randomWords } = require('../fixtures/text')
 const { getByUris } = require('../utils/entities')
 const { shouldNotBeCalled } = require('../utils/utils')
@@ -175,6 +175,18 @@ describe('search:entities', () => {
       results.should.be.an.Array()
       results.forEach(result => result.type.should.equal('works'))
       _.map(results, 'id').includes('Q180736').should.be.true()
+    })
+
+    it('should find a work by its author name', async () => {
+      const label = humanName()
+      const human = await createHuman({ labels: { en: label } })
+      const work = await createWorkWithAuthor(human)
+
+      await waitForIndexation('entities', work._id)
+
+      const results = await search({ types: 'works', search: label, lang: 'en', filter: 'inv' })
+      const foundIds = _.map(results, 'id')
+      foundIds.should.containEql(work._id)
     })
   })
 

--- a/tests/api/search/entities.test.js
+++ b/tests/api/search/entities.test.js
@@ -130,7 +130,6 @@ describe('search:entities', () => {
           waitForIndexation('entities', humanA._id),
           waitForIndexation('entities', humanB._id),
         ])
-
         const results = await search({ types: 'humans', search: label, lang: 'en', filter: 'inv' })
         const humanAScore = results.find(entity => entity.id === humanA._id)._score
         const humanBScore = results.find(entity => entity.id === humanB._id)._score
@@ -181,9 +180,7 @@ describe('search:entities', () => {
       const label = humanName()
       const human = await createHuman({ labels: { en: label } })
       const work = await createWorkWithAuthor(human)
-
       await waitForIndexation('entities', work._id)
-
       const results = await search({ types: 'works', search: label, lang: 'en', filter: 'inv' })
       const foundIds = _.map(results, 'id')
       foundIds.should.containEql(work._id)
@@ -193,9 +190,7 @@ describe('search:entities', () => {
       const label = randomWords()
       const serie = await createSerie({ labels: { en: label } })
       const work = await createWorkWithSerie(serie)
-
       await waitForIndexation('entities', work._id)
-
       const results = await search({ types: 'works', search: label, lang: 'en', filter: 'inv' })
       const foundIds = _.map(results, 'id')
       foundIds.should.containEql(work._id)
@@ -222,10 +217,7 @@ describe('search:entities', () => {
       const label = humanName()
       const human = await createHuman({ labels: { en: label } })
       const serie = await createSerieWithAuthor({ human })
-      console.log({ human, serie })
-
       await waitForIndexation('entities', serie._id)
-
       const results = await search({ types: 'series', search: label, lang: 'en', filter: 'inv' })
       const foundIds = _.map(results, 'id')
       foundIds.should.containEql(serie._id)
@@ -259,9 +251,7 @@ describe('search:entities', () => {
           'wdt:P123': [ publisher.uri ]
         }
       })
-      console.log({ label, publisher, collection })
       await waitForIndexation('entities', collection._id)
-
       const results = await search({ types: 'collections', search: label, lang: 'en', filter: 'inv' })
       const foundIds = _.map(results, 'id')
       foundIds.should.containEql(collection._id)

--- a/tests/api/search/entities.test.js
+++ b/tests/api/search/entities.test.js
@@ -238,6 +238,22 @@ describe('search:entities', () => {
       results.forEach(result => result.type.should.equal('collections'))
       _.map(results, 'id').includes('Q3409094').should.be.true()
     })
+
+    it('should find a collection by its publisher name', async () => {
+      const label = randomWords()
+      const publisher = await createPublisher({ labels: { en: label } })
+      const collection = await createCollection({
+        claims: {
+          'wdt:P123': [ publisher.uri ]
+        }
+      })
+      console.log({ label, publisher, collection })
+      await waitForIndexation('entities', collection._id)
+
+      const results = await search({ types: 'collections', search: label, lang: 'en', filter: 'inv' })
+      const foundIds = _.map(results, 'id')
+      foundIds.should.containEql(collection._id)
+    })
   })
 
   describe('publishers', () => {


### PR DESCRIPTION
addressing #213, among other cases (see commit messages)

This PR supposes to reindex entities, so should ideally be grouped with other changes requiring a reindexation, such as 56f41af (included in this PR) and #530