### PR TITLE
CORS policy update

### DIFF
--- a/server/lib/requests.js
+++ b/server/lib/requests.js
@@ -167,5 +167,6 @@ module.exports = {
   put: req('put'),
   delete: req('delete'),
   head,
+  options: req('options'),
   userAgent
 }

--- a/server/middlewares/middlewares.js
+++ b/server/middlewares/middlewares.js
@@ -19,8 +19,6 @@ module.exports = [
 
   content.jsonBodyParser,
   statics.favicon,
-
-  statics.enableCors,
   statics.mountStaticFiles,
 
   cache.cacheControl,

--- a/server/middlewares/middlewares.js
+++ b/server/middlewares/middlewares.js
@@ -10,6 +10,8 @@ module.exports = [
   // in the middleware are logged
   requestsLogger,
 
+  security.setCorsPolicy,
+
   // server/controllers/auth/fake_submit.js relies on the possibility
   // to submit a url encoded form data, so it needs to have the body-parser ready for it
   content.acceptUrlencoded('/api/submit'),
@@ -31,6 +33,4 @@ module.exports = [
   auth.authorizationHeader,
 
   content.deduplicateRequests,
-
-  security.enableCorsOnPublicApiRoutes
 ]

--- a/server/middlewares/security.js
+++ b/server/middlewares/security.js
@@ -3,7 +3,8 @@ const setCorsPolicy = (req, res, next) => {
   res.header('access-control-allow-methods', '*')
   res.header('access-control-allow-headers', 'content-type')
   // Recommend browsers to not send cookies, to prevent CSRF on endpoints requiring authentification
-  res.header('access-control-allow-credentials', 'false')
+  // by not setting access-control-allow-credentials, rather than setting it to false,
+  // see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials#directives
 
   if (req.method === 'OPTIONS') {
     // The headers above is all preflight requests should need

--- a/server/middlewares/security.js
+++ b/server/middlewares/security.js
@@ -1,17 +1,17 @@
 const enableCorsOnPublicApiRoutes = (req, res, next) => {
-  // Only have cross domain requests wide open for GET requests
-  // to avoid CSRF on request altering the database
-  if (req.method === 'GET') {
-    res.header('access-control-allow-origin', '*')
-    res.header('access-control-allow-methods', 'GET')
-    res.header('access-control-allow-headers', 'content-type')
-  } else {
-    res.header('access-control-allow-origin', 'https://api.inventaire.io')
-    res.header('access-control-allow-methods', 'GET,POST,PUT')
-    res.header('access-control-allow-credentials', 'true')
-  }
+  res.header('access-control-allow-origin', '*')
+  res.header('access-control-allow-methods', '*')
+  res.header('access-control-allow-headers', 'content-type')
+  // Recommend browsers to not send cookies, to prevent CSRF on endpoints requiring authentification
+  res.header('access-control-allow-credentials', 'false')
 
-  next()
+  if (req.method === 'OPTIONS') {
+    // The headers above is all preflight requests should need
+    // See https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request
+    res.end()
+  } else {
+    next()
+  }
 }
 
 module.exports = { enableCorsOnPublicApiRoutes }

--- a/server/middlewares/security.js
+++ b/server/middlewares/security.js
@@ -1,4 +1,4 @@
-const enableCorsOnPublicApiRoutes = (req, res, next) => {
+const setCorsPolicy = (req, res, next) => {
   res.header('access-control-allow-origin', '*')
   res.header('access-control-allow-methods', '*')
   res.header('access-control-allow-headers', 'content-type')
@@ -14,4 +14,4 @@ const enableCorsOnPublicApiRoutes = (req, res, next) => {
   }
 }
 
-module.exports = { enableCorsOnPublicApiRoutes }
+module.exports = { setCorsPolicy }

--- a/server/middlewares/statics.js
+++ b/server/middlewares/statics.js
@@ -2,14 +2,6 @@ const CONFIG = require('config')
 const __ = CONFIG.universalPath
 const pass = require('./pass')
 
-const enableCors = (req, res, next) => {
-  if (req.originalUrl.startsWith('/public')) {
-    res.setHeader('Access-Control-Allow-Origin', '*')
-    res.setHeader('Access-Control-Allow-Method', 'GET')
-  }
-  next()
-}
-
 if (CONFIG.serveStaticFiles) {
   const express = require('express')
   const publicPath = __.path('client', 'public')
@@ -28,7 +20,7 @@ if (CONFIG.serveStaticFiles) {
   const faviconPath = __.path('client', 'public/favicon.ico')
   const favicon = require('serve-favicon')(faviconPath)
 
-  module.exports = { enableCors, mountStaticFiles, favicon }
+  module.exports = { mountStaticFiles, favicon }
 } else {
-  module.exports = { enableCors, mountStaticFiles: pass, favicon: pass }
+  module.exports = { mountStaticFiles: pass, favicon: pass }
 }

--- a/tests/api/middlewares/cors.test.js
+++ b/tests/api/middlewares/cors.test.js
@@ -1,0 +1,20 @@
+const { rawRequest } = require('../utils/request')
+
+require('should')
+
+describe('CORS', () => {
+  describe('OPTIONS', () => {
+    it('should always answer with a 200', async () => {
+      const res = await rawRequest('options', '/api/whatever')
+      res.statusCode.should.equal(200)
+    })
+
+    it('should return access control headers', async () => {
+      const res = await rawRequest('options', '/api/whatever')
+      res.headers['access-control-allow-origin'].should.equal('*')
+      res.headers['access-control-allow-methods'].should.equal('*')
+      res.headers['access-control-allow-headers'].should.equal('content-type')
+      res.headers['access-control-allow-credentials'].should.equal('false')
+    })
+  })
+})

--- a/tests/api/middlewares/cors.test.js
+++ b/tests/api/middlewares/cors.test.js
@@ -13,7 +13,7 @@ describe('CORS', () => {
       res.headers['access-control-allow-origin'].should.equal('*')
       res.headers['access-control-allow-methods'].should.equal('*')
       res.headers['access-control-allow-headers'].should.equal('content-type')
-      res.headers['access-control-allow-credentials'].should.equal('false')
+      should(res.headers['access-control-allow-credentials']).not.be.ok()
     })
 
     it('should not return session cookies', async () => {

--- a/tests/api/middlewares/cors.test.js
+++ b/tests/api/middlewares/cors.test.js
@@ -1,6 +1,5 @@
+const should = require('should')
 const { rawRequest } = require('../utils/request')
-
-require('should')
 
 describe('CORS', () => {
   describe('OPTIONS', () => {
@@ -15,6 +14,11 @@ describe('CORS', () => {
       res.headers['access-control-allow-methods'].should.equal('*')
       res.headers['access-control-allow-headers'].should.equal('content-type')
       res.headers['access-control-allow-credentials'].should.equal('false')
+    })
+
+    it('should not return session cookies', async () => {
+      const res = await rawRequest('options', '/api/whatever')
+      should(res.headers['set-cookie']).not.be.ok()
     })
   })
 })


### PR DESCRIPTION
Addressing #301

* accept preflight requests by always returning a 200 with `access-control-allow-*` headers to `OPTIONS` requests
* open all public resources to cross-domain request
* deny access to resources requiring authentication by advising browsers to not include session cookies in cross-domain requests (by setting `access-control-allow-credentials=false`), to prevent CSRF

Authenticated requests from third party apps should then rather pass by OAuth tokens #84 