### PR TITLE
entities: add restore-version endpoint

### DIFF
--- a/server/controllers/entities/entities.js
+++ b/server/controllers/entities/entities.js
@@ -38,6 +38,7 @@ module.exports = {
       'update-claim': require('./update_claim'),
       'update-label': require('./update_label'),
       'revert-edit': require('./revert_edit'),
+      'restore-version': require('./restore_version'),
       'move-to-wikidata': require('./move_to_wikidata')
     },
     dataadmin: {

--- a/server/controllers/entities/history.js
+++ b/server/controllers/entities/history.js
@@ -1,7 +1,5 @@
 // An endpoint to get entities history as snapshots and diffs
 const _ = require('builders/utils')
-const error_ = require('lib/error/error')
-const responses_ = require('lib/responses')
 const patches_ = require('./lib/patches')
 const { hasAdminAccess } = require('lib/user_access_levels')
 const user_ = require('controllers/user/lib/user')

--- a/server/controllers/entities/lib/restore_version.js
+++ b/server/controllers/entities/lib/restore_version.js
@@ -1,0 +1,27 @@
+const Patch = require('models/patch')
+const entities_ = require('./entities')
+const patches_ = require('./patches')
+const validateEntity = require('./validate_entity')
+
+module.exports = async (patchId, userId) => {
+  const entityId = patchId.split(':')[0]
+  const restoredPatchIdNum = parseInt(patchId.split(':')[1])
+  const currentDoc = await entities_.byId(entityId)
+  const patches = await patches_.byEntityId(entityId)
+
+  const patchesToRevert = patches
+    .filter(patch => getPatchIdNum(patch._id) > restoredPatchIdNum)
+    .sort(byDescendingPatchIdNum)
+
+  let updatedDoc = currentDoc
+  for (const patchToRevert of patchesToRevert) {
+    updatedDoc = Patch.revert(updatedDoc, patchToRevert)
+  }
+
+  await validateEntity(updatedDoc)
+  const context = { restoredPatch: patchId }
+  return entities_.putUpdate({ userId, currentDoc, updatedDoc, context })
+}
+
+const getPatchIdNum = patchId => patchId.split(':')[1]
+const byDescendingPatchIdNum = (a, b) => getPatchIdNum(b._id) - getPatchIdNum(a._id)

--- a/server/controllers/entities/restore_version.js
+++ b/server/controllers/entities/restore_version.js
@@ -1,0 +1,12 @@
+const restoreVersion = require('./lib/restore_version')
+
+const sanitization = {
+  patch: {}
+}
+
+const controller = async ({ patchId, reqUserId }) => {
+  await restoreVersion(patchId, reqUserId)
+  return { ok: true }
+}
+
+module.exports = { sanitization, controller }

--- a/tests/api/entities/restore.test.js
+++ b/tests/api/entities/restore.test.js
@@ -1,0 +1,34 @@
+const should = require('should')
+const randomString = require('lib/utils/random_string')
+const { getByUri, updateLabel, restoreVersion, getHistory, addClaim } = require('../utils/entities')
+const { createWork } = require('../fixtures/entities')
+
+describe('entities:restore', () => {
+  it('should restore after label updates', async () => {
+    const originalLabel = randomString(6)
+    const { uri } = await createWork({ labels: { en: originalLabel } })
+    await updateLabel(uri, 'en', randomString(6))
+    await updateLabel(uri, 'en', randomString(6))
+    const firstVersionPatchId = `${uri.split(':')[1]}:2`
+    const res = await restoreVersion(firstVersionPatchId)
+    res.should.be.ok()
+    const work = await getByUri(uri)
+    work.labels.en.should.equal(originalLabel)
+    const restoredHistory = await getHistory(uri)
+    restoredHistory.length.should.equal(4)
+  })
+
+  it('should restore after claim update', async () => {
+    const { uri } = await createWork({ claims: { 'wdt:P50': [ 'wd:Q1174579' ] } })
+    await addClaim(uri, 'wdt:P921', 'wd:Q3196867')
+    await addClaim(uri, 'wdt:P50', 'wd:Q216092')
+    const firstVersionPatchId = `${uri.split(':')[1]}:2`
+    const res = await restoreVersion(firstVersionPatchId)
+    res.should.be.ok()
+    const work = await getByUri(uri)
+    work.claims['wdt:P50'].should.deepEqual([ 'wd:Q1174579' ])
+    should(work.claims['wdt:P921']).not.be.ok()
+    const restoredHistory = await getHistory(uri)
+    restoredHistory.length.should.equal(4)
+  })
+})

--- a/tests/api/utils/entities.js
+++ b/tests/api/utils/entities.js
@@ -97,7 +97,12 @@ const entitiesUtils = module.exports = {
   revertEdit: patchId => {
     assert_.string(patchId)
     return authReq('put', '/api/entities?action=revert-edit', { patch: patchId })
-  }
+  },
+
+  restoreVersion: patchId => {
+    assert_.string(patchId)
+    return authReq('put', '/api/entities?action=restore-version', { patch: patchId })
+  },
 }
 
 const normalizeUri = uri => _.isInvEntityId(uri) ? `inv:${uri}` : uri


### PR DESCRIPTION
continuing on #408

This would be useful to revert what seems to be repeated mistakes(?) of a user that used existing editions to turn them into completely different editions ([example](https://inventaire.io/entity/isbn:9782035858603/history)). Reverting one edit at a time makes the operation somewhat tedious, and the history unnecessarily big and hard to read (example [1](https://inventaire.io/entity/isbn:9782226062130/history), [2](https://inventaire.io/entity/isbn:9782070322831/history))