### PR TITLE
search claim filter

### DIFF
--- a/server/controllers/search/lib/entities_query_builder.js
+++ b/server/controllers/search/lib/entities_query_builder.js
@@ -109,7 +109,7 @@ const entitiesFields = (userLang, exact) => {
 const getClaimFilter = claimParameter => {
   return {
     terms: {
-      claim: [ claimParameter ]
+      claim: claimParameter.split('|')
     }
   }
 }

--- a/server/controllers/search/lib/entities_query_builder.js
+++ b/server/controllers/search/lib/entities_query_builder.js
@@ -14,7 +14,7 @@ module.exports = params => {
     { terms: { type: types } }
   ]
 
-  if (claim) filters.push(...getClaimFilter(claim))
+  if (claim) filters.push(...getClaimFilters(claim))
 
   if (!search) minScore = 0
 
@@ -109,7 +109,7 @@ const entitiesFields = (userLang, exact) => {
   return fields
 }
 
-const getClaimFilter = claimParameter => {
+const getClaimFilters = claimParameter => {
   return claimParameter
   .split(' ')
   .map(andCondition => {

--- a/server/controllers/search/lib/entities_query_builder.js
+++ b/server/controllers/search/lib/entities_query_builder.js
@@ -18,19 +18,18 @@ module.exports = params => {
 
   if (!search) minScore = 0
 
+  const shoulds = matchEntities(search, userLang, exact)
+
   return {
     query: {
       function_score: {
         query: {
           bool: {
             filter: filters,
-            // Because most of the work has been done at index time (indexing terms by ngrams)
-            // all this query needs to do is to look up search terms which is way more efficient than the match_phrase_prefix approach
-            // See https://www.elastic.co/guide/en/elasticsearch/guide/current/_index_time_search_as_you_type.html
-            should: matchEntities(search, userLang, exact),
-            // The default value would be 0 due to the presence of a filter
+            should: shoulds,
+            // The default value would be 0 due to the presence of filters
             // See https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html#bool-min-should-match
-            minimum_should_match: 1
+            minimum_should_match: shoulds != null ? 1 : 0
           }
         },
         // See: https://www.elastic.co/guide/en/elasticsearch/reference/7.10/query-dsl-function-score-query.html#function-field-value-factor

--- a/server/controllers/search/lib/entities_query_builder.js
+++ b/server/controllers/search/lib/entities_query_builder.js
@@ -1,6 +1,7 @@
 const { getSingularTypes } = require('lib/wikidata/aliases')
 const properties = require('controllers/entities/lib/properties/properties_values_constraints')
 const error_ = require('lib/error/error')
+const { trim } = require('lodash')
 const { isPropertyUri, isWdEntityUri } = require('lib/boolean_validations')
 
 module.exports = params => {
@@ -112,7 +113,7 @@ const getClaimFilters = claimParameter => {
   return claimParameter
   .split(' ')
   .map(andCondition => {
-    const orConditions = andCondition.split('|')
+    const orConditions = andCondition.split('|').map(trim)
     orConditions.forEach(validatePropertyAndValue)
     return {
       terms: {

--- a/server/controllers/search/lib/entities_query_builder.js
+++ b/server/controllers/search/lib/entities_query_builder.js
@@ -1,7 +1,7 @@
 const { getSingularTypes } = require('lib/wikidata/aliases')
 const properties = require('controllers/entities/lib/properties/properties_values_constraints')
 const error_ = require('lib/error/error')
-const { isPropertyUri } = require('lib/boolean_validations')
+const { isPropertyUri, isWdEntityUri } = require('lib/boolean_validations')
 
 module.exports = params => {
   const { lang: userLang, search, limit: size, exact, claim } = params
@@ -131,7 +131,14 @@ const validatePropertyAndValue = condition => {
   if (properties[property] == null) {
     throw error_.new('unknown property', 400, { property, value })
   }
-  if (!properties[property].validate(value)) {
-    throw error_.new('invalid property value', 400, { property, value })
+  // Using a custom validation for wdt:P31, to avoid having to pass an entityType
+  if (property === 'wdt:P31') {
+    if (!isWdEntityUri(value)) {
+      throw error_.new('invalid property value', 400, { property, value })
+    }
+  } else {
+    if (!properties[property].validate(value)) {
+      throw error_.new('invalid property value', 400, { property, value })
+    }
   }
 }

--- a/server/controllers/search/lib/entities_query_builder.js
+++ b/server/controllers/search/lib/entities_query_builder.js
@@ -11,7 +11,7 @@ module.exports = params => {
     { terms: { type: types } }
   ]
 
-  if (claim) filters.push(getClaimFilter(claim))
+  if (claim) filters.push(...getClaimFilter(claim))
 
   if (!search) minScore = 0
 
@@ -107,9 +107,13 @@ const entitiesFields = (userLang, exact) => {
 }
 
 const getClaimFilter = claimParameter => {
-  return {
-    terms: {
-      claim: claimParameter.split('|')
+  return claimParameter
+  .split(' ')
+  .map(condition => {
+    return {
+      terms: {
+        claim: condition.split('|')
+      }
     }
-  }
+  })
 }

--- a/server/controllers/search/lib/type_search.js
+++ b/server/controllers/search/lib/type_search.js
@@ -9,18 +9,19 @@ const indexedTypesSet = new Set(indexedTypes)
 const entitiesQueryBuilder = require('./entities_query_builder')
 const socialQueryBuilder = require('./social_query_builder')
 
-module.exports = async ({ lang, types, search, limit = 20, filter, exact, minScore }) => {
+module.exports = async ({ lang, types, search, limit = 20, filter, exact, minScore, claim }) => {
   assert_.array(types)
   for (const type of types) {
     if (!indexedTypesSet.has(type)) throw error_.new('invalid type', 500, { type, types })
   }
-  assert_.string(search)
+  if (search) assert_.string(search)
 
   const hasSocialTypes = types.includes('users') || types.includes('groups')
   const hasEntityTypes = _.someMatch(types, indexedEntitiesTypes)
 
-  if (hasSocialTypes && exact) {
-    throw error_.new('exact search is restricted to entity types', 400, { givenTypes: types, validTypes: indexedEntitiesTypes })
+  if (hasSocialTypes) {
+    if (exact) typeParameterError('exact', types)
+    if (claim != null) typeParameterError('exact', types)
   }
 
   // Query must be either social (user, group) or entities related
@@ -36,7 +37,7 @@ module.exports = async ({ lang, types, search, limit = 20, filter, exact, minSco
   } else {
     queryIndexes = entitiesIndexesPerFilter[filter]
     if (queryIndexes == null) throw error_.new('invalid filter', 500, { filter })
-    body = entitiesQueryBuilder({ lang, types, search, limit, exact, minScore })
+    body = entitiesQueryBuilder({ lang, types, search, limit, exact, minScore, claim })
   }
 
   const url = `${elasticHost}/${queryIndexes.join(',')}/_search`
@@ -50,4 +51,9 @@ const entitiesIndexesPerFilter = {
   wd: [ indexes.wikidata ],
   inv: [ indexes.entities ],
   [undefined]: [ indexes.wikidata, indexes.entities ],
+}
+
+const typeParameterError = (parameter, types) => {
+  const context = { givenTypes: types, validTypes: indexedEntitiesTypes }
+  throw error_.new(`${parameter} search is restricted to entity types`, 400, context)
 }

--- a/server/db/elasticsearch/formatters/entity.js
+++ b/server/db/elasticsearch/formatters/entity.js
@@ -207,16 +207,10 @@ const getEntityTerms = ({ labels, aliases }) => getMainFieldsWords({ labels, ali
 const getFlattenedClaims = claims => {
   const flattenedClaims = []
   for (const property in claims) {
-    if (!nonIndexedClaimsProperties.has(property)) {
-      const propertyClaims = claims[property]
-      for (const value of propertyClaims) {
-        flattenedClaims.push(`${property}=${value}`)
-      }
+    const propertyClaims = claims[property]
+    for (const value of propertyClaims) {
+      flattenedClaims.push(`${property}=${value}`)
     }
   }
   return flattenedClaims
 }
-
-const nonIndexedClaimsProperties = new Set([
-  'wdt:P31'
-])

--- a/server/db/elasticsearch/formatters/entity.js
+++ b/server/db/elasticsearch/formatters/entity.js
@@ -98,6 +98,8 @@ module.exports = async (entity, options = {}) => {
 
   entity.relationsTerms = await getRelationsTerms(entity)
 
+  entity.claim = getFlattenedClaims(entity.claims)
+
   // Those don't need to be indexed
   delete entity.claims
   delete entity.sitelinks
@@ -201,3 +203,20 @@ const indexedRelationsPerType = {
 
 // Not including descriptions
 const getEntityTerms = ({ labels, aliases }) => getMainFieldsWords({ labels, aliases })
+
+const getFlattenedClaims = claims => {
+  const flattenedClaims = []
+  for (const property in claims) {
+    if (!nonIndexedClaimsProperties.has(property)) {
+      const propertyClaims = claims[property]
+      for (const value of propertyClaims) {
+        flattenedClaims.push(`${property}=${value}`)
+      }
+    }
+  }
+  return flattenedClaims
+}
+
+const nonIndexedClaimsProperties = new Set([
+  'wdt:P31'
+])

--- a/server/db/elasticsearch/mappings/entities.js
+++ b/server/db/elasticsearch/mappings/entities.js
@@ -15,5 +15,6 @@ module.exports = {
     created: date,
     updated: date,
     popularity: integer,
+    claim: keyword,
   }
 }

--- a/server/db/elasticsearch/mappings/entities.js
+++ b/server/db/elasticsearch/mappings/entities.js
@@ -1,4 +1,4 @@
-const { flattenedTerms, integer, keyword, date, nested, terms } = require('./mappings_datatypes')
+const { flattenedTerms, integer, keyword, date, objectNotIndexed, terms } = require('./mappings_datatypes')
 
 module.exports = {
   properties: {
@@ -11,7 +11,7 @@ module.exports = {
     flattenedDescriptions: flattenedTerms,
     relationsTerms: flattenedTerms,
     uri: keyword,
-    images: nested,
+    images: objectNotIndexed,
     created: date,
     updated: date,
     popularity: integer,

--- a/server/db/elasticsearch/mappings/mappings_datatypes.js
+++ b/server/db/elasticsearch/mappings/mappings_datatypes.js
@@ -30,7 +30,8 @@ module.exports = {
   geoPoint: { type: 'geo_point' },
   integer: { type: 'integer' },
   keyword: { type: 'keyword' },
-  nested: { type: 'nested' },
+  // See https://www.elastic.co/guide/en/elasticsearch/reference/current/enabled.html
+  objectNotIndexed: { type: 'object', enabled: false },
   terms: { properties: getTermsProperties() },
   text: { type: 'text' },
   flattenedTerms: autocompleteText,

--- a/server/lib/sanitize/parameters.js
+++ b/server/lib/sanitize/parameters.js
@@ -183,7 +183,8 @@ const generics = {
       else return value
     },
     validate: _.isStrictlyPositiveInteger
-  }
+  },
+  string: nonEmptyString
 }
 
 const value = {

--- a/tests/api/search/entities.test.js
+++ b/tests/api/search/entities.test.js
@@ -141,6 +141,17 @@ describe('search:entities', () => {
         foundIds.should.not.containEql(humanB._id)
       })
     })
+
+    describe('claim', () => {
+      it('should find an entity by one of its relation claims', async () => {
+        const human = await createHuman()
+        const work = await createWorkWithAuthor(human)
+        await waitForIndexation('entities', work._id)
+        const results = await search({ types: 'works', claim: `wdt:P50=${human.uri}`, lang: 'en', filter: 'inv' })
+        const foundIds = _.map(results, 'id')
+        foundIds.should.containEql(work._id)
+      })
+    })
   })
 
   describe('humans', () => {

--- a/tests/api/search/entities.test.js
+++ b/tests/api/search/entities.test.js
@@ -160,6 +160,27 @@ describe('search:entities', () => {
         const foundIds = _.map(results, 'id')
         foundIds.should.containEql(work._id)
       })
+
+      it('should accept AND conditions', async () => {
+        const human = await createHuman()
+        const work = await createWorkWithAuthor(human)
+        await waitForIndexation('entities', work._id)
+        const results = await search({ types: 'works', claim: `wdt:P31=wd:Q47461344 wdt:P50=${human.uri}`, lang: 'en', filter: 'inv' })
+        const foundIds = _.map(results, 'id')
+        foundIds.should.containEql(work._id)
+        const results2 = await search({ types: 'works', claim: `wdt:P31=wd:Q2831984 wdt:P50=${human.uri}`, lang: 'en', filter: 'inv' })
+        const foundIds2 = _.map(results2, 'id')
+        foundIds2.should.not.containEql(work._id)
+      })
+
+      it('should accept a combination of AND and OR conditions', async () => {
+        const human = await createHuman()
+        const work = await createWorkWithAuthor(human)
+        await waitForIndexation('entities', work._id)
+        const results = await search({ types: 'works', claim: `wdt:P31=wd:Q47461344 wdt:P50=wd:Q535|wdt:P50=${human.uri}`, lang: 'en', filter: 'inv' })
+        const foundIds = _.map(results, 'id')
+        foundIds.should.containEql(work._id)
+      })
     })
   })
 

--- a/tests/api/search/entities.test.js
+++ b/tests/api/search/entities.test.js
@@ -37,18 +37,26 @@ describe('search:entities', () => {
     describe('exact', () => {
       it('should reject types that are not entity related', async () => {
         try {
-          await search({ types: [ 'groups', 'users' ], exact: true }).then(shouldNotBeCalled)
+          await search({ types: [ 'groups', 'users' ], search: 'foo', exact: true }).then(shouldNotBeCalled)
         } catch (err) {
           err.statusCode.should.equal(400)
           err.body.status_verbose.should.equal('exact search is restricted to entity types')
         }
       })
 
-      it('should return only exact matches', async () => {
+      // Ex: when requesting 'Myron Howe', 'Myron W Howe' will be considered an exact match
+      it('should return only results including exact matches of each words', async () => {
         const humanLabel = human.labels.en
         const results = await search({ types: 'humans', search: humanLabel, lang: 'en', exact: true })
         results.length.should.be.aboveOrEqual(1)
-        results.forEach(result => result.label.should.equal(humanLabel))
+        const labelWords = humanLabel.split(' ')
+        results.forEach(result => {
+          result.label.should.equal(humanLabel)
+          const resultLabelWords = result.label.split(' ')
+          labelWords.forEach(word => {
+            resultLabelWords.includes(word).should.be.true()
+          })
+        })
       })
 
       it('should accept a different word order', async () => {

--- a/tests/api/search/entities.test.js
+++ b/tests/api/search/entities.test.js
@@ -142,7 +142,14 @@ describe('search:entities', () => {
       })
     })
 
-    describe('claim', () => {
+    describe('claim', async () => {
+      let workAuthor, workWithAuthor
+      before(async () => {
+        workAuthor = await createHuman()
+        workWithAuthor = await createWorkWithAuthor(workAuthor)
+        await waitForIndexation('entities', workWithAuthor._id)
+      })
+
       it('should reject unknown properties', async () => {
         await search({ types: 'works', claim: 'wdt:P6=wd:Q535' })
         .then(shouldNotBeCalled)
@@ -162,42 +169,30 @@ describe('search:entities', () => {
       })
 
       it('should find an entity by one of its relation claims', async () => {
-        const human = await createHuman()
-        const work = await createWorkWithAuthor(human)
-        await waitForIndexation('entities', work._id)
-        const results = await search({ types: 'works', claim: `wdt:P50=${human.uri}`, lang: 'en', filter: 'inv' })
+        const results = await search({ types: 'works', claim: `wdt:P50=${workAuthor.uri}`, lang: 'en', filter: 'inv' })
         const foundIds = _.map(results, 'id')
-        foundIds.should.containEql(work._id)
+        foundIds.should.containEql(workWithAuthor._id)
       })
 
       it('should accept OR conditions', async () => {
-        const human = await createHuman()
-        const work = await createWorkWithAuthor(human)
-        await waitForIndexation('entities', work._id)
-        const results = await search({ types: 'works', claim: `wdt:P50=wd:Q535|wdt:P50=${human.uri}`, lang: 'en', filter: 'inv' })
+        const results = await search({ types: 'works', claim: `wdt:P50=wd:Q535|wdt:P50=${workAuthor.uri}`, lang: 'en', filter: 'inv' })
         const foundIds = _.map(results, 'id')
-        foundIds.should.containEql(work._id)
+        foundIds.should.containEql(workWithAuthor._id)
       })
 
       it('should accept AND conditions', async () => {
-        const human = await createHuman()
-        const work = await createWorkWithAuthor(human)
-        await waitForIndexation('entities', work._id)
-        const results = await search({ types: 'works', claim: `wdt:P31=wd:Q47461344 wdt:P50=${human.uri}`, lang: 'en', filter: 'inv' })
+        const results = await search({ types: 'works', claim: `wdt:P31=wd:Q47461344 wdt:P50=${workAuthor.uri}`, lang: 'en', filter: 'inv' })
         const foundIds = _.map(results, 'id')
-        foundIds.should.containEql(work._id)
-        const results2 = await search({ types: 'works', claim: `wdt:P31=wd:Q2831984 wdt:P50=${human.uri}`, lang: 'en', filter: 'inv' })
+        foundIds.should.containEql(workWithAuthor._id)
+        const results2 = await search({ types: 'works', claim: `wdt:P31=wd:Q2831984 wdt:P50=${workAuthor.uri}`, lang: 'en', filter: 'inv' })
         const foundIds2 = _.map(results2, 'id')
-        foundIds2.should.not.containEql(work._id)
+        foundIds2.should.not.containEql(workWithAuthor._id)
       })
 
       it('should accept a combination of AND and OR conditions', async () => {
-        const human = await createHuman()
-        const work = await createWorkWithAuthor(human)
-        await waitForIndexation('entities', work._id)
-        const results = await search({ types: 'works', claim: `wdt:P31=wd:Q47461344 wdt:P50=wd:Q535|wdt:P50=${human.uri}`, lang: 'en', filter: 'inv' })
+        const results = await search({ types: 'works', claim: `wdt:P31=wd:Q47461344 wdt:P50=wd:Q535|wdt:P50=${workAuthor.uri}`, lang: 'en', filter: 'inv' })
         const foundIds = _.map(results, 'id')
-        foundIds.should.containEql(work._id)
+        foundIds.should.containEql(workWithAuthor._id)
       })
     })
   })

--- a/tests/api/search/entities.test.js
+++ b/tests/api/search/entities.test.js
@@ -151,6 +151,15 @@ describe('search:entities', () => {
         const foundIds = _.map(results, 'id')
         foundIds.should.containEql(work._id)
       })
+
+      it('should accept OR conditions', async () => {
+        const human = await createHuman()
+        const work = await createWorkWithAuthor(human)
+        await waitForIndexation('entities', work._id)
+        const results = await search({ types: 'works', claim: `wdt:P50=wd:Q535|wdt:P50=${human.uri}`, lang: 'en', filter: 'inv' })
+        const foundIds = _.map(results, 'id')
+        foundIds.should.containEql(work._id)
+      })
     })
   })
 

--- a/tests/api/search/entities.test.js
+++ b/tests/api/search/entities.test.js
@@ -143,6 +143,24 @@ describe('search:entities', () => {
     })
 
     describe('claim', () => {
+      it('should reject unknown properties', async () => {
+        await search({ types: 'works', claim: 'wdt:P6=wd:Q535' })
+        .then(shouldNotBeCalled)
+        .catch(err => {
+          err.statusCode.should.equal(400)
+          err.body.status_verbose.should.equal('unknown property')
+        })
+      })
+
+      it('should reject invalid property values', async () => {
+        await search({ types: 'works', claim: 'wdt:P123=456' })
+        .then(shouldNotBeCalled)
+        .catch(err => {
+          err.statusCode.should.equal(400)
+          err.body.status_verbose.should.equal('invalid property value')
+        })
+      })
+
       it('should find an entity by one of its relation claims', async () => {
         const human = await createHuman()
         const work = await createWorkWithAuthor(human)

--- a/tests/api/search/search.test.js
+++ b/tests/api/search/search.test.js
@@ -11,7 +11,7 @@ describe('search:global', () => {
         await publicReq('get', '/api/search?lang=en&types=works').then(shouldNotBeCalled)
       } catch (err) {
         err.statusCode.should.equal(400)
-        err.body.status_verbose.should.equal('missing parameter in query: search')
+        err.body.status_verbose.should.equal('missing parameter in query: search or claim')
       }
     })
 

--- a/tests/api/search/search_entities.test.js
+++ b/tests/api/search/search_entities.test.js
@@ -149,60 +149,6 @@ describe('search:entities', () => {
         foundIds.should.not.containEql(humanB._id)
       })
     })
-
-    describe('claim', async () => {
-      let workAuthor, workWithAuthor
-      before(async () => {
-        workAuthor = await createHuman()
-        workWithAuthor = await createWorkWithAuthor(workAuthor)
-        await waitForIndexation('entities', workWithAuthor._id)
-      })
-
-      it('should reject unknown properties', async () => {
-        await search({ types: 'works', claim: 'wdt:P6=wd:Q535' })
-        .then(shouldNotBeCalled)
-        .catch(err => {
-          err.statusCode.should.equal(400)
-          err.body.status_verbose.should.equal('unknown property')
-        })
-      })
-
-      it('should reject invalid property values', async () => {
-        await search({ types: 'works', claim: 'wdt:P123=456' })
-        .then(shouldNotBeCalled)
-        .catch(err => {
-          err.statusCode.should.equal(400)
-          err.body.status_verbose.should.equal('invalid property value')
-        })
-      })
-
-      it('should find an entity by one of its relation claims', async () => {
-        const results = await search({ types: 'works', claim: `wdt:P50=${workAuthor.uri}`, lang: 'en', filter: 'inv' })
-        const foundIds = _.map(results, 'id')
-        foundIds.should.containEql(workWithAuthor._id)
-      })
-
-      it('should accept OR conditions', async () => {
-        const results = await search({ types: 'works', claim: `wdt:P50=wd:Q535|wdt:P50=${workAuthor.uri}`, lang: 'en', filter: 'inv' })
-        const foundIds = _.map(results, 'id')
-        foundIds.should.containEql(workWithAuthor._id)
-      })
-
-      it('should accept AND conditions', async () => {
-        const results = await search({ types: 'works', claim: `wdt:P31=wd:Q47461344 wdt:P50=${workAuthor.uri}`, lang: 'en', filter: 'inv' })
-        const foundIds = _.map(results, 'id')
-        foundIds.should.containEql(workWithAuthor._id)
-        const results2 = await search({ types: 'works', claim: `wdt:P31=wd:Q2831984 wdt:P50=${workAuthor.uri}`, lang: 'en', filter: 'inv' })
-        const foundIds2 = _.map(results2, 'id')
-        foundIds2.should.not.containEql(workWithAuthor._id)
-      })
-
-      it('should accept a combination of AND and OR conditions', async () => {
-        const results = await search({ types: 'works', claim: `wdt:P31=wd:Q47461344 wdt:P50=wd:Q535|wdt:P50=${workAuthor.uri}`, lang: 'en', filter: 'inv' })
-        const foundIds = _.map(results, 'id')
-        foundIds.should.containEql(workWithAuthor._id)
-      })
-    })
   })
 
   describe('humans', () => {

--- a/tests/api/search/search_entities_by_claim.test.js
+++ b/tests/api/search/search_entities_by_claim.test.js
@@ -1,0 +1,59 @@
+const _ = require('builders/utils')
+require('should')
+const { createHuman, createWorkWithAuthor } = require('../fixtures/entities')
+const { shouldNotBeCalled } = require('../utils/utils')
+const { search, waitForIndexation } = require('../utils/search')
+
+describe('search:entities:by-claim', async () => {
+  let workAuthor, workWithAuthor
+  before(async () => {
+    workAuthor = await createHuman()
+    workWithAuthor = await createWorkWithAuthor(workAuthor)
+    await waitForIndexation('entities', workWithAuthor._id)
+  })
+
+  it('should reject unknown properties', async () => {
+    await search({ types: 'works', claim: 'wdt:P6=wd:Q535' })
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.statusCode.should.equal(400)
+      err.body.status_verbose.should.equal('unknown property')
+    })
+  })
+
+  it('should reject invalid property values', async () => {
+    await search({ types: 'works', claim: 'wdt:P123=456' })
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.statusCode.should.equal(400)
+      err.body.status_verbose.should.equal('invalid property value')
+    })
+  })
+
+  it('should find an entity by one of its relation claims', async () => {
+    const results = await search({ types: 'works', claim: `wdt:P50=${workAuthor.uri}`, lang: 'en', filter: 'inv' })
+    const foundIds = _.map(results, 'id')
+    foundIds.should.containEql(workWithAuthor._id)
+  })
+
+  it('should accept OR conditions', async () => {
+    const results = await search({ types: 'works', claim: `wdt:P50=wd:Q535|wdt:P50=${workAuthor.uri}`, lang: 'en', filter: 'inv' })
+    const foundIds = _.map(results, 'id')
+    foundIds.should.containEql(workWithAuthor._id)
+  })
+
+  it('should accept AND conditions', async () => {
+    const results = await search({ types: 'works', claim: `wdt:P31=wd:Q47461344 wdt:P50=${workAuthor.uri}`, lang: 'en', filter: 'inv' })
+    const foundIds = _.map(results, 'id')
+    foundIds.should.containEql(workWithAuthor._id)
+    const results2 = await search({ types: 'works', claim: `wdt:P31=wd:Q2831984 wdt:P50=${workAuthor.uri}`, lang: 'en', filter: 'inv' })
+    const foundIds2 = _.map(results2, 'id')
+    foundIds2.should.not.containEql(workWithAuthor._id)
+  })
+
+  it('should accept a combination of AND and OR conditions', async () => {
+    const results = await search({ types: 'works', claim: `wdt:P31=wd:Q47461344 wdt:P50=wd:Q535|wdt:P50=${workAuthor.uri}`, lang: 'en', filter: 'inv' })
+    const foundIds = _.map(results, 'id')
+    foundIds.should.containEql(workWithAuthor._id)
+  })
+})

--- a/tests/api/search/search_entities_by_claim.test.js
+++ b/tests/api/search/search_entities_by_claim.test.js
@@ -3,6 +3,7 @@ require('should')
 const { createHuman, createWorkWithAuthor } = require('../fixtures/entities')
 const { shouldNotBeCalled } = require('../utils/utils')
 const { search, waitForIndexation } = require('../utils/search')
+const someOtherAuthorUri = 'inv:00000000000000000000000000000000'
 
 describe('search:entities:by-claim', async () => {
   let workAuthor, workWithAuthor
@@ -37,7 +38,7 @@ describe('search:entities:by-claim', async () => {
   })
 
   it('should accept OR conditions', async () => {
-    const results = await search({ types: 'works', claim: `wdt:P50=wd:Q535|wdt:P50=${workAuthor.uri}`, lang: 'en', filter: 'inv' })
+    const results = await search({ types: 'works', claim: `wdt:P50=${workAuthor.uri}|wdt:P50=${someOtherAuthorUri}`, lang: 'en', filter: 'inv' })
     const foundIds = _.map(results, 'id')
     foundIds.should.containEql(workWithAuthor._id)
   })
@@ -52,7 +53,7 @@ describe('search:entities:by-claim', async () => {
   })
 
   it('should accept a combination of AND and OR conditions', async () => {
-    const results = await search({ types: 'works', claim: `wdt:P31=wd:Q47461344 wdt:P50=wd:Q535|wdt:P50=${workAuthor.uri}`, lang: 'en', filter: 'inv' })
+    const results = await search({ types: 'works', claim: `wdt:P31=wd:Q47461344 wdt:P50=${workAuthor.uri}|wdt:P50=${someOtherAuthorUri}`, lang: 'en', filter: 'inv' })
     const foundIds = _.map(results, 'id')
     foundIds.should.containEql(workWithAuthor._id)
   })

--- a/tests/api/search/search_entities_by_claim.test.js
+++ b/tests/api/search/search_entities_by_claim.test.js
@@ -57,4 +57,18 @@ describe('search:entities:by-claim', async () => {
     const foundIds = _.map(results, 'id')
     foundIds.should.containEql(workWithAuthor._id)
   })
+
+  it('should accept a claim and a search', async () => {
+    const anotherWorkWithThatSameAuthor = await createWorkWithAuthor(workAuthor)
+    await waitForIndexation('entities', anotherWorkWithThatSameAuthor._id)
+    const workLabel = workWithAuthor.labels.en
+    const resultsWithOnlyClaimFilter = await search({ types: 'works', claim: `wdt:P50=${workAuthor.uri}`, lang: 'en', filter: 'inv' })
+    const foundIdsA = _.map(resultsWithOnlyClaimFilter, 'id')
+    foundIdsA.should.containEql(workWithAuthor._id)
+    foundIdsA.should.containEql(anotherWorkWithThatSameAuthor._id)
+    const resultsWithClaimFilterAndSearch = await search({ types: 'works', claim: `wdt:P50=${workAuthor.uri}`, search: workLabel, exact: true, lang: 'en', filter: 'inv' })
+    const foundIdsB = _.map(resultsWithClaimFilterAndSearch, 'id')
+    foundIdsB.should.containEql(workWithAuthor._id)
+    foundIdsB.should.not.containEql(anotherWorkWithThatSameAuthor._id)
+  })
 })

--- a/tests/api/utils/search.js
+++ b/tests/api/utils/search.js
@@ -46,17 +46,18 @@ const waitForIndexation = async (indexBaseName, id) => {
 
 module.exports = {
   search: async (...args) => {
-    let types, search, lang, filter, limit, exact, minScore
-    if (args.length === 1) ({ types, search, lang, filter, limit, exact, minScore } = args[0])
+    let types, search, lang, filter, limit, exact, minScore, claim
+    if (args.length === 1) ({ types, search, lang, filter, limit, exact, minScore, claim } = args[0])
     else [ types, search, lang, filter ] = args
     lang = lang || 'en'
     limit = limit || 10
     exact = exact || false
     if (_.isArray(types)) types = types.join('|')
-    search = encodeURIComponent(search)
-    let url = `${endpoint}?types=${types}&lang=${lang}&search=${search}&limit=${limit}&exact=${exact}`
+    let url = `${endpoint}?types=${types}&lang=${lang}&limit=${limit}&exact=${exact}`
+    if (search) url += `&search=${encodeURIComponent(search)}`
     if (filter) url += `&filter=${filter}`
     if (minScore) url += `&min-score=${minScore}`
+    if (claim) url += `&claim=${encodeURIComponent(claim)}`
     const { results } = await publicReq('get', url)
     return results
   },


### PR DESCRIPTION
This PR proposes a first implementation of search claim filters, inspired by [Wikibase `haswbstatement`](https://www.mediawiki.org/wiki/Help:Extension:WikibaseCirrusSearch#haswbstatement).

Implemented:
* [x] `AND`
* [x] `OR`
~~* [ ] `NOT`~~ (maybe it's fine to let that one out from this PR?)

Those filters would allow, for instance, to add search fields on authors layouts: in that example, the `claim` parameter would be set to `wdt:P50=${author.uri}` (or actually more probably `wdt:P50=${author.uri}|wdt:P58=${author.uri}|wdt:P110=${author.uri}|wdt:P6338=${author.uri}` to be complete)

This branch is based on `213-relations-search`, so most commits displayed below at the time of this message actually belong to #529, which should thus be considered first