### PR TITLE
experimentation on how to reuse entities data from another instance

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -28,6 +28,8 @@ const config = module.exports = {
     return `${this.publicProtocol}://${this.publicHost}:${this.port}`
   },
   invHost: 'https://inventaire.io',
+  // Set to 'https://inventaire.io' in ./local-dev.js to use inventaire.io entities locally
+  remoteEntities: null,
   // To allow fallback between servers, they need to share the same session keys:
   // one should have autoRotateKeys=true and the others autoRotateKeys=false
   autoRotateKeys: true,

--- a/server/controllers/config.js
+++ b/server/controllers/config.js
@@ -1,9 +1,10 @@
 const { sendStaticJson } = require('lib/responses')
-const { piwik } = require('config')
+const { piwik, remoteEntities } = require('config')
 const endpoint = piwik.enabled ? piwik.endpoint : null
 
 const clientConfig = JSON.stringify({
-  piwik: endpoint && endpoint.replace('/piwik.php', '')
+  piwik: endpoint && endpoint.replace('/piwik.php', ''),
+  remoteEntities
 })
 
 // A endpoint dedicated to pass configuration parameters to the client

--- a/server/controllers/entities/lib/remote/get_remote_entities_by_uris.js
+++ b/server/controllers/entities/lib/remote/get_remote_entities_by_uris.js
@@ -1,0 +1,34 @@
+const { remoteEntities } = require('config')
+const requests_ = require('lib/requests')
+const { buildPath, forceArray } = require('lib/utils/base')
+
+const getEntitiesByUris = async ({ uris }) => {
+  uris = forceArray(uris)
+  if (uris.length === 0) return []
+  const path = buildPath('/api/entities', { action: 'by-uris', uris: uris.join('|') })
+  const { entities } = await requests_.get(`${remoteEntities}${path}`)
+  return entities
+}
+
+const getEntityByUri = async ({ uri }) => {
+  const [ entity ] = await getEntitiesList(uri)
+  return entity
+}
+
+const getEntitiesList = async uris => {
+  const entities = await getEntitiesByUris({ uris })
+  return Object.values(entities)
+}
+
+const getUrisByClaim = async (property, value) => {
+  const path = buildPath('/api/entities', { action: 'reverse-claims', property, value })
+  const { uris } = await requests_.get(`${remoteEntities}${path}`)
+  return uris
+}
+
+module.exports = {
+  getEntitiesByUris,
+  getEntityByUri,
+  getEntitiesList,
+  getUrisByClaim,
+}

--- a/server/controllers/entities/lib/remote/instance_agnostic_entities.js
+++ b/server/controllers/entities/lib/remote/instance_agnostic_entities.js
@@ -1,0 +1,12 @@
+const { remoteEntities } = require('config')
+
+if (remoteEntities) {
+  module.exports = require('./get_remote_entities_by_uris')
+} else {
+  module.exports = {
+    getEntitiesByUris: require('../get_entities_by_uris'),
+    getEntityByUri: require('../get_entity_by_uri'),
+    getEntitiesList: require('../get_entities_list'),
+    getUrisByClaim: require('../entities').urisByClaim,
+  }
+}

--- a/server/controllers/images/lib/check_image.js
+++ b/server/controllers/images/lib/check_image.js
@@ -1,10 +1,17 @@
 const _ = require('builders/utils')
-const { imageIsUsed: entityImageIsUsed } = require('controllers/entities/lib/entities')
-const { imageIsUsed: groupImageIsUsed } = require('controllers/groups/lib/groups')
-const { imageIsUsed: userImageIsUsed } = require('controllers/user/lib/user')
 const assert_ = require('lib/utils/assert_types')
 const { containers } = require('controllers/images/lib/containers')
-const { checkDelays } = require('config').mediaStorage.images
+const CONFIG = require('config')
+const { checkDelays } = CONFIG.mediaStorage.images
+const { remoteEntities } = CONFIG
+
+const { imageIsUsed: groupImageIsUsed } = require('controllers/groups/lib/groups')
+const { imageIsUsed: userImageIsUsed } = require('controllers/user/lib/user')
+
+let entityImageIsUsed
+if (remoteEntities == null) {
+  entityImageIsUsed = require('controllers/entities/lib/entities').imageIsUsed
+}
 
 module.exports = async ({ container, hash, url, context }) => {
   if (url) [ container, hash ] = url.split('/').slice(2)

--- a/server/controllers/images/lib/containers.js
+++ b/server/controllers/images/lib/containers.js
@@ -1,6 +1,7 @@
 const _ = require('builders/utils')
 // 'swift' or 'local'
-const { mode } = require('config').mediaStorage
+const CONFIG = require('config')
+const { mode } = CONFIG.mediaStorage
 _.info(`media storage: ${mode}`)
 const { putImage, deleteImage } = require(`./${mode}_client`)
 const images_ = require('lib/images')
@@ -27,16 +28,18 @@ const containers = {
     deleteImage,
   },
 
-  entities: {
-    putImage: transformAndPutImage('entities', 'removeExif'),
-    deleteImage,
-  },
-
   // Placeholder to add 'remote' to the list of containers, when it's actually
   // used to fetch remote images
   remote: {},
   // Same but for emails and client assets
   assets: {}
+}
+
+if (CONFIG.remoteEntities == null) {
+  containers.entities = {
+    putImage: transformAndPutImage('entities', 'removeExif'),
+    deleteImage,
+  }
 }
 
 const uploadContainersNames = Object.keys(containers)

--- a/server/controllers/items/inventory_view.js
+++ b/server/controllers/items/inventory_view.js
@@ -1,6 +1,6 @@
 const _ = require('builders/utils')
 const error_ = require('lib/error/error')
-const getEntitiesByUris = require('controllers/entities/lib/get_entities_by_uris')
+const { getEntitiesByUris } = require('controllers/entities/lib/remote/instance_agnostic_entities')
 const replaceEditionsByTheirWork = require('./lib/view/replace_editions_by_their_work')
 const bundleViewData = require('./lib/view/bundle_view_data')
 const getAuthorizedItems = require('./lib/get_authorized_items')

--- a/server/controllers/items/lib/export/add_entities_data.js
+++ b/server/controllers/items/lib/export/add_entities_data.js
@@ -1,7 +1,6 @@
 const _ = require('builders/utils')
 const error_ = require('lib/error/error')
-const getEntityByUri = require('controllers/entities/lib/get_entity_by_uri')
-const getEntitiesList = require('controllers/entities/lib/get_entities_list')
+const { getEntityByUri, getEntitiesList } = require('controllers/entities/lib/remote/instance_agnostic_entities')
 
 module.exports = async item => {
   const { entity: uri } = item

--- a/server/controllers/items/lib/snapshot/get_entities.js
+++ b/server/controllers/items/lib/snapshot/get_entities.js
@@ -1,7 +1,6 @@
 const _ = require('builders/utils')
 const assert_ = require('lib/utils/assert_types')
-const getEntityByUri = require('controllers/entities/lib/get_entity_by_uri')
-const getEntitiesByUris = require('controllers/entities/lib/get_entities_by_uris')
+const { getEntityByUri, getEntitiesByUris } = require('controllers/entities/lib/remote/instance_agnostic_entities')
 const { aggregateClaims } = require('./helpers')
 
 const getRelativeEntities = relationProperty => async entity => {

--- a/server/controllers/items/lib/snapshot/refresh_snapshot.js
+++ b/server/controllers/items/lib/snapshot/refresh_snapshot.js
@@ -1,11 +1,9 @@
 const _ = require('builders/utils')
 const promises_ = require('lib/promises')
 const assert_ = require('lib/utils/assert_types')
-const entities_ = require('controllers/entities/lib/entities')
-const getEntityByUri = require('controllers/entities/lib/get_entity_by_uri')
-const getEntitiesByUris = require('controllers/entities/lib/get_entities_by_uris')
-const buildSnapshot = require('./build_snapshot')
+const { getEntityByUri, getEntitiesByUris, getUrisByClaim } = require('controllers/entities/lib/remote/instance_agnostic_entities')
 const { getWorkAuthorsAndSeries, getEditionGraphEntities } = require('./get_entities')
+const buildSnapshot = require('./build_snapshot')
 const { getDocData } = require('./helpers')
 
 let snapshot_
@@ -31,7 +29,7 @@ const fromUri = changedEntityUri => {
 module.exports = { fromDoc, fromUri }
 
 const multiWorkRefresh = relationProperty => async uri => {
-  const uris = await entities_.urisByClaim(relationProperty, uri)
+  const uris = await getUrisByClaim(relationProperty, uri)
   const snapshots = await Promise.all(uris.map(getSnapshotsByType.work))
   return _.flatten(snapshots)
 }
@@ -78,7 +76,7 @@ const getEditionsSnapshots = async (uri, works, authors, series) => {
   assert_.array(authors)
   assert_.array(series)
 
-  return entities_.urisByClaim('wdt:P629', uri)
+  return getUrisByClaim('wdt:P629', uri)
   .then(uris => getEntitiesByUris({ uris }))
   .then(res => _.values(res.entities))
   .then(promises_.map(edition => getEditionSnapshot([ edition, works, authors, series ])))

--- a/server/controllers/items/lib/validate_entity_and_shelves.js
+++ b/server/controllers/items/lib/validate_entity_and_shelves.js
@@ -1,10 +1,10 @@
 const _ = require('builders/utils')
 const error_ = require('lib/error/error')
 const allowlistedEntityTypes = [ 'edition', 'work' ]
+const { getEntityByUri } = require('controllers/entities/lib/remote/instance_agnostic_entities')
 
-let getEntityByUri, shelves_
+let shelves_
 const requireCircularDependencies = () => {
-  getEntityByUri = require('controllers/entities/lib/get_entity_by_uri')
   shelves_ = require('controllers/shelves/lib/shelves')
 }
 setImmediate(requireCircularDependencies)

--- a/server/controllers/items/lib/view/replace_editions_by_their_work.js
+++ b/server/controllers/items/lib/view/replace_editions_by_their_work.js
@@ -1,5 +1,5 @@
 const _ = require('builders/utils')
-const getEntitiesByUris = require('controllers/entities/lib/get_entities_by_uris')
+const { getEntitiesByUris } = require('controllers/entities/lib/remote/instance_agnostic_entities')
 
 module.exports = entities => {
   const { works, editions } = splitEntities(entities)

--- a/server/controllers/routes.js
+++ b/server/controllers/routes.js
@@ -11,8 +11,6 @@ const oauthServer = require('./auth/oauth_server')
 const routes = module.exports = {
   'api/auth': endpoint('./auth/auth'),
   'api/config': endpoint('./config'),
-  'api/data': endpoint('./data'),
-  'api/entities': endpoint('./entities/entities'),
   'api/feedback': endpoint('./feedback'),
   'api/feeds': endpoint('./feeds/feeds'),
   'api/groups': endpoint('./groups/groups'),
@@ -28,7 +26,6 @@ const routes = module.exports = {
   'api/search': endpoint('./search/search'),
   'api/shelves': endpoint('./shelves/shelves'),
   'api/submit': require('./auth/fake_submit'),
-  'api/tasks': endpoint('./tasks/tasks'),
   'api/tests*': endpoint('./tests'),
   'api/token': endpoint('./auth/token'),
   'api/transactions': endpoint('./transactions/transactions'),
@@ -37,6 +34,12 @@ const routes = module.exports = {
   'api/activitypub': endpoint('./activitypub/activitypub'),
   'img/*': endpoint('./images/resize'),
   '.well-known/webfinger': endpoint('./activitypub/webfinger')
+}
+
+if (CONFIG.remoteEntities == null) {
+  routes['api/data'] = endpoint('./data')
+  routes['api/entities'] = endpoint('./entities/entities')
+  routes['api/tasks'] = endpoint('./tasks/tasks')
 }
 
 if (CONFIG.logMissingI18nKeys) {

--- a/server/controllers/search/lib/type_search.js
+++ b/server/controllers/search/lib/type_search.js
@@ -2,7 +2,9 @@ const _ = require('builders/utils')
 const requests_ = require('lib/requests')
 const error_ = require('lib/error/error')
 const assert_ = require('lib/utils/assert_types')
-const { host: elasticHost } = require('config').elasticsearch
+const CONFIG = require('config')
+const { remoteEntities } = CONFIG
+const { host: elasticHost } = CONFIG.elasticsearch
 const { getHits, formatError } = require('lib/elasticsearch')
 const { indexes, indexedTypes, indexedEntitiesTypes } = require('./indexes')
 const indexedTypesSet = new Set(indexedTypes)
@@ -29,6 +31,10 @@ const typeSearch = async params => {
   // but cannot be both as results scores are built very differently
   if (hasSocialTypes && hasEntityTypes) {
     throw error_.new('can not have both social and entity types', 400, { types })
+  }
+
+  if (hasEntityTypes && remoteEntities != null) {
+    throw error_.new('entities should be searched on remote instance', 400, { types, remoteEntities })
   }
 
   let body, queryIndexes

--- a/server/db/couchdb/list.js
+++ b/server/db/couchdb/list.js
@@ -1,3 +1,5 @@
+const { remoteEntities } = require('config')
+
 // 'default' keys/values are used by couch init
 // keys -> dbs names
 // values -> design docs
@@ -5,20 +7,27 @@
 // 'optional' keys/values are dbs names/design_docs
 // that aren't required to run on production
 
-module.exports = {
+const list = {
   activities: [ 'activities' ],
   comments: [ 'comments' ],
-  entities: [ 'entities', 'entities_deduplicate' ],
   groups: [ 'groups' ],
   images: [ 'images' ],
   items: [ 'items' ],
   notifications: [ 'notifications' ],
-  patches: [ 'patches' ],
   shelves: [ 'shelves' ],
-  tasks: [ 'tasks' ],
   oauth_authorizations: [],
   oauth_clients: [],
   oauth_tokens: [],
   transactions: [ 'transactions' ],
   users: [ 'users', 'relations', 'invited' ],
 }
+
+if (remoteEntities == null) {
+  Object.assign(list, {
+    entities: [ 'entities', 'entities_deduplicate' ],
+    patches: [ 'patches' ],
+    tasks: [ 'tasks' ],
+  })
+}
+
+module.exports = list

--- a/server/db/elasticsearch/formatters/formatters.js
+++ b/server/db/elasticsearch/formatters/formatters.js
@@ -1,7 +1,16 @@
-module.exports = {
-  entities: require('./entity'),
+const { remoteEntities } = require('config')
+
+const formatters = module.exports = {
   groups: require('./group'),
   items: require('./item'),
   users: require('./user'),
-  wikidata: require('./entity'),
 }
+
+if (remoteEntities == null) {
+  Object.assign(formatters, {
+    entities: require('./entity'),
+    wikidata: require('./entity'),
+  })
+}
+
+module.exports = formatters

--- a/server/db/elasticsearch/list.js
+++ b/server/db/elasticsearch/list.js
@@ -1,15 +1,22 @@
 const CONFIG = require('config')
+const { remoteEntities } = CONFIG
 const _ = require('builders/utils')
 
-// Using CouchDB database names + environment suffix as indexes names
-const indexesData = [
+const list = [
   { indexBaseName: 'users', sync: true },
   { indexBaseName: 'groups', sync: true },
   { indexBaseName: 'items', sync: true },
-  { indexBaseName: 'entities', sync: true },
-  { indexBaseName: 'wikidata', index: 'wikidata', sync: false }
 ]
-.map(data => {
+
+if (remoteEntities == null) {
+  list.push(
+    { indexBaseName: 'entities', sync: true },
+    { indexBaseName: 'wikidata', index: 'wikidata', sync: false }
+  )
+}
+
+// Using CouchDB database names + environment suffix as indexes names
+const indexesData = list.map(data => {
   data.index = data.index || CONFIG.db.name(data.indexBaseName)
   return data
 })


### PR DESCRIPTION
Reusing the entities from another instance seems to be possible. What this does:
* disable local entities/patches/tasks databases and controllers
* for pieces of code from other controllers that were trying to access those databases (ex: to generate items snapshots), adds an abstraction layer: instance-agnostic functions, such as `getEntitiesByUris`, where entities are then fetched either locally or remotely depending on the configuration
* Search on entities was disable: clients are expected to perform entities search request on the remote instance instead

Other things that could be done:
* The current implementation doesn't do caching, so any call to `getEntitiesByUris` means doing requests to the remote instance
* Wikidata entities are also fetched on the remote Inventaire instance: directly fetching Wikidata entities on wikidata.org could give more autonomy from the remote Inventaire instance

Identified limitations:
* Some event hooks usually triggered by the local entities code (ex: `entity:update:label`, `entity:update:claim`, `entity:merge`, `entity:revert:merge`) will ~~never be triggered~~ not be triggered each time an entity from the remote instance is updated, as there is currently no update channel to listen to, leading to cached data not being invalidated (ex: again, items snapshots). Those events could be triggered when the update comes from the local instance though (as #549 would allow), just like for updates on Wikidata entities.

Client side branch: https://github.com/inventaire/inventaire-client/pull/291