### PR TITLE
invitations: by_email: do not throw when an empty string is sent as message

### DIFF
--- a/server/lib/sanitize/parameters.js
+++ b/server/lib/sanitize/parameters.js
@@ -37,12 +37,15 @@ const positiveInteger = {
 }
 
 const nonEmptyString = {
-  format: str => {
+  format: (str, name, config) => {
+    if (str === '' && config.optional) return
     if (typeof str === 'string') return str.normalize().trim()
     // Let the validation throw an error
     else return str
   },
   validate: (value, name, config) => {
+    if (value == null && config.optional) return true
+
     if (!_.isString(value)) {
       const details = `expected string, got ${_.typeOf(value)}`
       throw error_.new(`invalid ${name}: ${details}`, 400, { value })

--- a/tests/api/invitations/by_emails.test.js
+++ b/tests/api/invitations/by_emails.test.js
@@ -28,6 +28,11 @@ describe('invitations:by-emails', () => {
       emails[1].should.equal('b@foo.org')
     })
 
+    it('should accept an empty message', async () => {
+      const { emails } = await authReq('post', endpoint, { emails: 'a@foo.org', message: '' })
+      emails[0].should.equal('a@foo.org')
+    })
+
     it('should reject missing emails', async () => {
       await authReq('post', endpoint, {})
       .then(shouldNotBeCalled)


### PR DESCRIPTION
as the message is optional anyway