### PR TITLE
deleted users contributions

### DIFF
--- a/server/controllers/user/lib/authorized_user_data_pickers.js
+++ b/server/controllers/user/lib/authorized_user_data_pickers.js
@@ -17,6 +17,8 @@ module.exports = {
   omitPrivateData: (reqUserId, networkIds, extraAttribute) => {
     const attributes = getAttributes(extraAttribute)
     return userDoc => {
+      if (userDoc.type === 'deletedUser') return userDoc
+
       const userId = userDoc._id
       if (userId === reqUserId) return ownerSafeData(userDoc)
 

--- a/server/controllers/user/lib/user.js
+++ b/server/controllers/user/lib/user.js
@@ -84,7 +84,6 @@ const user_ = module.exports = {
     ])
 
     return usersDocs
-    .filter(user => user && user.type !== 'deletedUser')
     .map(omitPrivateData(reqUserId, networkIds, extraAttribute))
   },
 

--- a/server/db/couchdb/design_docs/users.json
+++ b/server/db/couchdb/design_docs/users.json
@@ -6,7 +6,7 @@
       "map": "(doc)->\n  if doc.type is 'user'\n    emit doc.email.toLowerCase(), null"
     },
     "byUsername": {
-      "map": "(doc)->\n  if doc.type is 'user' or doc.special\n    username = doc.username.toLowerCase()\n    emit username, null\n    if doc.stableUsername?\n      stableUsername = doc.stableUsername.toLowerCase()\n      if stableUsername isnt username then emit stableUsername, null"
+      "map": "(doc)->\n  if doc.type is 'user' or doc.type is 'deletedUser' or doc.special\n    username = doc.username.toLowerCase()\n    emit username, null\n    if doc.stableUsername?\n      stableUsername = doc.stableUsername.toLowerCase()\n      if stableUsername isnt username then emit stableUsername, null"
     },
     "byCreation": {
       "map": "(doc)->\n  if doc.type is 'user'\n    emit doc.created, doc.username"

--- a/tests/api/users/by_ids.test.js
+++ b/tests/api/users/by_ids.test.js
@@ -1,7 +1,8 @@
 const _ = require('builders/utils')
-const { shouldNotBeCalled, rethrowShouldNotBeCalledErrors } = require('tests/api/utils/utils')
+const { shouldNotBeCalled, rethrowShouldNotBeCalledErrors, getReservedUser } = require('tests/api/utils/utils')
 const { publicReq, authReq, customAuthReq, getUser, getUserB } = require('../utils/utils')
 const { getTwoFriends } = require('../fixtures/users')
+const { deleteUser } = require('../utils/users')
 
 const endpoint = '/api/users?action=by-ids'
 
@@ -51,5 +52,12 @@ describe('users:by-ids', () => {
     const ids = users.map(_.property('_id'))
     const res = await publicReq('get', `${endpoint}&ids=${ids.join('|')}`)
     _.keys(res.users).should.deepEqual(ids)
+  })
+
+  it('should get deleted users', async () => {
+    const user = await getReservedUser()
+    await deleteUser(user)
+    const res = await publicReq('get', `${endpoint}&ids=${user._id}`)
+    res.users[user._id].should.be.ok()
   })
 })

--- a/tests/api/users/by_username.test.js
+++ b/tests/api/users/by_username.test.js
@@ -1,10 +1,11 @@
 const _ = require('builders/utils')
 const should = require('should')
-const { publicReq, authReq, customAuthReq, getUser, getUserB, shouldNotBeCalled, rethrowShouldNotBeCalledErrors } = require('tests/api/utils/utils')
+const { publicReq, authReq, customAuthReq, getUser, getUserB, shouldNotBeCalled, rethrowShouldNotBeCalledErrors, getReservedUser } = require('tests/api/utils/utils')
 const { createUser } = require('../fixtures/users')
 const randomString = require('lib/utils/random_string')
 const { getTwoFriends } = require('../fixtures/users')
 const { Wait } = require('lib/promises')
+const { deleteUser } = require('../utils/users')
 const specialUsersNames = Object.keys(require('db/couchdb/hard_coded_documents').users)
 
 const endpoint = '/api/users?action=by-usernames'
@@ -65,5 +66,12 @@ describe('users:by-usernames', () => {
   it('should get a special user', async () => {
     const res = await publicReq('get', `${endpoint}&usernames=${specialUsersNames.join('|')}`)
     Object.keys(res.users).should.deepEqual(specialUsersNames)
+  })
+
+  it('should get a deleted user', async () => {
+    const user = await getReservedUser()
+    await deleteUser(user)
+    const res = await publicReq('get', `${endpoint}&usernames=${user.username}`)
+    res.users[user.username.toLowerCase()].should.be.ok()
   })
 })


### PR DESCRIPTION
By returning deleted users on `/api/users?action=by-ids` and  `/api/users?action=by-usernames`, this PR would allow the client to display relevant informations on a deleted user's contributions: currently, you just get a blank page with an error in console ([example](https://inventaire.io/users/1c9d665a3322cea4df5a37a419e00db4/contributions))