### PR TITLE
validate authorities entries entity types before passing it to the resolver

### DIFF
--- a/server/controllers/entities/lib/resolver/helpers.js
+++ b/server/controllers/entities/lib/resolver/helpers.js
@@ -11,9 +11,17 @@ module.exports = {
     }
   },
 
-  resolveSeed: seed => entities => {
+  resolveSeed: (seed, expectedEntityType) => entities => {
     // When only one entity is found, then seed is considered resolved
-    if (entities.length === 1) seed.uri = entities[0].uri
+    // at the condition that it does have the expected type
+    if (entities.length === 1) {
+      const entity = entities[0]
+      if (expectedEntityType) {
+        if (expectedEntityType === entity.type) seed.uri = entity.uri
+      } else {
+        seed.uri = entity.uri
+      }
+    }
     return seed
   }
 }

--- a/server/controllers/entities/lib/resolver/resolve_authors_from_works.js
+++ b/server/controllers/entities/lib/resolver/resolve_authors_from_works.js
@@ -13,5 +13,5 @@ const resolveAuthor = worksUris => author => {
   const authorSeedTerms = getEntityNormalizedTerms(author)
   return getAuthorsFromWorksUris(worksUris)
   .then(worksUris => worksUris.filter(someTermsMatch(authorSeedTerms)))
-  .then(resolveSeed(author))
+  .then(resolveSeed(author, 'human'))
 }

--- a/server/controllers/entities/lib/resolver/resolve_by_external_ids.js
+++ b/server/controllers/entities/lib/resolver/resolve_by_external_ids.js
@@ -1,36 +1,46 @@
 const _ = require('builders/utils')
+const getEntityByUri = require('../get_entity_by_uri')
 const resolveExternalIds = require('./resolve_external_ids')
 
-const resolveSeedsByExternalIds = seeds => Promise.all(seeds.map(resolveSeed))
+const resolveSeedsByExternalIds = (seeds, expectedEntityType) => {
+  return Promise.all(seeds.map(seed => resolveSeed(seed, expectedEntityType)))
+}
 
-const resolveSeed = async seed => {
+const resolveSeed = async (seed, expectedEntityType) => {
   if (seed.uri) return seed
   const uris = await resolveExternalIds(seed.claims)
   if (uris == null) return seed
-  if (uris.length === 1) seed.uri = uris[0]
+  if (uris.length === 1) {
+    const uri = uris[0]
+    if (expectedEntityType) {
+      const { type } = await getEntityByUri({ uri })
+      if (type === expectedEntityType) seed.uri = uri
+    } else {
+      seed.uri = uri
+    }
+  }
   return seed
 }
 
-const resolveSectionSeedsByExternalIds = async (section, entry) => {
+const resolveSectionSeedsByExternalIds = async (section, entry, expectedEntityType) => {
   const seeds = entry[section]
   if (!_.some(seeds)) return entry
 
-  return resolveSeedsByExternalIds(seeds)
+  return resolveSeedsByExternalIds(seeds, expectedEntityType)
   .then(seeds => { entry[section] = seeds })
   .then(() => entry)
 }
 
 const resolveEntrySeedsByExternalIds = async entry => {
   await Promise.all([
-    resolveSectionSeedsByExternalIds('authors', entry),
-    resolveSectionSeedsByExternalIds('works', entry),
+    resolveSectionSeedsByExternalIds('authors', entry, 'human'),
+    resolveSectionSeedsByExternalIds('works', entry, 'work'),
   ])
   return entry
 }
 
 module.exports = {
-  resolveSeedsByExternalIds,
   resolveEntrySeedsByExternalIds,
-  resolveAuthorsByExternalIds: resolveSectionSeedsByExternalIds.bind(null, 'authors'),
-  resolveWorksByExternalIds: resolveSectionSeedsByExternalIds.bind(null, 'works'),
+  resolveAuthorsByExternalIds: entry => resolveSectionSeedsByExternalIds('authors', entry, 'human'),
+  resolveWorksByExternalIds: entry => resolveSectionSeedsByExternalIds('works', entry, 'work'),
 }

--- a/server/controllers/entities/lib/resolver/resolve_works_from_authors.js
+++ b/server/controllers/entities/lib/resolver/resolve_works_from_authors.js
@@ -16,5 +16,5 @@ const resolveWork = authorsUris => work => {
   const workSeedTerms = getEntityNormalizedTerms(work)
   return getWorksFromAuthorsLabels(authorsUris)
   .then(works => works.filter(someTermsMatch(workSeedTerms)))
-  .then(resolveSeed(work))
+  .then(resolveSeed(work, 'work'))
 }

--- a/server/controllers/entities/lib/resolver/resolve_works_from_edition.js
+++ b/server/controllers/entities/lib/resolver/resolve_works_from_edition.js
@@ -16,5 +16,5 @@ module.exports = async (worksSeeds, editionSeed) => {
 const resolveWork = worksEntities => workSeed => {
   const workSeedTerms = getEntityNormalizedTerms(workSeed)
   const matchingWorks = worksEntities.filter(someTermsMatch(workSeedTerms))
-  return resolveSeed(workSeed)(matchingWorks)
+  return resolveSeed(workSeed, 'work')(matchingWorks)
 }

--- a/server/data/bnb/get_bnb_entry_from_isbn.js
+++ b/server/data/bnb/get_bnb_entry_from_isbn.js
@@ -61,7 +61,10 @@ const formatRow = async (isbn, result, rawResult) => {
   const entry = {}
   entry.edition = { isbn }
   if (edition) {
-    const { claims } = await parseSameasMatches(edition.value, edition.matches)
+    const { claims } = await parseSameasMatches({
+      matches: [ edition.value, edition.matches ],
+      expectedEntityType: 'edition',
+    })
     entry.edition.claims = {
       'wdt:P1476': edition.title,
       ...claims
@@ -72,7 +75,10 @@ const formatRow = async (isbn, result, rawResult) => {
     }
   }
   if (author) {
-    const { uri, claims } = await parseSameasMatches(author.value, author.matches)
+    const { uri, claims } = await parseSameasMatches({
+      matches: [ author.value, author.matches ],
+      expectedEntityType: 'human',
+    })
     entry.author = {
       uri,
       labels: { fr: author.label },

--- a/server/data/bne/get_bne_entry_from_isbn.js
+++ b/server/data/bne/get_bne_entry_from_isbn.js
@@ -72,7 +72,10 @@ const formatRow = async (isbn, result) => {
   const entry = {}
   entry.edition = { isbn }
   if (edition) {
-    const { claims } = await parseSameasMatches(edition.value)
+    const { claims } = await parseSameasMatches({
+      matches: [ edition.value ],
+      expectedEntityType: 'edition'
+    })
     entry.edition.claims = {
       'wdt:P1476': edition.title,
       ...claims
@@ -91,7 +94,10 @@ const formatRow = async (isbn, result) => {
     }
   }
   if (author) {
-    const { uri, claims } = await parseSameasMatches(author.value, author.matches)
+    const { uri, claims } = await parseSameasMatches({
+      matches: [ author.value, author.matches ],
+      expectedEntityType: 'human'
+    })
     entry.author = {
       uri,
       labels: { es: formatAuthorName(author.label) },

--- a/server/data/bnf/get_bnf_entry_from_isbn.js
+++ b/server/data/bnf/get_bnf_entry_from_isbn.js
@@ -94,7 +94,10 @@ const formatRow = async (isbn, result, rawResult) => {
   const entry = {}
   entry.edition = { isbn }
   if (edition) {
-    const { claims } = await parseSameasMatches(edition.value, edition.matches)
+    const { claims } = await parseSameasMatches({
+      matches: [ edition.value, edition.matches ],
+      expectedEntityType: 'edition'
+    })
     entry.edition.claims = {
       'wdt:P1476': edition.title,
       ...claims
@@ -104,7 +107,10 @@ const formatRow = async (isbn, result, rawResult) => {
     }
   }
   if (work.value) {
-    const { uri, claims } = await parseSameasMatches(work.value, work.matches)
+    const { uri, claims } = await parseSameasMatches({
+      matches: [ work.value, work.matches ],
+      expectedEntityType: 'work'
+    })
     entry.work = {
       uri,
       labels: {
@@ -115,7 +121,10 @@ const formatRow = async (isbn, result, rawResult) => {
     if (work.value.includes('temp-work')) entry.work.tempBnfId = work.value
   }
   if (author.value) {
-    const { uri, claims } = await parseSameasMatches(author.value, author.matches)
+    const { uri, claims } = await parseSameasMatches({
+      matches: [ author.value, author.matches ],
+      expectedEntityType: 'human'
+    })
     entry.author = {
       uri,
       labels: { fr: formatAuthorName(author.label) },

--- a/server/data/lib/external_ids.js
+++ b/server/data/lib/external_ids.js
@@ -29,21 +29,19 @@ const parseSameasMatches = async ({ matches, expectedEntityType }) => {
 }
 
 const setFoundValue = async (entryData, property, value, expectedEntityType) => {
-  if (property === 'uri') {
-    // Wikidata edition entities should not be used until
-    // https://github.com/inventaire/inventaire/issues/182 is resolved
-    if (expectedEntityType !== 'edition') {
-      const uri = value
-      const { type } = await getEntityByUri({ uri })
-      if (type === expectedEntityType) {
-        entryData.uri = uri
-      } else {
-        _.warn({ entryData, property, value, type, expectedEntityType }, 'type mismatch')
-      }
-    }
-  } else {
+  if (property !== 'uri') {
     entryData.claims[property] = value
+    return
   }
+  // Wikidata edition entities should not be used until
+  // https://github.com/inventaire/inventaire/issues/182 is resolved
+  if (expectedEntityType === 'edition') return
+  const uri = value
+  const { type } = await getEntityByUri({ uri })
+  if (type !== expectedEntityType) {
+    return _.warn({ entryData, property, value, type, expectedEntityType }, 'type mismatch')
+  }
+  entryData.uri = uri
 }
 
 const getUrlData = async url => {

--- a/tests/integration/data/get_resolved_entry.js
+++ b/tests/integration/data/get_resolved_entry.js
@@ -36,4 +36,12 @@ describe('get resolved seed', () => {
     const edition = await getResolvedEntry('84-95618-60-5')
     edition.claims['wdt:P629'].should.deepEqual([ 'wd:Q81689' ])
   })
+
+  it('should not resolve an entity with the wrong type', async () => {
+    const edition = await getResolvedEntry('978-88-7799-292-5')
+    // BNF finds that the work is wd:Q238476, which is not identified
+    // as a work by server/controllers/entities/lib/get_entity_type.js
+    // wd:Q238476 should thus be discarded and an new inv entity should be set as wdt:P629
+    edition.claims['wdt:P629'][0].should.startWith('inv:')
+  })
 })

--- a/tests/integration/data/get_resolved_entry.js
+++ b/tests/integration/data/get_resolved_entry.js
@@ -37,7 +37,7 @@ describe('get resolved seed', () => {
     edition.claims['wdt:P629'].should.deepEqual([ 'wd:Q81689' ])
   })
 
-  it('should not resolve an entity with the wrong type', async () => {
+  it('should create local entity when resolved entity has an unknown type', async () => {
     const edition = await getResolvedEntry('978-88-7799-292-5')
     // BNF finds that the work is wd:Q238476, which is not identified
     // as a work by server/controllers/entities/lib/get_entity_type.js


### PR DESCRIPTION
The kind of error this is trying to address (logs from prod main server, starting at `Sep 20 19:45:56`):
```js
****** next entry ******
{
  edition: {
    isbn: '9788877992925',
    claims: {
      'wdt:P1476': [ 'La donazione di Costantino' ],
      'wdt:P268': [ '42479597n' ],
      'wdt:P407': [ 'wd:Q397' ]
    },
    labels: {}
  },
  works: [
    {
      uri: 'wd:Q238476',
      labels: { fr: 'Donation de Constantin' },
      claims: { 'wdt:P268': [ '123807414' ] }
    }
  ],
  authors: []
}
-----
****** inv entity creation ******
{
  labels: {},
  claims: {
    'wdt:P31': [ 'wd:Q3331189' ],
    'wdt:P629': [ 'wd:Q238476' ],
    'wdt:P212': [ '978-88-7799-292-5' ],
    'invp:P2': [ 'c51bb8a2ade9980d14416d3f575d806d8d3ffa43' ],
    'wdt:P1476': [ 'La donazione di Costantino' ],
    'wdt:P268': [ '42479597n' ],
    'wdt:P407': [ 'wd:Q397' ]
  },
  userId: '00000000000000000000000000000000',
  batchId: 1632159956576
}
-----
****** getEntitiesByUris err: isbn:9788877992925 ******
{
  statusCode: 400,
  emitter: [
    'Error: invalid claim entity type: undefined',
    '(anonymous): server/controllers/entities/lib/validate_and_format_claim_value.js:71:23',
    'processTicksAndRejections internal/process/task_queues.js:93:5',
    'async Promise.all index 1',
    'async module.exports : server/controllers/entities/lib/validate_and_format_claim_value.js:34:3'
  ]
}
Context: [ 'wd:Q238476' ]
-----
```
This error (which can be reproduced by visiting https://inventaire.io/entity/978-88-7799-292-5) could be prevented if `wd:Q238476` was not resolved as a work. One could say that the fault is on `getEntityType`, which couldn't identify that `wd:Q238476` is of type `work`, but fixing `getEntityType` is a problem for another day