### PR TITLE
create_inv_entity: skip creation of a blank entity

### DIFF
--- a/server/controllers/entities/lib/create_inv_entity.js
+++ b/server/controllers/entities/lib/create_inv_entity.js
@@ -1,4 +1,5 @@
 const _ = require('builders/utils')
+const Entity = require('models/entity')
 const entities_ = require('./entities')
 const validateEntity = require('./validate_entity')
 const { prefixifyInv } = require('./prefix')
@@ -9,9 +10,10 @@ module.exports = async params => {
 
   await validateEntity({ labels, claims })
 
-  const blankEntityDoc = await entities_.createBlank()
+  const blankEntityDoc = Entity.create()
 
   const entity = await entities_.edit({
+    create: true,
     userId,
     currentDoc: blankEntityDoc,
     updatedLabels: labels,


### PR DESCRIPTION
to prevent having blank entities hanging in the database when the creation crashes due to, for instance, a missing wdt:P629 on an edition (we had 500 of those in the database before I deleted them today)