### PR TITLE
allow to filter contributions by claim property or label lang

### DIFF
--- a/server/controllers/entities/contributions.js
+++ b/server/controllers/entities/contributions.js
@@ -7,7 +7,11 @@ const sanitization = {
   limit: { default: 100, max: 1000 },
   offset: { default: 0 },
   property: { optional: true },
-  lang: { optional: true },
+  lang: {
+    optional: true,
+    // Override global parameter default
+    default: null,
+  },
 }
 
 const controller = params => {

--- a/server/controllers/entities/contributions.js
+++ b/server/controllers/entities/contributions.js
@@ -1,17 +1,22 @@
 // An endpoint to list entities edits made by a user
-const patches_ = require('./lib/patches')
+const { byUserId, byDate, byUserIdAndProperty } = require('./lib/patches')
 
 const sanitization = {
   user: { optional: true },
   limit: { default: 100, max: 1000 },
-  offset: { default: 0 }
+  offset: { default: 0 },
+  property: { optional: true },
 }
 
-const controller = ({ userId, limit, offset }) => {
+const controller = ({ userId, limit, offset, property }) => {
   if (userId != null) {
-    return patches_.byUserId(userId, limit, offset)
+    if (property) {
+      return byUserIdAndProperty({ userId, property, limit, offset })
+    } else {
+      return byUserId({ userId, limit, offset })
+    }
   } else {
-    return patches_.byDate(limit, offset)
+    return byDate({ limit, offset })
   }
 }
 

--- a/server/controllers/entities/contributions.js
+++ b/server/controllers/entities/contributions.js
@@ -1,29 +1,29 @@
 // An endpoint to list entities edits made by a user
 const { byUserId, byDate, byUserIdAndFilter } = require('./lib/patches')
 const error_ = require('lib/error/error')
+const { isPropertyUri, isLang } = require('lib/boolean_validations')
 
 const sanitization = {
   user: { optional: true },
   limit: { default: 100, max: 1000 },
   offset: { default: 0 },
-  property: { optional: true },
-  lang: {
+  filter: {
+    generic: 'string',
     optional: true,
-    // Override global parameter default
-    default: null,
-  },
+  }
 }
 
 const controller = params => {
-  const { userId, limit, offset, property, lang } = params
-  if (property && lang) {
-    throw error_.new('can not use both property and lang filters', 400, params)
+  const { userId, limit, offset, filter } = params
+
+  const hasFilter = filter != null
+
+  if (hasFilter && !(isPropertyUri(filter) || isLang(filter))) {
+    throw error_.new('invalid filter', 400, params)
   }
 
-  const filter = property || lang
-
   if (userId != null) {
-    if (filter) {
+    if (hasFilter) {
       return byUserIdAndFilter({ userId, filter, limit, offset })
     } else {
       return byUserId({ userId, limit, offset })

--- a/server/controllers/entities/contributions.js
+++ b/server/controllers/entities/contributions.js
@@ -1,14 +1,24 @@
 // An endpoint to list entities edits made by a user
 const { byUserId, byDate, byUserIdAndProperty } = require('./lib/patches')
+const error_ = require('lib/error/error')
 
 const sanitization = {
   user: { optional: true },
   limit: { default: 100, max: 1000 },
   offset: { default: 0 },
   property: { optional: true },
+  lang: { optional: true },
 }
 
-const controller = ({ userId, limit, offset, property }) => {
+const controller = params => {
+  const { userId, limit, offset, lang } = params
+  let { property } = params
+  if (property && lang) {
+    throw error_.new('can not use both property and lang filters', 400, params)
+  }
+
+  property = property || lang
+
   if (userId != null) {
     if (property) {
       return byUserIdAndProperty({ userId, property, limit, offset })

--- a/server/controllers/entities/contributions.js
+++ b/server/controllers/entities/contributions.js
@@ -1,5 +1,5 @@
 // An endpoint to list entities edits made by a user
-const { byUserId, byDate, byUserIdAndProperty } = require('./lib/patches')
+const { byUserId, byDate, byUserIdAndFilter } = require('./lib/patches')
 const error_ = require('lib/error/error')
 
 const sanitization = {
@@ -11,17 +11,16 @@ const sanitization = {
 }
 
 const controller = params => {
-  const { userId, limit, offset, lang } = params
-  let { property } = params
+  const { userId, limit, offset, property, lang } = params
   if (property && lang) {
     throw error_.new('can not use both property and lang filters', 400, params)
   }
 
-  property = property || lang
+  const filter = property || lang
 
   if (userId != null) {
-    if (property) {
-      return byUserIdAndProperty({ userId, property, limit, offset })
+    if (filter) {
+      return byUserIdAndFilter({ userId, filter, limit, offset })
     } else {
       return byUserId({ userId, limit, offset })
     }

--- a/server/controllers/entities/lib/patches.js
+++ b/server/controllers/entities/lib/patches.js
@@ -11,9 +11,20 @@ module.exports = {
   byId: db.get,
   byEntityId: entityId => db.viewByKeys('byEntityId', [ entityId ]),
   byEntityIds: entityIds => db.viewByKeys('byEntityId', entityIds),
-  byUserId: async (userId, limit, offset) => {
+
+  byDate: async ({ limit, offset }) => {
+    const viewRes = await db.view(designDocName, 'byDate', {
+      limit,
+      skip: offset,
+      descending: true,
+      include_docs: true
+    })
+    return formatPatchesPage({ viewRes, limit, offset })
+  },
+
+  byUserId: async ({ userId, limit, offset }) => {
     const [ viewRes, total ] = await Promise.all([
-      db.view(designDocName, 'byUserId', {
+      db.view(designDocName, 'byUserIdAndDate', {
         startkey: [ userId, maxKey ],
         endkey: [ userId ],
         descending: true,
@@ -24,20 +35,29 @@ module.exports = {
       }),
       // Unfortunately, the response doesn't gives the total range length
       // so we need to query it separately
-      getUserTotalContributions(userId)
+      getUserContributionsCount(userId)
     ])
 
     return formatPatchesPage({ viewRes, total, limit, offset })
   },
 
-  byDate: async (limit, offset) => {
-    const viewRes = await db.view(designDocName, 'byDate', {
-      limit,
-      skip: offset,
-      descending: true,
-      include_docs: true
-    })
-    return formatPatchesPage({ viewRes, limit, offset })
+  byUserIdAndProperty: async ({ userId, property, limit, offset }) => {
+    const [ viewRes, total ] = await Promise.all([
+      db.view(designDocName, 'byUserIdAndPropertyAndDate', {
+        startkey: [ userId, property, maxKey ],
+        endkey: [ userId, property ],
+        descending: true,
+        limit,
+        skip: offset,
+        include_docs: true,
+        reduce: false
+      }),
+      // Unfortunately, the response doesn't gives the total range length
+      // so we need to query it separately
+      getUserPropertyContributionsCount(userId, property)
+    ])
+
+    return formatPatchesPage({ viewRes, total, limit, offset })
   },
 
   byRedirectUri: db.viewByKey.bind(null, 'byRedirectUri'),
@@ -138,19 +158,29 @@ const sortAndFilterContributions = rows => {
 // see server/db/couchdb/hard_coded_documents.js
 const noSpecialUser = row => !row.user.startsWith('000000000000000000000000000000')
 
-const getUserTotalContributions = userId => {
-  return db.view(designDocName, 'byUserId', {
-    group_level: 1,
-    // Maybe there is a way to only pass the userId key
-    // but I couln't find it
+const getUserContributionsCount = userId => {
+  return getRangeLength({
+    viewName: 'byUserIdAndDate',
     startkey: [ userId ],
-    endkey: [ userId, maxKey ]
+    endkey: [ userId, maxKey ],
   })
-  // Testing the row existance in case we got an invalid user id
-  .then(res => {
-    const userRow = res.rows[0]
-    return userRow ? userRow.value : 0
+}
+
+const getUserPropertyContributionsCount = (userId, property) => {
+  return getRangeLength({
+    viewName: 'byUserIdAndPropertyAndDate',
+    startkey: [ userId, property ],
+    endkey: [ userId, property, maxKey ],
   })
+}
+
+const getRangeLength = async ({ viewName, startkey, endkey }) => {
+  const { rows } = await db.view(designDocName, viewName, {
+    group_level: startkey.length,
+    startkey,
+    endkey,
+  })
+  return rows[0] != null ? rows[0].value : 0
 }
 
 const formatPatchesPage = ({ viewRes, total, limit, offset }) => {

--- a/server/controllers/entities/lib/patches.js
+++ b/server/controllers/entities/lib/patches.js
@@ -41,11 +41,11 @@ module.exports = {
     return formatPatchesPage({ viewRes, total, limit, offset })
   },
 
-  byUserIdAndProperty: async ({ userId, property, limit, offset }) => {
+  byUserIdAndFilter: async ({ userId, filter, limit, offset }) => {
     const [ viewRes, total ] = await Promise.all([
-      db.view(designDocName, 'byUserIdAndPropertyAndDate', {
-        startkey: [ userId, property, maxKey ],
-        endkey: [ userId, property ],
+      db.view(designDocName, 'byUserIdAndFilterAndDate', {
+        startkey: [ userId, filter, maxKey ],
+        endkey: [ userId, filter ],
         descending: true,
         limit,
         skip: offset,
@@ -54,7 +54,7 @@ module.exports = {
       }),
       // Unfortunately, the response doesn't gives the total range length
       // so we need to query it separately
-      getUserPropertyContributionsCount(userId, property)
+      getUserPropertyContributionsCount(userId, filter)
     ])
 
     return formatPatchesPage({ viewRes, total, limit, offset })
@@ -166,11 +166,11 @@ const getUserContributionsCount = userId => {
   })
 }
 
-const getUserPropertyContributionsCount = (userId, property) => {
+const getUserPropertyContributionsCount = (userId, filter) => {
   return getRangeLength({
-    viewName: 'byUserIdAndPropertyAndDate',
-    startkey: [ userId, property ],
-    endkey: [ userId, property, maxKey ],
+    viewName: 'byUserIdAndFilterAndDate',
+    startkey: [ userId, filter ],
+    endkey: [ userId, filter, maxKey ],
   })
 }
 

--- a/server/db/couchdb/design_docs/patches.js
+++ b/server/db/couchdb/design_docs/patches.js
@@ -52,16 +52,17 @@ module.exports = {
     ],
     reduce: '_count'
   },
-  byUserIdAndPropertyAndDate: {
+  byUserIdAndFilterAndDate: {
     map: doc => {
       const { user, timestamp } = doc
       for (const operation of doc.patch) {
+        // ops included: 'add', 'remove'
         if (operation.op !== 'test') {
-          const property = operation.path.split('/')[2]
-          // Here `property` can be both a label lang or a claim property
-          if (property != null) {
+          // `filter` can be both a label lang or a claim property
+          const filter = operation.path.split('/')[2]
+          if (filter != null) {
             // return to only emit once per matching doc
-            return emit([ user, property, timestamp ])
+            return emit([ user, filter, timestamp ])
           }
         }
       }

--- a/server/db/couchdb/design_docs/patches.js
+++ b/server/db/couchdb/design_docs/patches.js
@@ -64,6 +64,8 @@ module.exports = {
             // return to only emit once per matching doc
             return emit([ user, filter, timestamp ])
           }
+          // TODO: handle case where path=/claims or path=/labels
+          // Known case: after a reverse merge
         }
       }
     },

--- a/server/db/couchdb/design_docs/patches.js
+++ b/server/db/couchdb/design_docs/patches.js
@@ -4,7 +4,7 @@ module.exports = {
       emit(doc._id.split(':')[0], null)
     }
   },
-  byUserId: {
+  byUserIdAndDate: {
     map: doc => emit([ doc.user, doc.timestamp ], null),
     reduce: '_count'
   },
@@ -51,5 +51,21 @@ module.exports = {
       }
     ],
     reduce: '_count'
-  }
+  },
+  byUserIdAndPropertyAndDate: {
+    map: doc => {
+      const { user, timestamp } = doc
+      for (const operation of doc.patch) {
+        if (operation.op !== 'test') {
+          const property = operation.path.split('/')[2]
+          // Here `property` can be both a label lang or a claim property
+          if (property != null) {
+            // return to only emit once per matching doc
+            return emit([ user, property, timestamp ])
+          }
+        }
+      }
+    },
+    reduce: '_count'
+  },
 }

--- a/tests/api/entities/contributions.test.js
+++ b/tests/api/entities/contributions.test.js
@@ -3,6 +3,7 @@ const { adminReq, getUser, getReservedUser } = require('../utils/utils')
 const { createWork } = require('../fixtures/entities')
 const endpoint = '/api/entities?action=contributions'
 const { wait } = require('lib/promises')
+const { updateClaim } = require('../utils/entities')
 
 describe('entities:contributions', () => {
   it('should return contributions from all users by default', async () => {
@@ -75,6 +76,24 @@ describe('entities:contributions', () => {
     const { patches: patches2 } = await adminReq('get', `${endpoint}&user=${user._id}`)
     getWorkId(patches2[0]._id).should.equal(workB._id)
     getWorkId(patches2[1]._id).should.equal(work._id)
+  })
+
+  describe('filter', () => {
+    it('should filter by claim property', async () => {
+      const user = await getReservedUser()
+      const work = await createWork({ user })
+      const property = 'wdt:P921'
+      await updateClaim({ uri: work.uri, property, newValue: 'wd:Q1', user })
+      await updateClaim({ uri: work.uri, property: 'wdt:P136', newValue: 'wd:Q2', user })
+      await updateClaim({ uri: work.uri, property, newValue: 'wd:Q3', user })
+      await updateClaim({ uri: work.uri, property, oldValue: 'wd:Q1', user })
+      const { patches, total } = await adminReq('get', `${endpoint}&user=${user._id}&property=${property}`)
+      patches.length.should.equal(3)
+      total.should.equal(3)
+      patches.forEach(({ patch }) => {
+        patch.some(operation => operation.path.includes(property)).should.be.true()
+      })
+    })
   })
 })
 

--- a/tests/api/entities/contributions.test.js
+++ b/tests/api/entities/contributions.test.js
@@ -87,7 +87,7 @@ describe('entities:contributions', () => {
       await updateClaim({ uri, property: 'wdt:P136', newValue: 'wd:Q2', user })
       await updateClaim({ uri, property, newValue: 'wd:Q3', user })
       await updateClaim({ uri, property, oldValue: 'wd:Q1', user })
-      const { patches, total } = await adminReq('get', `${endpoint}&user=${user._id}&property=${property}`)
+      const { patches, total } = await adminReq('get', `${endpoint}&user=${user._id}&filter=${property}`)
       patches.length.should.equal(3)
       total.should.equal(3)
       patches.forEach(({ patch }) => {
@@ -102,7 +102,7 @@ describe('entities:contributions', () => {
       await updateLabel({ uri, lang, value: 'foo', user })
       await updateLabel({ uri, lang: 'it', value: 'bar', user })
       await updateLabel({ uri, lang, value: 'buzz', user })
-      const { patches, total } = await adminReq('get', `${endpoint}&user=${user._id}&lang=${lang}`)
+      const { patches, total } = await adminReq('get', `${endpoint}&user=${user._id}&filter=${lang}`)
       patches.length.should.equal(2)
       total.should.equal(2)
       patches.forEach(({ patch }) => {


### PR DESCRIPTION
A useful tool for administrators to misinformed edits on a precise property: my current use-case is a user having change many `wdt:P629`, and those would need to be reverted, but it needs to be done manually as some entities were further edited.

This PR depends on #585 for convenience, but could be rewritten without it if #585 was to get stuck