### PR TITLE
sanitization: parameter aliases and config validation at start-up

### DIFF
--- a/server/controllers/auth/connection.js
+++ b/server/controllers/auth/connection.js
@@ -1,14 +1,14 @@
-const { sanitize } = require('lib/sanitize/sanitize')
+const { sanitize, validateSanitization } = require('lib/sanitize/sanitize')
 const error_ = require('lib/error/error')
 const passport_ = require('lib/passport/passport')
 const setLoggedInCookie = require('./lib/set_logged_in_cookie')
 const { ownerSafeData } = require('controllers/user/lib/authorized_user_data_pickers')
 
-const signupSanitization = {
+const signupSanitization = validateSanitization({
   username: {},
   email: {},
   password: {}
-}
+})
 
 const logoutRedirect = (redirect, req, res) => {
   res.clearCookie('loggedIn')

--- a/server/controllers/auth/token.js
+++ b/server/controllers/auth/token.js
@@ -1,16 +1,16 @@
 const _ = require('builders/utils')
 const ActionsControllers = require('lib/actions_controllers')
 const token_ = require('controllers/user/lib/token')
-const { sanitize } = require('lib/sanitize/sanitize')
+const { sanitize, validateSanitization } = require('lib/sanitize/sanitize')
 const passport_ = require('lib/passport/passport')
 const setLoggedInCookie = require('./lib/set_logged_in_cookie')
 
-const sanitization = {
+const sanitization = validateSanitization({
   email: {},
   token: {
     length: token_.tokenLength
   }
-}
+})
 
 const confirmEmailValidity = async (req, res) => {
   const { email, token } = sanitize(req, res, sanitization)

--- a/server/controllers/entities/images.js
+++ b/server/controllers/entities/images.js
@@ -6,13 +6,13 @@
 // Primary use case: feed Elasticsearch documents with an 'images' object
 // from which to pick the best illustration for live search results
 
-const { sanitize } = require('lib/sanitize/sanitize')
+const { sanitize, validateSanitization } = require('lib/sanitize/sanitize')
 const error_ = require('lib/error/error')
 const getEntitiesImages = require('./lib/get_entities_images')
 const { img: imgUrlBuilder } = require('lib/emails/app_api')
 const getThumbData = require('data/commons/thumb')
 
-const sanitization = {
+const sanitization = validateSanitization({
   uris: {},
   refresh: { optional: true },
   redirect: {
@@ -27,7 +27,7 @@ const sanitization = {
     generic: 'positiveInteger',
     optional: true
   }
-}
+})
 
 module.exports = async (req, res) => {
   const { uris, refresh, redirect, width, height } = sanitize(req, res, sanitization)

--- a/server/controllers/feeds/feeds.js
+++ b/server/controllers/feeds/feeds.js
@@ -1,13 +1,13 @@
 const error_ = require('lib/error/error')
 const headers_ = require('lib/headers')
-const { sanitize } = require('lib/sanitize/sanitize')
+const { sanitize, validateSanitization } = require('lib/sanitize/sanitize')
 const getAuthentifiedUser = require('./lib/get_authentified_user')
 const userFeedData = require('./lib/user_feed_data')
 const groupFeedData = require('./lib/group_feed_data')
 const shelfFeedData = require('./lib/shelf_feed_data')
 const generateFeedFromFeedData = require('./lib/generate_feed_from_feed_data')
 
-const sanitization = {
+const sanitization = validateSanitization({
   user: {
     optional: true
   },
@@ -28,7 +28,7 @@ const sanitization = {
     // Set the defaults manually after having checked req.headers
     default: null
   }
-}
+})
 
 module.exports = {
   get: async (req, res) => {

--- a/server/controllers/invitations/by_emails.js
+++ b/server/controllers/invitations/by_emails.js
@@ -8,13 +8,13 @@ const sendInvitationAndReturnData = require('./lib/send_invitation_and_return_da
 const groups_ = require('controllers/groups/lib/groups')
 const Group = require('models/group')
 const { Track } = require('lib/track')
-const { sanitize } = require('lib/sanitize/sanitize')
+const { sanitize, validateSanitization } = require('lib/sanitize/sanitize')
 
-const sanitization = {
+const sanitization = validateSanitization({
   emails: {},
   message: { optional: true },
   group: { optional: true },
-}
+})
 
 module.exports = async (req, res) => {
   const params = sanitize(req, res, sanitization)

--- a/server/controllers/items/export.js
+++ b/server/controllers/items/export.js
@@ -1,4 +1,4 @@
-const { sanitize } = require('lib/sanitize/sanitize')
+const { sanitize, validateSanitization } = require('lib/sanitize/sanitize')
 const items_ = require('./lib/items')
 const addEntitiesData = require('./lib/export/add_entities_data')
 const FormatItemRow = require('./lib/export/format_item_row')
@@ -6,11 +6,11 @@ const csvHeaderRow = require('./lib/export/csv_header_row')
 const responses_ = require('lib/responses')
 const shelves_ = require('controllers/shelves/lib/shelves')
 
-const sanitization = {
+const sanitization = validateSanitization({
   format: {
     allowlist: [ 'csv' ]
   }
-}
+})
 
 module.exports = async (req, res) => {
   const { reqUserId } = sanitize(req, res, sanitization)

--- a/server/controllers/transactions/update_state.js
+++ b/server/controllers/transactions/update_state.js
@@ -3,15 +3,15 @@ const responses_ = require('lib/responses')
 const transactions_ = require('./lib/transactions')
 const { verifyIsRequester, verifyIsOwner, verifyRightToInteract } = require('./lib/rights_verification')
 const { states, statesList } = require('models/attributes/transaction')
-const { sanitize } = require('lib/sanitize/sanitize')
+const { sanitize, validateSanitization } = require('lib/sanitize/sanitize')
 const { Track } = require('lib/track')
 
-const sanitization = {
+const sanitization = validateSanitization({
   transaction: {},
   state: {
     allowlist: statesList
   }
-}
+})
 
 module.exports = (req, res) => {
   const params = sanitize(req, res, sanitization)

--- a/server/lib/controller_wrapper.js
+++ b/server/lib/controller_wrapper.js
@@ -3,7 +3,7 @@ const error_ = require('lib/error/error')
 const validateObject = require('lib/validate_object')
 const { rolesByAccess } = require('./user_access_levels')
 const { send } = require('./responses')
-const { sanitize } = require('./sanitize/sanitize')
+const { sanitize, validateSanitization } = require('./sanitize/sanitize')
 const { track } = require('./track')
 const assert_ = require('./utils/assert_types')
 const { verifySignature } = require('../controllers/activitypub/lib/security')
@@ -56,7 +56,10 @@ const validateControllerWrapperParams = controllerParams => {
   assert_.string(access)
   assert_.array(rolesByAccess[access])
   assert_.function(controller)
-  if (sanitization) assert_.object(sanitization)
+  if (sanitization) {
+    assert_.object(sanitization)
+    validateSanitization(sanitization)
+  }
   if (trackActionArray) assert_.array(trackActionArray)
 }
 

--- a/server/lib/sanitize/parameters.js
+++ b/server/lib/sanitize/parameters.js
@@ -195,22 +195,6 @@ const generics = {
   }
 }
 
-const value = {
-  // Endpoints accepting a 'value' can specify a type
-  // or have to do their own validation
-  // as a value can be anything, including null
-  validate: (value, name, config) => {
-    const { type: expectedType } = config
-    if (expectedType) {
-      const valueType = _.typeOf(value)
-      if (valueType !== expectedType) {
-        throw error_.new(`invalid value type: ${valueType} (expected ${expectedType})`, 400, { value })
-      }
-    }
-    return true
-  }
-}
-
 module.exports = {
   '@context': allowlistedStrings,
   actor: nonEmptyString,
@@ -255,10 +239,8 @@ module.exports = {
   listing: allowlistedString,
   message: nonEmptyString,
   name: nonEmptyString,
-  'new-value': value,
   object: nonEmptyString,
   offset: Object.assign({}, positiveInteger, { default: 0 }),
-  'old-value': value,
   options: allowlistedStrings,
   owners: couchUuids,
   password: {
@@ -310,5 +292,19 @@ module.exports = {
   usernames,
   relatives: allowlistedStrings,
   requester: couchUuid,
-  value,
+  // Endpoints accepting a 'value' can specify a type
+  // or have to do their own validation
+  // as a value can be anything, including null
+  value: {
+    validate: (value, name, config) => {
+      const { type: expectedType } = config
+      if (expectedType) {
+        const valueType = _.typeOf(value)
+        if (valueType !== expectedType) {
+          throw error_.new(`invalid value type: ${valueType} (expected ${expectedType})`, 400, { value })
+        }
+      }
+      return true
+    },
+  },
 }

--- a/server/lib/sanitize/sanitize.js
+++ b/server/lib/sanitize/sanitize.js
@@ -39,8 +39,6 @@ const sanitize = (req, res, configs) => {
   return input
 }
 
-module.exports = { sanitize }
-
 const optionsNames = new Set([ 'nonJsonBody' ])
 
 const sanitizeParameter = (input, name, config, place, res) => {
@@ -79,16 +77,29 @@ const getParameterFunctions = (name, generic) => {
   } else {
     parameter = parameters[name]
   }
+  return parameter
+}
 
+const validateSanitization = configs => {
+  for (const name in configs) {
+    if (!optionsNames.has(name)) {
+      const config = configs[name]
+      validateSanitizationParameter(name, config)
+    }
+  }
+  return configs
+}
+
+const validateSanitizationParameter = (name, config) => {
+  const { generic } = config
+  const parameter = getParameterFunctions(name, generic)
   if (parameter == null) {
     if (generic) {
-      throw error_.new('invalid generic name', 500, { generic })
+      throw error_.new('invalid generic name', 500, { name, generic })
     } else {
       throw error_.new('invalid parameter name', 500, { name })
     }
   }
-
-  return parameter
 }
 
 const prefixedParameterPattern = /^(old|new)-/
@@ -150,3 +161,5 @@ const addWarning = (res, message) => {
   _.warn(message)
   responses_.addWarning(res, 'parameters', message)
 }
+
+module.exports = { sanitize, validateSanitization }

--- a/server/lib/sanitize/sanitize.js
+++ b/server/lib/sanitize/sanitize.js
@@ -51,9 +51,7 @@ const sanitizeParameter = (input, name, config, place, res) => {
     if (generic) {
       throw error_.new('invalid generic name', 500, { generic })
     } else {
-      addWarning(res, `unexpected config parameter: ${name}`)
-      delete input[name]
-      return
+      throw error_.new('invalid parameter name', 500, { name })
     }
   }
 

--- a/tests/unit/libs/046-sanitize.js
+++ b/tests/unit/libs/046-sanitize.js
@@ -14,18 +14,20 @@ describe('sanitize', () => {
     }
   })
 
-  it('should add a warning for unknown parameter (server error)', async () => {
+  it('should throw a 500 when the server uses an unknown parameter', async () => {
     const req = { query: { foo: 1000 } }
     const res = {}
     const configs = {
       foo: {}
     }
-    const input = sanitize(req, res, configs)
-    input.should.deepEqual({})
-    res.warnings.should.be.an.Object()
-    res.warnings.parameters.should.deepEqual([
-      'unexpected config parameter: foo'
-    ])
+    try {
+      sanitize(req, res, configs)
+      shouldNotBeCalled()
+    } catch (err) {
+      err.message.should.equal('invalid parameter name')
+      err.context.name.should.equal('foo')
+      err.statusCode.should.equal(500)
+    }
   })
 
   it('should add a warning for unexpected parameter (user error)', async () => {

--- a/tests/unit/libs/046-sanitize.js
+++ b/tests/unit/libs/046-sanitize.js
@@ -505,4 +505,34 @@ describe('sanitize', () => {
       bbox.should.deepEqual([ 0, 0, 1, 1 ])
     })
   })
+
+  describe('parameter prefixed aliases', () => {
+    it('should allow to use parameter aliases ', async () => {
+      const req = { query: { 'new-password': '12345678', 'old-password': '12345678' } }
+      const configs = { 'new-password': {}, 'old-password': {} }
+      sanitize(req, {}, configs)
+    })
+
+    it('should reject an alias used instead of the primary parameter name', async () => {
+      const req = { query: { 'new-password': '12345678' } }
+      const configs = { password: {} }
+      try {
+        sanitize(req, {}, configs)
+        shouldNotBeCalled()
+      } catch (err) {
+        err.message.should.equal('missing parameter in query: password')
+      }
+    })
+
+    it('should reject a primary paramer named used instead of an alias', async () => {
+      const req = { query: { password: '12345678' } }
+      const configs = { 'new-password': {} }
+      try {
+        sanitize(req, {}, configs)
+        shouldNotBeCalled()
+      } catch (err) {
+        err.message.should.equal('missing parameter in query: new-password')
+      }
+    })
+  })
 })


### PR DESCRIPTION
Does 2 features were coded together but do not depend on each others (could be splitted, if one is blocking)

## parameter aliases
Allow to use a well known sanitization parameter (ex: `password`) with a prefix (ex: `new`) without having to set yet another parameter in `server/lib/sanitize/parameters.js`

## config validation at start-up
Until this, if a controller was trying to use parameter not defined in `server/lib/sanitize/parameters.js`, that bug would only be raised when a user would make a request.