### PR TITLE
invitations email: prevent leaking user email

### DIFF
--- a/server/lib/emails/email.js
+++ b/server/lib/emails/email.js
@@ -125,7 +125,6 @@ module.exports = {
     return emailAddress => {
       return {
         to: emailAddress,
-        replyTo: inviter.email,
         subject: i18n(lang, 'email_invitation_subject', inviter),
         template: 'email_invitation',
         context: { inviter, message, lang, host }
@@ -142,7 +141,6 @@ module.exports = {
     // Object required to pass as i18n strings context
     return emailAddress => ({
       to: emailAddress,
-      replyTo: inviter.email,
       subject: i18n(lang, 'group_email_invitation_subject', { username, groupName }),
       template: 'group_email_invitation',
       context: { message, lang, host, username, groupName, pathname }


### PR DESCRIPTION
as they are likely not aware that the email they used to signup to inventaire is being leaked when inviting people