### PR TITLE
Add claims attachements to entity actors

### DIFF
--- a/server/controllers/activitypub/lib/build_attachements.js
+++ b/server/controllers/activitypub/lib/build_attachements.js
@@ -1,0 +1,64 @@
+const _ = require('builders/utils')
+const { buildLink, entityUrl, defaultLabel, propertyLabel } = require('./helpers')
+const propertiesDisplay = require('./properties_display.js')
+const getEntityByUri = require('controllers/entities/lib/get_entity_by_uri')
+const typesWithAttachements = Object.keys(propertiesDisplay)
+
+module.exports = async entity => {
+  const { claims, type } = entity
+  if (!typesWithAttachements.includes(type)) return
+
+  const attachementsList = propertiesDisplay[type]
+  const properties = Object.keys(attachementsList)
+  const attachements = await Promise.all(properties.map(buildAttachement(claims, attachementsList)))
+  return _.compact(attachements)
+}
+
+const buildAttachement = (claims, attachementsList) => async prop => {
+  const claimValues = claims[prop]
+  if (!claimValues) return
+  const attachement = {
+    type: 'PropertyValue',
+    name: propertyLabel(prop)
+  }
+  const attachementValue = await buildAttachementValues(claimValues, prop, attachementsList)
+  if (attachementValue && _.isNonEmptyString(attachementValue)) {
+    attachement.value = attachementValue
+    return attachement
+  }
+}
+
+const buildAttachementValues = async (claimValues, prop, attachementsList) => {
+  const claimType = attachementsList[prop]
+  const attachementValues = await Promise.all(claimValues.map(buildAttachementValue(claimType, prop)))
+  return _.compact(attachementValues).join(', ') || null
+}
+
+const buildEntity = async ({ claimValue, claimType }) => {
+  let attachementValue
+  const isWdUri = claimValue && claimValue.startsWith('wd:')
+  if (isWdUri) {
+    const wdUrl = entityUrl(claimValue)
+    const entity = await getEntityByUri({ uri: claimValue })
+    const label = defaultLabel(entity)
+    attachementValue = claimType === 'entityString' ? label : buildLinkWrapper({ claimValue: wdUrl, text: label })
+  }
+  if (attachementValue) return attachementValue
+}
+
+const buildLinkWrapper = args => {
+  const { claimValue, text } = args
+  return buildLink(claimValue, text)
+}
+
+const claimTypesActions = {
+  entity: buildEntity,
+  entityString: buildEntity,
+  string: _.identity,
+}
+
+const buildAttachementValue = (claimType, prop) => async claimValue => {
+  const escapeClaimValue = _.escape(claimValue) // html urls
+  const claimTypeAction = claimTypesActions[claimType]
+  if (claimTypeAction) return claimTypeAction({ claimValue: escapeClaimValue, claimType, prop })
+}

--- a/server/controllers/activitypub/lib/build_attachements.js
+++ b/server/controllers/activitypub/lib/build_attachements.js
@@ -1,5 +1,6 @@
 const _ = require('builders/utils')
 const { buildLink, entityUrl, defaultLabel, propertyLabel } = require('./helpers')
+const platforms = require('./platforms')
 const propertiesDisplay = require('./properties_display.js')
 const getEntityByUri = require('controllers/entities/lib/get_entity_by_uri')
 const typesWithAttachements = Object.keys(propertiesDisplay)
@@ -50,11 +51,27 @@ const buildLinkWrapper = args => {
   const { claimValue, text } = args
   return buildLink(claimValue, text)
 }
+// only year for now
+const buildTime = ({ claimValue }) => parseInt(claimValue.split('-')[0])
+
+const buildPlatform = ({ claimValue, prop }) => {
+  const plateformProp = platforms[prop]
+  if (!plateformProp) return
+  const { url, text } = plateformProp
+  const attachementValue = buildLinkWrapper({
+    claimValue: url(claimValue),
+    text: text(claimValue)
+  })
+  if (attachementValue) return attachementValue
+}
 
 const claimTypesActions = {
   entity: buildEntity,
   entityString: buildEntity,
   string: _.identity,
+  time: buildTime,
+  platform: buildPlatform,
+  url: buildLinkWrapper
 }
 
 const buildAttachementValue = (claimType, prop) => async claimValue => {

--- a/server/controllers/activitypub/lib/helpers.js
+++ b/server/controllers/activitypub/lib/helpers.js
@@ -3,6 +3,8 @@ const host = CONFIG.fullPublicHost()
 const qs = require('querystring')
 const { isEntityUri, isUsername } = require('lib/boolean_validations')
 const error_ = require('lib/error/error')
+const { unprefixify } = require('controllers/entities/lib/prefix')
+const { i18n } = require('lib/emails/i18n/i18n')
 
 const makeUrl = ({ origin, endpoint, params }) => {
   origin = origin || host
@@ -26,6 +28,18 @@ const getActorTypeFromName = name => {
   else throw error_.notFound({ name })
 }
 
+const defaultLabel = entity => entity.labels.en || Object.values(entity.labels)[0] || entity.claims['wdt:P1476']?.[0]
+
+const buildLink = (url, text) => {
+  if (!text) text = url.split('://')[1]
+  // Mimicking Mastodon
+  return `<a href="${url}" rel="me nofollow noopener noreferrer" target="_blank">${text}</a>`
+}
+
+const entityUrl = uri => `${host}/entity/${uri}`
+
+const propertyLabel = prop => i18n('en', unprefixify(prop))
+
 module.exports = {
   makeUrl,
   getEntityActorName,
@@ -33,4 +47,8 @@ module.exports = {
   getActivityIdFromPatchId,
   getActorTypeFromName,
   isEntityActivityId,
+  defaultLabel,
+  entityUrl,
+  propertyLabel,
+  buildLink
 }

--- a/server/controllers/activitypub/lib/platforms.js
+++ b/server/controllers/activitypub/lib/platforms.js
@@ -1,0 +1,11 @@
+const _ = require('builders/utils')
+
+module.exports = {
+  'wdt:P4033': {
+    text: _.identity,
+    url: address => {
+      const [ username, domain ] = address.split('@')
+      return `https://${domain}/@${username}`
+    }
+  }
+}

--- a/server/controllers/activitypub/lib/properties_display.js
+++ b/server/controllers/activitypub/lib/properties_display.js
@@ -1,6 +1,26 @@
 // Ordered list of properties displayed as attachments
 // Keep in sync with client/app/modules/entities/views/templates/{work,author,publisher,edition}_claims.hbs
 
+const workProperties = {
+  'wdt:P361': 'entity', // part of
+  'wdt:P179': 'entity', // serie
+  'wdt:P1545': 'string', // serie ordinal
+  'wdt:P407': 'entityString', // original language
+  'wdt:P577': 'time', // publication date
+  'wdt:P144': 'entity', // based on
+  'wdt:P941': 'entity', // inspired by
+  'wdt:P136': 'entity', // genre
+  'wdt:P135': 'entity', // movement
+  'wdt:P921': 'entity', // main subject
+  'wdt:P840': 'entity', // narrative set in
+  'wdt:P674': 'entity', // characters
+  'wdt:P1433': 'entity', // published in
+  'wdt:P155': 'entity', // preceded by
+  'wdt:P156': 'entity', // followed by
+  'wdt:P856': 'url', // official website
+  'wdt:P953': 'url', // full text available at
+}
+
 const authorProperties = {
   'wdt:P135': 'entity', // movement
   'wdt:P136': 'entity', // genre
@@ -17,6 +37,48 @@ const authorProperties = {
   'wdt:P4033': 'platform', // mastodon
 }
 
+const editionProperties = {
+  'wdt:P1680': 'string', // subtitle
+  'wdt:P629': 'entity', // edition of
+  'wdt:P50': 'entity', // author
+  'wdt:P58': 'entity', // scenarist
+  'wdt:P110': 'entity', // illustrator
+  'wdt:P6338': 'entity', // colorist
+  'wdt:P179': 'entity', // serie
+  'wdt:P2679': 'entity', // author of foreword
+  'wdt:P2680': 'entity', // author of afterword
+  'wdt:P655': 'entity', // translator
+  'wdt:P407': 'entityString', // edition language
+  'wdt:P123': 'entity', // publisher
+  'wdt:P195': 'entity', // collection
+  'wdt:P577': 'time', // publication date
+  'wdt:P1104': 'quantity', // number of pages
+  'wdt:P2635': 'quantity', // number of volumes
+  'wdt:P856': 'url', // official website
+  // TODO: add 'wdt:P212' and 'wdt:P957'
+}
+
+const publisherProperties = {
+  'wdt:P571': 'time', // inception
+  'wdt:P576': 'time', // dissolution
+  'wdt:P112': 'entity', // founded by
+  'wdt:P127': 'entity', // owned by
+  'wdt:P856': 'url', // official website
+  'wdt:P4033': 'platform', // mastodon
+}
+
+const collectionProperties = {
+  'wdt:P1680': 'string', // subtitle
+  'wdt:P123': 'entity', // publisher
+  'wdt:P98': 'entity', // editor
+  'wdt:P856': 'url', // official website
+}
+
 module.exports = {
   human: authorProperties,
+  work: workProperties,
+  publisher: publisherProperties,
+  edition: editionProperties,
+  collection: collectionProperties,
+  serie: workProperties,
 }

--- a/server/controllers/activitypub/lib/properties_display.js
+++ b/server/controllers/activitypub/lib/properties_display.js
@@ -1,0 +1,22 @@
+// Ordered list of properties displayed as attachments
+// Keep in sync with client/app/modules/entities/views/templates/{work,author,publisher,edition}_claims.hbs
+
+const authorProperties = {
+  'wdt:P135': 'entity', // movement
+  'wdt:P136': 'entity', // genre
+  'wdt:P27': 'entityString', // country of citizenship
+  'wdt:P103': 'entityString', // native language
+  'wdt:P1412': 'entityString', // language of expression
+  'wdt:P69': 'entity', // educated at
+  'wdt:P106': 'entity', // occupation
+  'wdt:P166': 'entity', // award received
+  'wdt:P39': 'entityString', // position held
+  'wdt:P1066': 'entity', // student of
+  'wdt:P737': 'entity', // influence by
+  'wdt:P856': 'url', // official website
+  'wdt:P4033': 'platform', // mastodon
+}
+
+module.exports = {
+  human: authorProperties,
+}

--- a/tests/api/activitypub/actor.test.js
+++ b/tests/api/activitypub/actor.test.js
@@ -147,6 +147,32 @@ describe('activitypub:actor', () => {
       name3.should.be.below(name4)
     })
 
+    it('should set entity claim as attachment', async () => {
+      const { value } = await getAttachement('wd-Q140057', 'P941')
+      value.should.containEql(`${fullPublicHost}/entity/wd:`)
+    })
+
+    it('should set entity string claim as attachment', async () => {
+      const { value } = await getAttachement('wd-Q140057', 'P407')
+      value.should.equal('French')
+    })
+
+    it('should set date claim as attachment', async () => {
+      const { value } = await getAttachement('wd-Q11859', 'P577')
+      value.should.equal('1837')
+    })
+
+    it('should set URL claim as attachment', async () => {
+      const { value } = await getAttachement('wd-Q856656', 'P856')
+      value.should.containEql('www.la-pleiade.fr')
+    })
+
+    it('should set platform claim as attachment', async () => {
+      const { value } = await getAttachement('wd-Q110436', 'P4033')
+      value.should.containEql('doctorow@mamot.fr')
+      value.should.containEql('https://mamot.fr/@doctorow')
+    })
+
     it('should redirect to the entity main url when requesting html', async () => {
       const wdId = 'Q237087'
       const actorUrl = makeUrl({ params: { action: 'actor', name: `wd-${wdId}` } })


### PR DESCRIPTION
roughly addressing #579 

check it on the sandbox, ie. searching for @wd-Q84352@sandbox.inventaire.io

properties translations do not seem to work on sandbox (in prod either?)

missing features: - ebooks, - authors birth and death - summary when no description