### PR TITLE
activity pub follow-ups

### DIFF
--- a/server/controllers/activitypub/activity.js
+++ b/server/controllers/activitypub/activity.js
@@ -1,12 +1,40 @@
 const activities_ = require('./lib/activities')
 const formatUserItemsActivities = require('./lib/format_user_items_activities')
 const { findOneByUsername } = require('controllers/user/lib/user')
+const { isEntityActivityId } = require('./lib/helpers')
+const { isCouchUuid } = require('lib/boolean_validations')
+const error_ = require('lib/error/error')
+const patches_ = require('controllers/entities/lib/patches')
+const { getActivitiesFromPatch } = require('./lib/entity_patch_activities')
 
 const sanitization = {
-  id: {}
+  id: {
+    // override couchUuid validation
+    generic: 'string'
+  }
 }
 
 const controller = async ({ id }) => {
+  if (isEntityActivityId(id)) {
+    return getEntityActivity(id)
+  } else {
+    return getUserActivity(id)
+  }
+}
+
+const getEntityActivity = async id => {
+  let [ , entityId, versionNumber, activityNumber ] = id.split('-')
+  const patchId = `${entityId}:${versionNumber}`
+  const patch = await patches_.byId(patchId)
+  const activities = await getActivitiesFromPatch(patch)
+  activityNumber = parseInt(activityNumber)
+  const activity = activities[activityNumber]
+  if (!activity) throw error_.notFound({ id })
+  return activity
+}
+
+const getUserActivity = async id => {
+  if (!isCouchUuid(id)) throw error_.new('invalid activity id', 400, { id })
   const activityDoc = await activities_.byId(id)
   const { name } = activityDoc.actor
   const user = await findOneByUsername(name)

--- a/server/controllers/activitypub/follow.js
+++ b/server/controllers/activitypub/follow.js
@@ -10,7 +10,7 @@ const { isEntityUri, isUsername } = require('lib/boolean_validations')
 module.exports = async params => {
   const { id: externalId, type } = params
   let { actor, object } = params
-  if (!object.startsWith(host)) throw error_.new(`invalid object, string should start with ${host}`, 400, { object })
+  if (!object?.startsWith(host)) throw error_.new(`invalid object, string should start with ${host}`, 400, { object })
   const { name: requestedObjectName } = qs.parse(object)
 
   if (isEntityUri(getEntityUriFromActorName(requestedObjectName))) {

--- a/server/controllers/activitypub/inbox.js
+++ b/server/controllers/activitypub/inbox.js
@@ -15,7 +15,9 @@ const sanitization = {
     allowlist: [ 'https://www.w3.org/ns/activitystreams' ]
   },
   actor: {},
-  object: {}
+  object: {
+    generic: 'stringOrObject'
+  }
 }
 
 const controller = async params => {

--- a/server/controllers/activitypub/lib/entity_patch_activities.js
+++ b/server/controllers/activitypub/lib/entity_patch_activities.js
@@ -17,7 +17,7 @@ const deliverEntityActivitiesFromPatch = async patch => {
 
 const getActivitiesFromPatch = async patch => {
   const rows = byClaimValueAndDate(patch)
-  if (rows.length === 0) return
+  if (rows.length === 0) return []
   return formatEntityPatchesActivities(rows)
 }
 

--- a/server/controllers/activitypub/lib/entity_patch_activities.js
+++ b/server/controllers/activitypub/lib/entity_patch_activities.js
@@ -2,20 +2,23 @@ const _ = require('builders/utils')
 const { postActivityToActorFollowersInboxes } = require('./post_activity')
 const formatEntityPatchesActivities = require('./format_entity_patches_activities')
 
-module.exports = patch => {
-  return deliverEntityActivitiesFromPatch(patch)
-  .catch(_.Error('create_activities_on_entities_updates err'))
+const deliverEntityActivitiesFromPatch = async patch => {
+  try {
+    const activities = await getActivitiesFromPatch(patch)
+    if (activities.length === 0) return
+    await Promise.all(activities.map(activity => {
+      const actorName = new URL(activity.actor).searchParams.get('name')
+      return postActivityToActorFollowersInboxes({ activity, actorName })
+    }))
+  } catch (err) {
+    _.error(err, 'create_activities_on_entities_updates err')
+  }
 }
 
-const deliverEntityActivitiesFromPatch = async patch => {
+const getActivitiesFromPatch = async patch => {
   const rows = byClaimValueAndDate(patch)
   if (rows.length === 0) return
-  const activities = await formatEntityPatchesActivities(rows)
-  if (activities.length === 0) return
-  await Promise.all(activities.map(activity => {
-    const actorName = new URL(activity.actor).searchParams.get('name')
-    return postActivityToActorFollowersInboxes({ activity, actorName })
-  }))
+  return formatEntityPatchesActivities(rows)
 }
 
 // Mimick server/db/couchdb/design_docs/patches.json byClaimValueAndDate
@@ -42,4 +45,9 @@ const byClaimValueAndDate = doc => {
     }
   }
   return rows
+}
+
+module.exports = {
+  deliverEntityActivitiesFromPatch,
+  getActivitiesFromPatch,
 }

--- a/server/controllers/activitypub/lib/format_entity_patches_activities.js
+++ b/server/controllers/activitypub/lib/format_entity_patches_activities.js
@@ -3,7 +3,7 @@ const getEntitiesList = require('controllers/entities/lib/get_entities_list')
 const { prefixifyInv } = require('controllers/entities/lib/prefix')
 const { i18n } = require('lib/emails/i18n/i18n')
 const getBestLangValue = require('lib/get_best_lang_value')
-const { makeUrl, getEntityActorName } = require('./helpers')
+const { makeUrl, getEntityActorName, getActivityIdFromPatchId } = require('./helpers')
 const host = CONFIG.fullPublicHost()
 
 module.exports = rows => {
@@ -20,15 +20,15 @@ const activityText = {
 
 const hasActivityText = ({ value: property }) => activityText[property] != null
 
-const formatEntityPatchActivity = async row => {
+const formatEntityPatchActivity = async (row, rowIndex) => {
   const { id: patchId, key, value: property } = row
   const [ objectUri, timestamp ] = key
   const subjectUri = prefixifyInv(patchId.split(':')[0])
   const [ subjectEntity, objectEntity ] = await getEntitiesList([ subjectUri, objectUri ])
-
   const subjectLabel = getBestLangValue('en', subjectEntity.originalLang, subjectEntity.labels).value
   const objectLabel = getBestLangValue('en', objectEntity.originalLang, objectEntity.labels).value
-  const id = `${host}/api/activitypub?action=activity&id=${patchId}`
+  const activityId = getActivityIdFromPatchId(patchId, rowIndex)
+  const id = `${host}/api/activitypub?action=activity&id=${activityId}`
   const name = getEntityActorName(objectUri)
   const actor = makeUrl({ params: { action: 'actor', name } })
   const subjectUrl = `${host}/entity/${subjectUri}`

--- a/server/controllers/activitypub/lib/format_entity_patches_activities.js
+++ b/server/controllers/activitypub/lib/format_entity_patches_activities.js
@@ -31,11 +31,13 @@ const formatEntityPatchActivity = async row => {
   const id = `${host}/api/activitypub?action=activity&id=${patchId}`
   const name = getEntityActorName(objectUri)
   const actor = makeUrl({ params: { action: 'actor', name } })
+  const subjectUrl = `${host}/entity/${subjectUri}`
+  const objectUrl = `${host}/entity/${objectUri}`
 
   const object = {
     id,
     type: 'Note',
-    content: `<p>${i18n('en', activityText[property], { subjectLabel, objectLabel })}</p>`,
+    content: `<p>${i18n('en', activityText[property], { subjectLabel, subjectUrl, objectLabel, objectUrl })}</p>`,
     published: new Date(timestamp).toISOString(),
   }
 

--- a/server/controllers/activitypub/lib/format_entity_patches_activities.js
+++ b/server/controllers/activitypub/lib/format_entity_patches_activities.js
@@ -13,6 +13,9 @@ module.exports = rows => {
 
 const activityText = {
   'wdt:P50': 'author_has_new_work',
+  'wdt:P123': 'publisher_has_new_edition',
+  'wdt:P195': 'collection_has_new_edition',
+  'wdt:P921': 'subject_has_new_work',
 }
 
 const hasActivityText = ({ value: property }) => activityText[property] != null

--- a/server/controllers/activitypub/lib/helpers.js
+++ b/server/controllers/activitypub/lib/helpers.js
@@ -12,5 +12,15 @@ const makeUrl = ({ origin, endpoint, params }) => {
 
 const getEntityActorName = uri => uri.replace(':', '-')
 const getEntityUriFromActorName = name => name.replace('-', ':')
+const getActivityIdFromPatchId = (patchId, rowIndex) => `inv-${patchId.replace(':', '-')}-${rowIndex}`
 
-module.exports = { makeUrl, getEntityActorName, getEntityUriFromActorName }
+const activityIdPattern = /^inv-[0-9a-f]{32}-\d{1,3}-\d{1,3}$/
+const isEntityActivityId = activityId => activityIdPattern.test(activityId)
+
+module.exports = {
+  makeUrl,
+  getEntityActorName,
+  getEntityUriFromActorName,
+  getActivityIdFromPatchId,
+  isEntityActivityId,
+}

--- a/server/controllers/activitypub/lib/post_activity.js
+++ b/server/controllers/activitypub/lib/post_activity.js
@@ -43,6 +43,7 @@ const signAndPostActivity = async ({ actorName, recipientActorUri, activity }) =
 // TODO: use sharedInbox
 const postActivityToActorFollowersInboxes = async ({ activity, actorName }) => {
   const followActivities = await getFollowActivitiesByObject(actorName)
+  if (followActivities.length === 0) return
   const followersActorsUris = _.uniq(_.map(followActivities, 'actor.uri'))
   return Promise.all(followersActorsUris.map(uri => {
     return signAndPostActivity({ actorName, recipientActorUri: uri, activity })

--- a/server/controllers/activitypub/lib/radio_hooks.js
+++ b/server/controllers/activitypub/lib/radio_hooks.js
@@ -7,7 +7,7 @@ const { postActivityToActorFollowersInboxes } = require('./post_activity')
 const { byActorName, createActivity } = require('./activities')
 const formatUserItemsActivities = require('./format_user_items_activities')
 const formatShelfItemsActivities = require('./format_shelf_items_activities')
-const deliverEntityActivitiesFromPatch = require('./deliver_entity_activities_from_patch')
+const { deliverEntityActivitiesFromPatch } = require('./entity_patch_activities')
 const debouncedActivities = {}
 
 module.exports = () => {

--- a/server/controllers/activitypub/lib/security.js
+++ b/server/controllers/activitypub/lib/security.js
@@ -29,7 +29,13 @@ const security_ = module.exports = {
     if (signature === undefined) throw error_.new('no signature header', 400, reqHeaders)
     // "headers" below specify the list of HTTP headers included when generating the signature for the message
     const { keyId: actorUrl, signature: signatureString, headers } = parseSignature(signature)
-    const publicKey = await fetchActorPublicKey(actorUrl)
+    let publicKey
+    try {
+      publicKey = await fetchActorPublicKey(actorUrl)
+    } catch (err) {
+      _.warn({ method, pathname, body: req.body }, 'could not fetch public key')
+      throw err
+    }
     const verifier = crypto.createVerify('rsa-sha256')
     const signedString = buildSignatureString(Object.assign(reqHeaders, { headers, method: method.toLowerCase(), pathname }))
     verifier.update(signedString)

--- a/server/controllers/activitypub/outbox.js
+++ b/server/controllers/activitypub/outbox.js
@@ -63,6 +63,7 @@ const getEntityActivities = async ({ name, offset, limit }) => {
     return buildPaginatedEntityOutbox(entity, offset, limit, baseOutbox)
   }
 }
+
 const getBaseOutbox = url => {
   return {
     '@context': [ 'https://www.w3.org/ns/activitystreams' ],

--- a/server/controllers/activitypub/undo.js
+++ b/server/controllers/activitypub/undo.js
@@ -1,9 +1,12 @@
+const _ = require('builders/utils')
 const error_ = require('lib/error/error')
 const { byExternalId, deleteById } = require('controllers/activitypub/lib/activities')
 const { isNonEmptyString } = require('lib/boolean_validations')
 
 module.exports = async params => {
-  const { actor, object } = params
+  let { actor, object } = params
+
+  if (_.isPlainObject(object)) object = object.id
 
   if (!isNonEmptyString(object)) throw error_.new('invalid activity object', 400, params)
   const activity = await byExternalId(object)

--- a/server/lib/sanitize/parameters.js
+++ b/server/lib/sanitize/parameters.js
@@ -186,7 +186,10 @@ const generics = {
     },
     validate: _.isStrictlyPositiveInteger
   },
-  string: nonEmptyString
+  string: nonEmptyString,
+  stringOrObject: {
+    validate: value => _.isNonEmptyString(value) || _.isPlainObject(value)
+  }
 }
 
 const value = {

--- a/tests/api/activitypub/activity.test.js
+++ b/tests/api/activitypub/activity.test.js
@@ -7,6 +7,8 @@ const { publicReq, signedReq } = require('../utils/utils')
 const { wait } = require('lib/promises')
 const { makeUrl } = require('../utils/activitypub')
 const requests_ = require('lib/requests')
+const { createWork, createHuman, addAuthor } = require('../fixtures/entities')
+const { getEntityActorName } = require('controllers/activitypub/lib/helpers')
 
 describe('activity', () => {
   describe('users', () => {
@@ -18,12 +20,31 @@ describe('activity', () => {
       const { remoteHost, remoteUsername } = await signedReq({ object: actorUrl, url: inboxUrl, type: 'Follow' })
       await createItem(user)
       await wait(debounceTime + 500)
-      await publicReq('get', `/api/activitypub?action=outbox&name=${username}&offset=0`)
+      const outboxUrl = makeUrl({ params: { action: 'outbox', name: username, offset: 0 } })
+      await publicReq('get', outboxUrl)
       const { inbox } = await requests_.get(`${remoteHost}/inbox_inspection?username=${remoteUsername}`)
       const [ createActivity ] = inbox
       const activityUrl = createActivity.object.id
       const activityId = new URL(activityUrl).searchParams.get('id')
       const activity = await publicReq('get', `/api/activitypub?action=activity&id=${activityId}`)
+      activity.id.should.equal(`${activityUrl}#create`)
+      activity.type.should.equal('Create')
+      activity.object.id.should.equal(activityUrl)
+      activity.object.type.should.equal('Note')
+      activity.object.content.should.be.a.String()
+    })
+  })
+
+  describe('entities', () => {
+    it('should get an activity', async () => {
+      const { uri: authorUri } = await createHuman()
+      const { uri: workUri } = await createWork()
+      await addAuthor(workUri, authorUri)
+      const actorName = getEntityActorName(authorUri)
+      const outboxUrl = makeUrl({ params: { action: 'outbox', name: actorName, offset: 0 } })
+      const { orderedItems } = await publicReq('get', outboxUrl)
+      const activityUrl = orderedItems[0].object.id
+      const activity = await publicReq('get', activityUrl)
       activity.id.should.equal(`${activityUrl}#create`)
       activity.type.should.equal('Create')
       activity.object.id.should.equal(activityUrl)

--- a/tests/api/activitypub/activity.test.js
+++ b/tests/api/activitypub/activity.test.js
@@ -3,28 +3,24 @@ const debounceTime = CONFIG.activitiesDebounceTime
 require('should')
 const { createItem } = require('../fixtures/items')
 const { createUser } = require('../fixtures/users')
-const { publicReq, signedReq } = require('../utils/utils')
+const { createShelfWithItem } = require('../fixtures/shelves')
+const { publicReq } = require('../utils/utils')
 const { wait } = require('lib/promises')
 const { makeUrl } = require('../utils/activitypub')
-const requests_ = require('lib/requests')
 const { createWork, createHuman, addAuthor } = require('../fixtures/entities')
 const { getEntityActorName } = require('controllers/activitypub/lib/helpers')
+const { getActorName } = require('../utils/shelves')
 
 describe('activity', () => {
   describe('users', () => {
     it('should get an activity', async () => {
       const user = await createUser({ fediversable: true })
       const { username } = user
-      const actorUrl = makeUrl({ params: { action: 'actor', name: username } })
-      const inboxUrl = makeUrl({ params: { action: 'inbox', name: username } })
-      const { remoteHost, remoteUsername } = await signedReq({ object: actorUrl, url: inboxUrl, type: 'Follow' })
       await createItem(user)
       await wait(debounceTime + 500)
       const outboxUrl = makeUrl({ params: { action: 'outbox', name: username, offset: 0 } })
-      await publicReq('get', outboxUrl)
-      const { inbox } = await requests_.get(`${remoteHost}/inbox_inspection?username=${remoteUsername}`)
-      const [ createActivity ] = inbox
-      const activityUrl = createActivity.object.id
+      const { orderedItems } = await publicReq('get', outboxUrl)
+      const activityUrl = orderedItems[0].object.id
       const activityId = new URL(activityUrl).searchParams.get('id')
       const activity = await publicReq('get', `/api/activitypub?action=activity&id=${activityId}`)
       activity.id.should.equal(`${activityUrl}#create`)
@@ -45,6 +41,25 @@ describe('activity', () => {
       const { orderedItems } = await publicReq('get', outboxUrl)
       const activityUrl = orderedItems[0].object.id
       const activity = await publicReq('get', activityUrl)
+      activity.id.should.equal(`${activityUrl}#create`)
+      activity.type.should.equal('Create')
+      activity.object.id.should.equal(activityUrl)
+      activity.object.type.should.equal('Note')
+      activity.object.content.should.be.a.String()
+    })
+  })
+
+  describe('shelf', () => {
+    it('should get an activity', async () => {
+      const user = createUser({ fediversable: true })
+      const { shelf } = await createShelfWithItem(user)
+      const name = getActorName(shelf)
+      await wait(debounceTime + 500)
+      const outboxUrl = makeUrl({ params: { action: 'outbox', name, offset: 0 } })
+      const { orderedItems } = await publicReq('get', outboxUrl)
+      const activityUrl = orderedItems[0].object.id
+      const activityId = new URL(activityUrl).searchParams.get('id')
+      const activity = await publicReq('get', `/api/activitypub?action=activity&id=${activityId}`)
       activity.id.should.equal(`${activityUrl}#create`)
       activity.type.should.equal('Create')
       activity.object.id.should.equal(activityUrl)

--- a/tests/api/activitypub/activity.test.js
+++ b/tests/api/activitypub/activity.test.js
@@ -9,24 +9,26 @@ const { makeUrl } = require('../utils/activitypub')
 const requests_ = require('lib/requests')
 
 describe('activity', () => {
-  it('should get an activity', async () => {
-    const user = await createUser({ fediversable: true })
-    const { username } = user
-    const actorUrl = makeUrl({ params: { action: 'actor', name: username } })
-    const inboxUrl = makeUrl({ params: { action: 'inbox', name: username } })
-    const { remoteHost, remoteUsername } = await signedReq({ object: actorUrl, url: inboxUrl, type: 'Follow' })
-    await createItem(user)
-    await wait(debounceTime + 500)
-    await publicReq('get', `/api/activitypub?action=outbox&name=${username}&offset=0`)
-    const { inbox } = await requests_.get(`${remoteHost}/inbox_inspection?username=${remoteUsername}`)
-    const [ createActivity ] = inbox
-    const activityUrl = createActivity.object.id
-    const activityId = new URL(activityUrl).searchParams.get('id')
-    const activity = await publicReq('get', `/api/activitypub?action=activity&id=${activityId}`)
-    activity.id.should.equal(`${activityUrl}#create`)
-    activity.type.should.equal('Create')
-    activity.object.id.should.equal(activityUrl)
-    activity.object.type.should.equal('Note')
-    activity.object.content.should.be.a.String()
+  describe('users', () => {
+    it('should get an activity', async () => {
+      const user = await createUser({ fediversable: true })
+      const { username } = user
+      const actorUrl = makeUrl({ params: { action: 'actor', name: username } })
+      const inboxUrl = makeUrl({ params: { action: 'inbox', name: username } })
+      const { remoteHost, remoteUsername } = await signedReq({ object: actorUrl, url: inboxUrl, type: 'Follow' })
+      await createItem(user)
+      await wait(debounceTime + 500)
+      await publicReq('get', `/api/activitypub?action=outbox&name=${username}&offset=0`)
+      const { inbox } = await requests_.get(`${remoteHost}/inbox_inspection?username=${remoteUsername}`)
+      const [ createActivity ] = inbox
+      const activityUrl = createActivity.object.id
+      const activityId = new URL(activityUrl).searchParams.get('id')
+      const activity = await publicReq('get', `/api/activitypub?action=activity&id=${activityId}`)
+      activity.id.should.equal(`${activityUrl}#create`)
+      activity.type.should.equal('Create')
+      activity.object.id.should.equal(activityUrl)
+      activity.object.type.should.equal('Note')
+      activity.object.content.should.be.a.String()
+    })
   })
 })

--- a/tests/api/activitypub/actor.test.js
+++ b/tests/api/activitypub/actor.test.js
@@ -6,6 +6,9 @@ const { updateUser } = require('../utils/users')
 const { shouldNotBeCalled, rethrowShouldNotBeCalledErrors, publicReq } = require('../utils/utils')
 const { createShelf } = require('../fixtures/shelves')
 const { getActorName } = require('../utils/shelves')
+const CONFIG = require('config')
+const { publicHost } = CONFIG
+const fullPublicHost = CONFIG.fullPublicHost()
 
 describe('activitypub:actor', () => {
   it('should reject unknown actor', async () => {
@@ -100,6 +103,17 @@ describe('activitypub:actor', () => {
       const actorUrl = makeUrl({ params: { action: 'actor', name: 'wd-Q237087' } })
       const body = await publicReq('get', actorUrl)
       body.icon.url.should.startWith('https://commons.wikimedia.org/wiki/Special:FilePath')
+    })
+
+    it('should set URLs as attachment', async () => {
+      const actorUrl = makeUrl({ params: { action: 'actor', name: 'wd-Q237087' } })
+      const body = await publicReq('get', actorUrl)
+      body.attachment[0].type.should.equal('PropertyValue')
+      body.attachment[0].name.should.equal(publicHost)
+      body.attachment[0].value.should.containEql(`${fullPublicHost}/entity/wd:Q237087`)
+      body.attachment[1].type.should.equal('PropertyValue')
+      body.attachment[1].name.should.equal('wikidata.org')
+      body.attachment[1].value.should.containEql('https://www.wikidata.org/wiki/Q237087')
     })
   })
 

--- a/tests/api/activitypub/inbox_undo.test.js
+++ b/tests/api/activitypub/inbox_undo.test.js
@@ -97,6 +97,36 @@ describe('activitypub:inbox:Undo', () => {
       const activities2 = await getFollowActivitiesByObject(name)
       activities2.length.should.equal(0)
     })
+
+    it('should accept an "object" as object', async () => {
+      const { uri } = await createHuman()
+      const name = getEntityActorName(uri)
+      const actorUrl = makeUrl({ params: { action: 'actor', name } })
+      const inboxUrl = makeUrl({ params: { action: 'inbox', name } })
+      const emitterUser = await createRemoteActivityPubServerUser()
+      await signedReq({
+        emitterUser,
+        type: 'Follow',
+        object: actorUrl,
+        url: inboxUrl
+      })
+      const activities = await getFollowActivitiesByObject(name)
+      const activity = activities[0]
+      await signedReq({
+        emitterUser,
+        url: inboxUrl,
+        type: 'Undo',
+        object: {
+          id: activity.externalId,
+          type: 'Follow',
+          actor: emitterUser.actor,
+          object: actorUrl
+        }
+      })
+      await wait(500)
+      const activities2 = await getFollowActivitiesByObject(name)
+      activities2.length.should.equal(0)
+    })
   })
 
   describe('shelf', () => {

--- a/tests/api/activitypub/outbox.test.js
+++ b/tests/api/activitypub/outbox.test.js
@@ -213,7 +213,7 @@ describe('outbox', () => {
       createActivity.type.should.equal('Create')
       createActivity.object.type.should.equal('Note')
       createActivity.object.content.should.startWith('<p>')
-      new URL(createActivity.object.id).searchParams.get('id').should.containEql(workId)
+      new URL(createActivity.object.id).searchParams.get('id').should.containEql(`inv-${workId}-`)
       createActivity.to.should.containEql('Public')
     })
 


### PR DESCRIPTION
a PR that makes various follow up after https://github.com/inventaire/inventaire/pull/552 https://github.com/inventaire/inventaire/pull/554 https://github.com/inventaire/inventaire/pull/544

remaining todo:
- implement `/api/activitypub?action=activity` for shelves activities