### PR TITLE
controllers: extract non-action-related logic from ActionsControllers function

### DIFF
--- a/server/lib/actions_controllers.js
+++ b/server/lib/actions_controllers.js
@@ -22,13 +22,11 @@ module.exports = controllers => {
   return async (req, res) => {
     // Accepting the action to be passed either as a query string
     // or as a body parameter for more flexibility
-    let action = req.query.action || req.body.action
+    const action = req.query.action || req.body.action || 'default'
 
-    if (action == null && actionsControllersParams.default == null) {
+    if (action === 'default' && actionsControllersParams.default == null) {
       return error_.bundleMissingQuery(req, res, 'action')
     }
-
-    action = action || 'default'
 
     const controllerParams = actionsControllersParams[action]
     if (controllerParams == null) return error_.unknownAction(req, res)

--- a/server/lib/actions_controllers.js
+++ b/server/lib/actions_controllers.js
@@ -1,87 +1,68 @@
-const { someMatch } = require('builders/utils')
 const error_ = require('lib/error/error')
 const validateObject = require('lib/validate_object')
 const { rolesByAccess } = require('./user_access_levels')
-const { send } = require('./responses')
-const { sanitize } = require('./sanitize/sanitize')
-const { track } = require('./track')
-const assert_ = require('./utils/assert_types')
+const { controllerWrapper, validateControllerWrapperParams } = require('./controller_wrapper')
+
+// A function to route requests to an endpoint to sub-endpoints
+// identified by their 'action' names:
+//
+// controllers = {
+//   [accessLevel]: {
+//     [actionA]: controller,
+//     [actionB]: {
+//       sanitization,
+//       controller,
+//       track,
+//     },
+//   }
+// }
 
 module.exports = controllers => {
-  const actions = getActions(controllers)
+  const actionsControllersParams = getActionsControllersParams(controllers)
   return async (req, res) => {
     // Accepting the action to be passed either as a query string
     // or as a body parameter for more flexibility
-    const action = req.query.action || req.body.action
+    let action = req.query.action || req.body.action
 
-    if (action == null && actions.default == null) {
+    if (action == null && actionsControllersParams.default == null) {
       return error_.bundleMissingQuery(req, res, 'action')
     }
 
-    const actionData = action ? actions[action] : actions.default
-    if (actionData == null) {
-      return error_.unknownAction(req, res)
-    }
+    action = action || 'default'
 
-    // user.roles doesn't contain 'public' and 'authentified', but those are needed to resolve access levels
-    let roles = [ 'public' ]
-    if (req.user) {
-      roles.push('authentified')
-      if (req.user.roles) roles = roles.concat(req.user.roles)
-    }
+    const controllerParams = actionsControllersParams[action]
+    if (controllerParams == null) return error_.unknownAction(req, res)
 
-    if (!someMatch(roles, actionData.access)) {
-      return error_.unauthorizedApiAccess(req, res, { roles, requiredAccessLevel: actionData.access })
-    }
-
-    const { controller, sanitization, trackActionArray } = actionData
-    try {
-      if (sanitization) {
-        const params = sanitize(req, res, sanitization)
-        const result = await controller(params, req, res)
-        send(res, result)
-        if (trackActionArray) track(req, trackActionArray)
-      } else {
-        await controller(req, res)
-      }
-    } catch (err) {
-      error_.handler(req, res, err)
-    }
+    return controllerWrapper(controllerParams, req, res)
   }
 }
 
 const accessLevels = Object.keys(rolesByAccess)
 
-const getActions = controllers => {
+const getActionsControllersParams = controllers => {
   validateObject(controllers, accessLevels, 'object')
 
   const controllerKeys = Object.keys(controllers)
-  const actions = {}
+  const actionsControllersParams = {}
 
   controllerKeys.forEach(access => {
     for (const action in controllers[access]) {
-      const controllerData = controllers[access][action]
-      actions[action] = getActionData(access, controllerData)
+      const actionData = controllers[access][action]
+      actionsControllersParams[action] = getActionControllerParams(access, actionData)
     }
   })
 
-  return actions
+  return actionsControllersParams
 }
 
-const getActionData = (access, controllerData) => {
-  let controller, sanitization, trackActionArray
-  if (controllerData.sanitization) {
-    ({ controller, sanitization, track: trackActionArray } = controllerData)
-    assert_.object(sanitization)
-    if (trackActionArray) assert_.array(trackActionArray)
+const getActionControllerParams = (access, actionData) => {
+  let controller, sanitization, track
+  if (actionData.sanitization) {
+    ({ controller, sanitization, track } = actionData)
   } else {
-    controller = controllerData
+    controller = actionData
   }
-  assert_.function(controller)
-  return {
-    access: rolesByAccess[access],
-    controller,
-    sanitization,
-    trackActionArray,
-  }
+  const controllerParams = { access, controller, sanitization, track }
+  validateControllerWrapperParams(controllerParams)
+  return controllerParams
 }

--- a/server/lib/controller_wrapper.js
+++ b/server/lib/controller_wrapper.js
@@ -1,0 +1,72 @@
+const { someMatch } = require('builders/utils')
+const error_ = require('lib/error/error')
+const validateObject = require('lib/validate_object')
+const { rolesByAccess } = require('./user_access_levels')
+const { send } = require('./responses')
+const { sanitize } = require('./sanitize/sanitize')
+const { track } = require('./track')
+const assert_ = require('./utils/assert_types')
+
+// A function to do the basic operations most controllers will need:
+// - check access rights
+// - sanitize input
+// - send data for valid response
+// - handle errors
+// - track actions
+const controllerWrapper = async (controllerParams, req, res) => {
+  const { access, controller, sanitization, track: trackActionArray } = controllerParams
+  // user.roles doesn't contain 'public' and 'authentified', but those are needed to resolve access levels
+  const roles = [ 'public' ]
+  if (req.user) {
+    roles.push('authentified')
+    if (req.user.roles) roles.push(...req.user.roles)
+  }
+
+  if (!someMatch(roles, rolesByAccess[access])) {
+    return error_.unauthorizedApiAccess(req, res, { roles, requiredAccessLevel: access })
+  }
+
+  try {
+    if (sanitization) {
+      const params = sanitize(req, res, sanitization)
+      const result = await controller(params, req, res)
+      send(res, result)
+      if (trackActionArray) track(req, trackActionArray)
+    } else {
+      await controller(req, res)
+    }
+  } catch (err) {
+    error_.handler(req, res, err)
+  }
+}
+
+const ControllerWrapper = controllerParams => {
+  validateControllerWrapperParams(controllerParams)
+  return controllerWrapper.bind(null, controllerParams)
+}
+
+// Allow to validate parameters separately, so that
+// consumers of controllerWrapper can run this validate only once
+// when the server is starting (rather than for each request)
+const validateControllerWrapperParams = controllerParams => {
+  validateObject(controllerParams, controllerParamsKeys)
+  const { access, controller, sanitization, track: trackActionArray } = controllerParams
+  assert_.string(access)
+  assert_.array(rolesByAccess[access])
+  assert_.function(controller)
+  if (sanitization) assert_.object(sanitization)
+  if (trackActionArray) assert_.array(trackActionArray)
+}
+
+const controllerParamsKeys = [
+  'access',
+  'controller',
+  'sanitization',
+  'track',
+]
+
+module.exports = {
+  controllerWrapper,
+  ControllerWrapper,
+  validateControllerWrapperParams
+}

--- a/server/lib/sanitize/sanitize.js
+++ b/server/lib/sanitize/sanitize.js
@@ -39,10 +39,7 @@ const sanitize = (req, res, configs) => {
   return input
 }
 
-module.exports = {
-  sanitize,
-  sanitizeAsync: async (req, res, configs) => sanitize(req, res, configs)
-}
+module.exports = { sanitize }
 
 const optionsNames = new Set([ 'nonJsonBody' ])
 

--- a/tests/unit/libs/046-sanitize.js
+++ b/tests/unit/libs/046-sanitize.js
@@ -1,33 +1,17 @@
 const should = require('should')
-const { sanitize, sanitizeAsync } = require('lib/sanitize/sanitize')
+const { sanitize } = require('lib/sanitize/sanitize')
 const { shouldNotBeCalled } = require('../utils')
 
 describe('sanitize', () => {
-  describe('sanitize', () => {
-    it('should be a function', () => {
-      sanitize.should.be.a.Function()
-    })
-  })
-
-  describe('sanitizeAsync', () => {
-    it('should be a function', () => {
-      sanitizeAsync.should.be.a.Function()
-    })
-
-    it('should return a promise', done => {
-      // eslint-disable-next-line handle-callback-err
-      sanitizeAsync().catch(err => done())
-    })
-  })
-
   it('should reject invalid req objects based on req.query existance', async () => {
     const req = {}
     const configs = {}
-    await sanitizeAsync(req, {}, configs)
-    .then(shouldNotBeCalled)
-    .catch(err => {
+    try {
+      sanitize(req, {}, configs)
+      shouldNotBeCalled()
+    } catch (err) {
       err.message.should.startWith('TypeError: expected object, got undefined')
-    })
+    }
   })
 
   it('should add a warning for unknown parameter (server error)', async () => {
@@ -105,11 +89,12 @@ describe('sanitize', () => {
       const req = { query: { lang: '1212515' } }
       const res = {}
       const configs = { lang: { optional: true } }
-      await sanitizeAsync(req, res, configs)
-      .then(shouldNotBeCalled)
-      .catch(err => {
+      try {
+        sanitize(req, res, configs)
+        shouldNotBeCalled()
+      } catch (err) {
         err.message.should.equal('invalid lang: 1212515')
-      })
+      }
     })
   })
 
@@ -117,11 +102,12 @@ describe('sanitize', () => {
     it('should not return the value', async () => {
       const req = { query: { password: 'a' } }
       const configs = { password: {} }
-      await sanitizeAsync(req, {}, configs)
-      .then(shouldNotBeCalled)
-      .catch(err => {
+      try {
+        sanitize(req, {}, configs)
+        shouldNotBeCalled()
+      } catch (err) {
         err.context.value.should.equal('*')
-      })
+      }
     })
   })
 
@@ -149,11 +135,12 @@ describe('sanitize', () => {
       }
       const { foo } = sanitize({ query: { foo: 'a' } }, res, configs)
       foo.should.equal('a')
-      await sanitizeAsync({ query: { foo: 'd' } }, res, configs)
-      .then(shouldNotBeCalled)
-      .catch(err => {
+      try {
+        sanitize({ query: { foo: 'd' } }, res, configs)
+        shouldNotBeCalled()
+      } catch (err) {
         err.message.should.startWith('invalid foo')
-      })
+      }
     })
 
     it('should throw when passed an invalid generic name', async () => {
@@ -164,11 +151,12 @@ describe('sanitize', () => {
           generic: 'bar'
         }
       }
-      await sanitizeAsync(req, res, configs)
-      .then(shouldNotBeCalled)
-      .catch(err => {
+      try {
+        sanitize(req, res, configs)
+        shouldNotBeCalled()
+      } catch (err) {
         err.message.should.equal('invalid generic name')
-      })
+      }
     })
 
     it('should clone default values', async () => {
@@ -217,31 +205,34 @@ describe('sanitize', () => {
     it('should reject negative values', async () => {
       const req = { query: { limit: '-5' } }
       const configs = { limit: {} }
-      await sanitizeAsync(req, {}, configs)
-      .then(shouldNotBeCalled)
-      .catch(err => {
+      try {
+        sanitize(req, {}, configs)
+        shouldNotBeCalled()
+      } catch (err) {
         err.message.should.equal('invalid limit: -5')
-      })
+      }
     })
 
     it('should reject non-integer values', async () => {
       const req = { query: { limit: '5.5' } }
       const configs = { limit: {} }
-      await sanitizeAsync(req, {}, configs)
-      .then(shouldNotBeCalled)
-      .catch(err => {
+      try {
+        sanitize(req, {}, configs)
+        shouldNotBeCalled()
+      } catch (err) {
         err.message.should.equal('invalid limit: 5.5')
-      })
+      }
     })
 
     it('should reject non-number values', async () => {
       const req = { query: { limit: 'bla' } }
       const configs = { limit: {} }
-      await sanitizeAsync(req, {}, configs)
-      .then(shouldNotBeCalled)
-      .catch(err => {
+      try {
+        sanitize(req, {}, configs)
+        shouldNotBeCalled()
+      } catch (err) {
         err.message.should.equal('invalid limit: bla')
-      })
+      }
     })
   })
 
@@ -249,11 +240,12 @@ describe('sanitize', () => {
     it('should reject invalid uuids values', async () => {
       const req = { query: { user: 'foo' } }
       const configs = { user: {} }
-      await sanitizeAsync(req, {}, configs)
-      .then(shouldNotBeCalled)
-      .catch(err => {
+      try {
+        sanitize(req, {}, configs)
+        shouldNotBeCalled()
+      } catch (err) {
         err.message.should.equal('invalid user: foo')
-      })
+      }
     })
 
     it('should accept valid uuids', async () => {
@@ -269,21 +261,23 @@ describe('sanitize', () => {
     it('should reject a token of invalid type', async () => {
       const req = { query: { token: 1251251 } }
       const configs = { token: { length: 32 } }
-      await sanitizeAsync(req, {}, configs)
-      .then(shouldNotBeCalled)
-      .catch(err => {
+      try {
+        sanitize(req, {}, configs)
+        shouldNotBeCalled()
+      } catch (err) {
         err.message.should.equal('invalid token: expected string, got number')
-      })
+      }
     })
 
     it('should reject an invalid token', async () => {
       const req = { query: { token: 'foo' } }
       const configs = { token: { length: 32 } }
-      await sanitizeAsync(req, {}, configs)
-      .then(shouldNotBeCalled)
-      .catch(err => {
+      try {
+        sanitize(req, {}, configs)
+        shouldNotBeCalled()
+      } catch (err) {
         err.message.should.equal('invalid token length: expected 32, got 3')
-      })
+      }
     })
   })
 
@@ -291,11 +285,12 @@ describe('sanitize', () => {
     it('should stringify invalid values', async () => {
       const req = { query: { foo: [ 123 ] } }
       const configs = { foo: { generic: 'object' } }
-      await sanitizeAsync(req, {}, configs)
-      .then(shouldNotBeCalled)
-      .catch(err => {
+      try {
+        sanitize(req, {}, configs)
+        shouldNotBeCalled()
+      } catch (err) {
         err.message.should.equal('invalid foo: [123]')
-      })
+      }
     })
   })
 
@@ -303,21 +298,23 @@ describe('sanitize', () => {
     it('should reject invalid type', async () => {
       const req = { query: { uris: 1251251 } }
       const configs = { uris: {} }
-      await sanitizeAsync(req, {}, configs)
-      .then(shouldNotBeCalled)
-      .catch(err => {
+      try {
+        sanitize(req, {}, configs)
+        shouldNotBeCalled()
+      } catch (err) {
         err.message.should.equal('invalid uris: expected array, got number')
-      })
+      }
     })
 
     it('should reject array including invalid values', async () => {
       const req = { query: { uris: [ 1251251 ] } }
       const configs = { uris: {} }
-      await sanitizeAsync(req, {}, configs)
-      .then(shouldNotBeCalled)
-      .catch(err => {
+      try {
+        sanitize(req, {}, configs)
+        shouldNotBeCalled()
+      } catch (err) {
         err.message.should.startWith('invalid uri: expected uri, got')
-      })
+      }
     })
 
     it('should accept uris as an array of strings', async () => {
@@ -339,11 +336,12 @@ describe('sanitize', () => {
     it('should reject invalid type', async () => {
       const req = { query: { uri: 1251251 } }
       const configs = { uri: {} }
-      await sanitizeAsync(req, {}, configs)
-      .then(shouldNotBeCalled)
-      .catch(err => {
+      try {
+        sanitize(req, {}, configs)
+        shouldNotBeCalled()
+      } catch (err) {
         err.message.should.startWith('invalid uri')
-      })
+      }
     })
   })
 
@@ -351,21 +349,23 @@ describe('sanitize', () => {
     it('should reject invalid type', async () => {
       const req = { query: { ids: 1251251 } }
       const configs = { ids: {} }
-      await sanitizeAsync(req, {}, configs)
-      .then(shouldNotBeCalled)
-      .catch(err => {
+      try {
+        sanitize(req, {}, configs)
+        shouldNotBeCalled()
+      } catch (err) {
         err.message.should.equal('invalid ids: expected array, got number')
-      })
+      }
     })
 
     it('should reject array including invalid values', async () => {
       const req = { query: { ids: [ 1251251 ] } }
       const configs = { ids: {} }
-      await sanitizeAsync(req, {}, configs)
-      .then(shouldNotBeCalled)
-      .catch(err => {
+      try {
+        sanitize(req, {}, configs)
+        shouldNotBeCalled()
+      } catch (err) {
         err.message.should.startWith('invalid id: expected id, got')
-      })
+      }
     })
 
     it('should deduplicate ids', async () => {
@@ -379,11 +379,12 @@ describe('sanitize', () => {
     it('should reject an empty array', async () => {
       const req = { query: { ids: [] } }
       const configs = { ids: {} }
-      await sanitizeAsync(req, {}, configs)
-      .then(shouldNotBeCalled)
-      .catch(err => {
+      try {
+        sanitize(req, {}, configs)
+        shouldNotBeCalled()
+      } catch (err) {
         err.message.should.startWith("ids array can't be empty")
-      })
+      }
     })
   })
 
@@ -408,11 +409,12 @@ describe('sanitize', () => {
       const req = { query: { lang: '12512' } }
       const res = {}
       const configs = { lang: {} }
-      await sanitizeAsync(req, res, configs)
-      .then(shouldNotBeCalled)
-      .catch(err => {
+      try {
+        sanitize(req, res, configs)
+        shouldNotBeCalled()
+      } catch (err) {
         err.message.should.equal('invalid lang: 12512')
-      })
+      }
     })
   })
 
@@ -421,11 +423,12 @@ describe('sanitize', () => {
       const req = { query: { relatives: [ 'bar', 'foo' ] } }
       const res = {}
       const configs = { relatives: { allowlist: [ 'bar' ] } }
-      await sanitizeAsync(req, res, configs)
-      .then(shouldNotBeCalled)
-      .catch(err => {
+      try {
+        sanitize(req, res, configs)
+        shouldNotBeCalled()
+      } catch (err) {
         err.message.should.startWith('invalid relative')
-      })
+      }
     })
 
     it('should return relatives if allowlisted', async () => {
@@ -450,11 +453,12 @@ describe('sanitize', () => {
       const req = { query: {} }
       const res = {}
       const configs = { name: {} }
-      await sanitizeAsync(req, res, configs)
-      .then(shouldNotBeCalled)
-      .catch(err => {
+      try {
+        sanitize(req, res, configs)
+        shouldNotBeCalled()
+      } catch (err) {
         err.message.should.equal('missing parameter in query: name')
-      })
+      }
     })
   })
 
@@ -462,31 +466,34 @@ describe('sanitize', () => {
     it('should reject an incomplete bbox', async () => {
       const req = { query: { bbox: '[0, 0, 1]' } }
       const configs = { bbox: {} }
-      await sanitizeAsync(req, {}, configs)
-      .then(shouldNotBeCalled)
-      .catch(err => {
+      try {
+        sanitize(req, {}, configs)
+        shouldNotBeCalled()
+      } catch (err) {
         err.message.should.startWith('invalid bbox')
-      })
+      }
     })
 
     it('should reject bbox with a higher minLng than maxLng', async () => {
       const req = { query: { bbox: '[0, 2, 1, 1]' } }
       const configs = { bbox: {} }
-      await sanitizeAsync(req, {}, configs)
-      .then(shouldNotBeCalled)
-      .catch(err => {
+      try {
+        sanitize(req, {}, configs)
+        shouldNotBeCalled()
+      } catch (err) {
         err.message.should.startWith('invalid bbox')
-      })
+      }
     })
 
     it('should reject bbox with a higher minLat than maxLat', async () => {
       const req = { query: { bbox: '[2, 0, 1, 1]' } }
       const configs = { bbox: {} }
-      await sanitizeAsync(req, {}, configs)
-      .then(shouldNotBeCalled)
-      .catch(err => {
+      try {
+        sanitize(req, {}, configs)
+        shouldNotBeCalled()
+      } catch (err) {
         err.message.should.startWith('invalid bbox')
-      })
+      }
     })
 
     it('should parse a valid bbox', async () => {


### PR DESCRIPTION
* allows to declare endpoints in a deboilerplatified way, even when not passing by `ActionsControllers`

Bonus:
* remove last bits of `sanitizeAsync`