### PR TITLE
convert P1545 claims into qualifiers of P179 on-the-fly

### DIFF
--- a/server/controllers/entities/lib/create_wd_entity.js
+++ b/server/controllers/entities/lib/create_wd_entity.js
@@ -6,6 +6,7 @@ const validateEntity = require('./validate_entity')
 const getEntityType = require('./get_entity_type')
 const properties = require('./properties/properties_values_constraints')
 const { prefixifyWd, unprefixify } = require('./prefix')
+const { relocateQualifierProperties } = require('lib/wikidata/data_model_adapter')
 const allowlistedEntityTypes = [ 'work', 'serie', 'human', 'publisher', 'collection' ]
 
 module.exports = async params => {
@@ -63,8 +64,8 @@ const validateWikidataCompliance = entity => {
 
 const format = entity => {
   const { claims } = entity
-  entity.claims = Object.keys(claims)
-    .reduce(unprefixifyClaims(claims), {})
+  entity.claims = Object.keys(claims).reduce(unprefixifyClaims(claims), {})
+  relocateQualifierProperties(entity)
   return entity
 }
 

--- a/server/controllers/entities/lib/entities_relations_temporary_cache.js
+++ b/server/controllers/entities/lib/entities_relations_temporary_cache.js
@@ -26,6 +26,7 @@ module.exports = {
       { type: 'del', key },
       { type: 'del', key: expireTimeKey },
     ])
+    .catch(ignoreKeyNotFound)
   }
 }
 
@@ -78,6 +79,10 @@ const checkExpiredCache = async () => {
     batch.push({ type: 'del', key: expiredTimeKeys })
   }
   await db.batch(batch)
+}
+
+const ignoreKeyNotFound = err => {
+  if (err.name !== 'NotFoundError') throw err
 }
 
 setInterval(checkExpiredCache, checkFrequency)

--- a/server/controllers/entities/lib/queries_utils.js
+++ b/server/controllers/entities/lib/queries_utils.js
@@ -1,3 +1,5 @@
+const { isPositiveIntegerString } = require('lib/boolean_validations')
+
 module.exports = {
   getSimpleDayDate: date => {
     if (date) {
@@ -13,7 +15,7 @@ module.exports = {
   sortByScore: (a, b) => b.score - a.score
 }
 
-const earliestDate = -10000
+const earliestDate = -10e10
 const getPartScore = obj => {
   const { date, ordinal, subparts } = obj
   // Push parts with subparts up if they don't have a date or ordinal of their own
@@ -31,6 +33,15 @@ const lastYearTime = new Date('2100').getTime()
 
 const lastOrdinal = 1000
 const ordinalNum = ordinal => {
-  if (/^\d+$/.test(ordinal)) return parseInt(ordinal)
-  else return lastOrdinal
+  if (isPositiveIntegerString(ordinal)) {
+    return parseInt(ordinal)
+  } else {
+    // Allows to sort ordinals that combine letters and numbers
+    // ex: HS1 should come before HS2, but after numbers-only ordinals
+    return lastOrdinal + getStringNumericRepresentation(ordinal)
+  }
+}
+
+const getStringNumericRepresentation = ordinal => {
+  return parseInt(Buffer.from(ordinal).toString('hex'), 16)
 }

--- a/server/controllers/entities/lib/update_wd_claim.js
+++ b/server/controllers/entities/lib/update_wd_claim.js
@@ -8,6 +8,7 @@ const properties = require('./properties/properties_values_constraints')
 const entitiesRelationsTemporaryCache = require('./entities_relations_temporary_cache')
 const { cachedRelationProperties } = require('./temporarily_cache_relations')
 const { unprefixify, prefixifyWd } = require('./prefix')
+const { qualifierProperties } = require('lib/wikidata/data_model_adapter')
 
 module.exports = async (user, id, property, oldValue, newValue) => {
   wdOauth.validate(user)
@@ -31,15 +32,10 @@ module.exports = async (user, id, property, oldValue, newValue) => {
 
   let res
 
-  if (newValue) {
-    if (oldValue) {
-      res = await wdEdit.claim.update({ id, property: propertyId, oldValue, newValue }, { credentials })
-    } else {
-      res = await wdEdit.claim.create({ id, property: propertyId, value: newValue }, { credentials })
-    }
+  if (qualifierProperties[propertyId]) {
+    res = await updateRelocatedClaim({ id, propertyId, newValue, oldValue, credentials })
   } else {
-    const guid = await getClaimGuid(id, propertyId, oldValue)
-    res = await wdEdit.claim.remove({ guid }, { credentials })
+    res = await updateClaim({ id, propertyId, newValue, oldValue, credentials })
   }
 
   if (cachedRelationProperties.includes(property)) {
@@ -57,11 +53,57 @@ module.exports = async (user, id, property, oldValue, newValue) => {
   return res
 }
 
-const getClaimGuid = async (id, propertyId, oldVal) => {
+const updateClaim = async ({ id, propertyId, newValue, oldValue, credentials }) => {
+  if (newValue) {
+    if (oldValue) {
+      return wdEdit.claim.update({ id, property: propertyId, oldValue, newValue }, { credentials })
+    } else {
+      return wdEdit.claim.create({ id, property: propertyId, value: newValue }, { credentials })
+    }
+  } else {
+    const guid = await getClaimGuid(id, propertyId, oldValue)
+    return wdEdit.claim.remove({ guid }, { credentials })
+  }
+}
+
+const updateRelocatedClaim = async params => {
+  const { id, propertyId, newValue, oldValue, credentials } = params
+  const { claimProperty, noClaimErrorMessage, tooManyClaimsErrorMessage } = qualifierProperties[propertyId]
+  const propertyClaims = await getPropertyClaims(id, claimProperty)
+  if (!propertyClaims) throw error_.new(noClaimErrorMessage, 400, params)
+  if (propertyClaims.length !== 1) throw error_.new(tooManyClaimsErrorMessage, 400, params)
+  const claim = propertyClaims[0]
+  const guid = claim.id
+  if (newValue) {
+    if (oldValue) {
+      return wdEdit.qualifier.update({ guid, property: propertyId, oldValue, newValue }, { credentials })
+    } else {
+      return wdEdit.qualifier.set({ guid, property: propertyId, value: newValue }, { credentials })
+    }
+  } else {
+    const hash = getQualifierHash(claim, propertyId, oldValue)
+    return wdEdit.qualifier.remove({ guid, hash }, { credentials })
+  }
+}
+
+const getPropertyClaims = async (id, propertyId) => {
   const entity = await getWdEntity([ id ])
-  const propClaims = entity.claims[propertyId]
+  return entity.claims[propertyId]
+}
+
+const getClaimGuid = async (id, propertyId, oldVal) => {
+  const propClaims = await getPropertyClaims(id, propertyId)
   const simplifyPropClaims = wdk.simplify.propertyClaims(propClaims)
   const oldValIndex = simplifyPropClaims.indexOf(oldVal)
   const targetClaim = propClaims[oldValIndex]
   return targetClaim.id
+}
+
+const getQualifierHash = (claim, property, value) => {
+  const qualifiers = wdk.simplify.propertyQualifiers(claim.qualifiers[property], { keepHashes: true })
+  const matchingQualifiers = qualifiers.filter(qualifier => qualifier.value === value)
+  if (matchingQualifiers.length !== 1) {
+    throw error_.new('unique matching qualifier not found', 400, { claim, property, value })
+  }
+  return matchingQualifiers[0].hash
 }

--- a/server/lib/wikidata/data_model_adapter.js
+++ b/server/lib/wikidata/data_model_adapter.js
@@ -1,4 +1,15 @@
 const error_ = require('lib/error/error')
+const { qualifier: simplifyQualifier } = require('wikidata-sdk').simplify
+
+const flattenQualifierProperties = (simplifiedClaims, rawClaims) => {
+  if (simplifiedClaims['wdt:P179']?.length === 1) {
+    const { qualifiers: serieQualifiers } = rawClaims.P179[0]
+    if (serieQualifiers?.P1545?.length === 1) {
+      const simplifiedQualifier = simplifyQualifier(serieQualifiers.P1545[0])
+      simplifiedClaims['wdt:P1545'] = [ simplifiedQualifier ]
+    }
+  }
+}
 
 const relocateQualifierProperties = invEntity => {
   const { claims } = invEntity
@@ -30,4 +41,4 @@ const relocateQualifierProperties = invEntity => {
   delete claims['wdt:P1545']
 }
 
-module.exports = { relocateQualifierProperties }
+module.exports = { flattenQualifierProperties, relocateQualifierProperties }

--- a/server/lib/wikidata/data_model_adapter.js
+++ b/server/lib/wikidata/data_model_adapter.js
@@ -1,0 +1,33 @@
+const error_ = require('lib/error/error')
+
+const relocateQualifierProperties = invEntity => {
+  const { claims } = invEntity
+  const series = claims['wdt:P179']
+  const seriesOrdinals = claims['wdt:P1545']
+
+  if (!seriesOrdinals) return
+
+  if (!series) {
+    throw error_.new('a serie ordinal can not be move to Wikidata without a serie', 400, invEntity)
+  }
+
+  if (series.length !== 1) {
+    throw error_.new('a serie ordinal can not be set on several serie claims', 400, invEntity)
+  }
+
+  if (seriesOrdinals.length !== 1) {
+    throw error_.new('can not import several serie ordinals', 400, invEntity)
+  }
+
+  // Using wikibase-edit compact notation
+  claims['wdt:P179'] = {
+    value: series[0],
+    qualifiers: {
+      'wdt:P1545': seriesOrdinals[0],
+    }
+  }
+
+  delete claims['wdt:P1545']
+}
+
+module.exports = { relocateQualifierProperties }

--- a/server/lib/wikidata/data_model_adapter.js
+++ b/server/lib/wikidata/data_model_adapter.js
@@ -41,4 +41,12 @@ const relocateQualifierProperties = invEntity => {
   delete claims['wdt:P1545']
 }
 
-module.exports = { flattenQualifierProperties, relocateQualifierProperties }
+const qualifierProperties = {
+  P1545: {
+    claimProperty: 'P179',
+    noClaimErrorMessage: 'a serie needs to be set before setting an ordinal',
+    tooManyClaimsErrorMessage: 'there needs to be exactly one serie to be allowed to set an ordinal',
+  }
+}
+
+module.exports = { flattenQualifierProperties, relocateQualifierProperties, qualifierProperties }

--- a/server/lib/wikidata/format_claims.js
+++ b/server/lib/wikidata/format_claims.js
@@ -2,6 +2,7 @@ const _ = require('builders/utils')
 const assert_ = require('lib/utils/assert_types')
 const { claims: simplifyClaims } = require('wikidata-sdk').simplify
 const allowlistedProperties = require('./allowlisted_properties')
+const { flattenQualifierProperties } = require('./data_model_adapter')
 
 const options = {
   entityPrefix: 'wd',
@@ -13,5 +14,9 @@ module.exports = (claims, wdId) => {
   assert_.object(claims)
   assert_.string(wdId)
   const allowlistedClaims = _.pick(claims, allowlistedProperties)
-  return simplifyClaims(allowlistedClaims, options)
+  const simplifiedClaims = simplifyClaims(allowlistedClaims, options)
+
+  flattenQualifierProperties(simplifiedClaims, allowlistedClaims)
+
+  return simplifiedClaims
 }

--- a/tests/api/entities/get_by_uris.test.js
+++ b/tests/api/entities/get_by_uris.test.js
@@ -4,6 +4,7 @@ const { authReq, shouldNotBeCalled, rethrowShouldNotBeCalledErrors } = require('
 const { createEditionWithIsbn, createWorkWithAuthor, createEditionWithWorkAuthorAndSerie, createHuman, someFakeUri, generateIsbn13 } = require('../fixtures/entities')
 const { getByUris, merge, deleteByUris } = require('../utils/entities')
 const workWithAuthorPromise = createWorkWithAuthor()
+const getWdEntity = require('data/wikidata/get_entity')
 
 describe('entities:get:by-uris', () => {
   it('should reject invalid uri', async () => {
@@ -146,5 +147,38 @@ describe('entities:get:by-isbns', () => {
     entity.should.be.an.Object()
     entity.uri.should.equal(uri)
     should(res.notFound).not.be.ok()
+  })
+})
+
+describe('wikidata qualifiers adapter', () => {
+  it('should flatten wikidata qualifier properties used as mainsnak in inventaire', async () => {
+    const id = 'Q3024217'
+    const uri = `wd:${id}`
+
+    // The test relies on the state of an entity on Wikidata that needs
+    // to be checked to assert that we are actually testing the desired behavior
+    const rawEntity = await getWdEntity(id)
+    if (rawEntity.claims.P1545) throw new Error(`${id} should not have a P1545 claim`)
+
+    const { entities } = await getByUris(uri, null, true)
+    const entity = entities[uri]
+    entity.claims['wdt:P179'].should.deepEqual([ 'wd:Q1130014' ])
+    // This claim is expected to be a qualifier from the one above
+    entity.claims['wdt:P1545'].should.deepEqual([ '111' ])
+  })
+
+  it('should not flatten wikidata qualifier properties when there are too many', async () => {
+    const id = 'Q54802792'
+    const uri = `wd:${id}`
+
+    // The test relies on the state of an entity on Wikidata that needs
+    // to be checked to assert that we are actually testing the desired behavior
+    const rawEntity = await getWdEntity(id)
+    if (rawEntity.claims.P179.length !== 2) throw new Error(`${id} should have 2 P179 claims`)
+    if (rawEntity.claims.P1545) throw new Error(`${id} should not have a P1545 claim`)
+
+    const { entities } = await getByUris(uri, null, true)
+    const entity = entities[uri]
+    should(entity.claims['wdt:P1545']).not.be.ok()
   })
 })

--- a/tests/unit/libs/051-wikidata_data_model_converter.js
+++ b/tests/unit/libs/051-wikidata_data_model_converter.js
@@ -1,0 +1,76 @@
+require('should')
+const { relocateQualifierProperties } = require('lib/wikidata/data_model_adapter')
+const { shouldNotBeCalled } = require('../utils')
+
+describe('wikidata data model converter', () => {
+  describe('relocateQualifierProperties', () => {
+    it('should pass when no serie ordinal is set', () => {
+      relocateQualifierProperties({ claims: {} })
+    })
+
+    it('should throw when no serie is set but a serie ordinal is', () => {
+      try {
+        relocateQualifierProperties({
+          claims: {
+            'wdt:P1545': [ '1' ]
+          }
+        })
+        shouldNotBeCalled()
+      } catch (err) {
+        err.message.should.equal('a serie ordinal can not be move to Wikidata without a serie')
+      }
+    })
+
+    it('should not throw when several series are set but no ordinal', () => {
+      relocateQualifierProperties({
+        claims: {
+          'wdt:P179': [ 'wd:Q1', 'wd:Q2' ],
+        }
+      })
+    })
+
+    it('should throw when several series are set with an ordinal', () => {
+      try {
+        relocateQualifierProperties({
+          claims: {
+            'wdt:P179': [ 'wd:Q1', 'wd:Q2' ],
+            'wdt:P1545': [ '1' ],
+          }
+        })
+        shouldNotBeCalled()
+      } catch (err) {
+        err.message.should.equal('a serie ordinal can not be set on several serie claims')
+      }
+    })
+
+    it('should throw when several serie ordinals are set', () => {
+      try {
+        relocateQualifierProperties({
+          claims: {
+            'wdt:P179': [ 'wd:Q1' ],
+            'wdt:P1545': [ '1', '2' ],
+          }
+        })
+        shouldNotBeCalled()
+      } catch (err) {
+        err.message.should.equal('can not import several serie ordinals')
+      }
+    })
+
+    it('should move a serie ordinal as qualifier of a claim', () => {
+      const claims = {
+        'wdt:P179': [ 'wd:Q1' ],
+        'wdt:P1545': [ '1' ],
+      }
+      relocateQualifierProperties({ claims })
+      claims.should.deepEqual({
+        'wdt:P179': {
+          value: 'wd:Q1',
+          qualifiers: {
+            'wdt:P1545': '1',
+          }
+        }
+      })
+    })
+  })
+})


### PR DESCRIPTION
Addressing #433 the hacky way, until we get to support qualifiers #145 

P1545 being set as claims instead of qualifiers of P179 has been a recurring problem, more and more pressing as it was generating quite some frustration from the Wikidata community ([latest example](https://www.wikidata.org/wiki/User_talk:Fitz_Loinvoyant#Serial_ordinal)): this hacky fix would relieve the pressure and let us either take our time to implement qualifiers, or not implement it at all.

As for any operation editing Wikidata, writing automated tests is hard, so here are the manual tests for `update-claim`:
- [set a P1545 qualifier](https://www.wikidata.org/w/index.php?title=Q4115189&diff=1538602121&oldid=1538601961)
- [update an existing P1545 qualifier](https://www.wikidata.org/w/index.php?title=Q4115189&diff=1538602212&oldid=1538602121)
- [remove an existing P1545 qualifier](https://www.wikidata.org/w/index.php?title=Q4115189&diff=1538602281&oldid=1538602212)

`move-to-wikidata` would need to be tested in prod
