### PR TITLE
controllers deboilerplatification

### DIFF
--- a/server/controllers/shelves/update.js
+++ b/server/controllers/shelves/update.js
@@ -1,8 +1,4 @@
-const responses_ = require('lib/responses')
-const error_ = require('lib/error/error')
-const { Track } = require('lib/track')
-const shelves_ = require('controllers/shelves/lib/shelves')
-const { sanitize } = require('lib/sanitize/sanitize')
+const { updateAttributes } = require('controllers/shelves/lib/shelves')
 
 const sanitization = {
   shelf: {},
@@ -14,10 +10,13 @@ const sanitization = {
   name: { optional: true }
 }
 
-module.exports = (req, res, next) => {
-  sanitize(req, res, sanitization)
-  .then(shelves_.updateAttributes)
-  .then(responses_.Wrap(res, 'shelf'))
-  .then(Track(req, [ 'shelf', 'update' ]))
-  .catch(error_.Handler(req, res))
+const controller = async params => {
+  const shelf = await updateAttributes(params)
+  return { shelf }
+}
+
+module.exports = {
+  sanitization,
+  controller,
+  track: [ 'shelf', 'update' ]
 }

--- a/server/lib/actions_controllers.js
+++ b/server/lib/actions_controllers.js
@@ -1,11 +1,14 @@
-const _ = require('builders/utils')
+const { someMatch } = require('builders/utils')
 const error_ = require('lib/error/error')
 const validateObject = require('lib/validate_object')
 const { rolesByAccess } = require('./get_user_access_levels')
+const { send } = require('./responses')
+const { sanitizeSync } = require('./sanitize/sanitize')
+const { track } = require('./track')
 
 module.exports = controllers => {
   const actions = getActions(controllers)
-  return (req, res) => {
+  return async (req, res) => {
     // Accepting the action to be passed either as a query string
     // or as a body parameter for more flexibility
     const action = req.query.action || req.body.action
@@ -26,8 +29,23 @@ module.exports = controllers => {
       if (req.user.roles) roles = roles.concat(req.user.roles)
     }
 
-    if (_.someMatch(roles, actionData.access)) actionData.controller(req, res)
-    else error_.unauthorizedApiAccess(req, res, { roles, requiredAccessLevel: actionData.access })
+    if (!someMatch(roles, actionData.access)) {
+      return error_.unauthorizedApiAccess(req, res, { roles, requiredAccessLevel: actionData.access })
+    }
+
+    const { controller, sanitization, trackActionArray } = actionData
+    try {
+      if (sanitization) {
+        const params = sanitizeSync(req, res, sanitization)
+        const result = await controller(params, req, res)
+        send(res, result)
+        if (trackActionArray) track(req, trackActionArray)
+      } else {
+        await controller(req, res)
+      }
+    } catch (err) {
+      error_.handler(req, res, err)
+    }
   }
 }
 
@@ -41,12 +59,25 @@ const getActions = controllers => {
 
   controllerKeys.forEach(access => {
     for (const action in controllers[access]) {
-      actions[action] = {
-        controller: controllers[access][action],
-        access: rolesByAccess[access]
-      }
+      const controllerData = controllers[access][action]
+      actions[action] = getActionData(access, controllerData)
     }
   })
 
   return actions
+}
+
+const getActionData = (access, controllerData) => {
+  let controller, sanitization, trackActionArray
+  if (controllerData.sanitization) {
+    ({ controller, sanitization, track: trackActionArray } = controllerData)
+  } else {
+    controller = controllerData
+  }
+  return {
+    access: rolesByAccess[access],
+    controller,
+    sanitization,
+    trackActionArray,
+  }
 }

--- a/server/lib/actions_controllers.js
+++ b/server/lib/actions_controllers.js
@@ -5,6 +5,7 @@ const { rolesByAccess } = require('./get_user_access_levels')
 const { send } = require('./responses')
 const { sanitizeSync } = require('./sanitize/sanitize')
 const { track } = require('./track')
+const assert_ = require('./utils/assert_types')
 
 module.exports = controllers => {
   const actions = getActions(controllers)
@@ -71,9 +72,12 @@ const getActionData = (access, controllerData) => {
   let controller, sanitization, trackActionArray
   if (controllerData.sanitization) {
     ({ controller, sanitization, track: trackActionArray } = controllerData)
+    assert_.object(sanitization)
+    if (trackActionArray) assert_.array(trackActionArray)
   } else {
     controller = controllerData
   }
+  assert_.function(controller)
   return {
     access: rolesByAccess[access],
     controller,


### PR DESCRIPTION
This PR proposes to move controllers boilerplate to [`server/lib/actions_controllers.js`](https://github.com/inventaire/inventaire/blob/a930c1c/server/lib/actions_controllers.js), taking `server/controllers/shelves/update.js` as an example of what could be done (leaving the application in bulk of this new format to another PR)