### PR TITLE
refresh items snapshots after new entity operations

### DIFF
--- a/server/controllers/entities/lib/restore_version.js
+++ b/server/controllers/entities/lib/restore_version.js
@@ -1,3 +1,4 @@
+const { emit } = require('lib/radio')
 const Patch = require('models/patch')
 const entities_ = require('./entities')
 const patches_ = require('./patches')
@@ -20,7 +21,9 @@ module.exports = async (patchId, userId) => {
 
   await validateEntity(updatedDoc)
   const context = { restoredPatch: patchId }
-  return entities_.putUpdate({ userId, currentDoc, updatedDoc, context })
+  const docAfterUpdate = await entities_.putUpdate({ userId, currentDoc, updatedDoc, context })
+  await emit('entity:restore:version', updatedDoc)
+  return docAfterUpdate
 }
 
 const getPatchIdNum = patchId => patchId.split(':')[1]

--- a/server/controllers/entities/lib/revert_edit.js
+++ b/server/controllers/entities/lib/revert_edit.js
@@ -1,3 +1,4 @@
+const { emit } = require('lib/radio')
 const Patch = require('models/patch')
 const entities_ = require('./entities')
 const patches_ = require('./patches')
@@ -9,7 +10,9 @@ const revertFromPatchDoc = async (patch, userId) => {
   const updatedDoc = Patch.revert(currentDoc, patch)
   await validateEntity(updatedDoc)
   const context = { revertPatch: patch._id }
-  return entities_.putUpdate({ userId, currentDoc, updatedDoc, context })
+  const docAfterUpdate = await entities_.putUpdate({ userId, currentDoc, updatedDoc, context })
+  await emit('entity:revert:edit', updatedDoc)
+  return docAfterUpdate
 }
 
 const revertFromPatchId = async (patchId, userId) => {

--- a/server/controllers/entities/lib/update_inv_claim.js
+++ b/server/controllers/entities/lib/update_inv_claim.js
@@ -34,7 +34,7 @@ const updateInvClaim = async (user, id, property, oldVal, newVal) => {
 
   await inferredClaimUpdates(updatedDoc, property, oldVal)
 
-  await radio.emit('entity:update:claim', updatedDoc, property, oldVal, newVal)
+  await radio.emit('entity:update:claim', updatedDoc)
 
   if (property === 'invp:P2' && oldVal != null) {
     await radio.emit('image:needs:check', { container: 'entities', hash: oldVal, context: 'update' })

--- a/server/controllers/entities/lib/update_inv_label.js
+++ b/server/controllers/entities/lib/update_inv_label.js
@@ -1,7 +1,6 @@
 const _ = require('builders/utils')
 const error_ = require('lib/error/error')
 const entities_ = require('./entities')
-const radio = require('lib/radio')
 const retryOnConflict = require('lib/retry_on_conflict')
 const updateLabel = require('./update_label')
 
@@ -10,9 +9,8 @@ const updateInvLabel = async (user, id, lang, value) => {
 
   if (!_.isInvEntityId(id)) throw error_.newInvalid('id', id)
 
-  return entities_.byId(id)
-  .then(updateLabel.bind(null, lang, value, reqUserId))
-  .then(updatedDoc => radio.emit('entity:update:label', updatedDoc, lang, value))
+  const entity = await entities_.byId(id)
+  return updateLabel(lang, value, reqUserId, entity)
 }
 
 module.exports = retryOnConflict({ updateFn: updateInvLabel })

--- a/server/controllers/entities/lib/update_label.js
+++ b/server/controllers/entities/lib/update_label.js
@@ -4,13 +4,16 @@ const entities_ = require('./entities')
 const Entity = require('models/entity')
 const getEntityType = require('./get_entity_type')
 const typeWithoutLabels = require('./type_without_labels')
+const { emit } = require('lib/radio')
 
-module.exports = (lang, value, userId, currentDoc) => {
+module.exports = async (lang, value, userId, currentDoc) => {
   checkEntityTypeCanHaveLabel(currentDoc)
 
   let updatedDoc = _.cloneDeep(currentDoc)
   updatedDoc = Entity.setLabel(updatedDoc, lang, value)
-  return entities_.putUpdate({ userId, currentDoc, updatedDoc })
+  const docAfterUpdate = await entities_.putUpdate({ userId, currentDoc, updatedDoc })
+  await emit('entity:update:label', updatedDoc)
+  return docAfterUpdate
 }
 
 const checkEntityTypeCanHaveLabel = currentDoc => {

--- a/server/controllers/items/lib/snapshot/update_snapshot_on_entity_change.js
+++ b/server/controllers/items/lib/snapshot/update_snapshot_on_entity_change.js
@@ -21,6 +21,8 @@ const refreshSnapshot = require('./refresh_snapshot')
 module.exports = () => {
   radio.on('entity:update:label', refreshSnapshot.fromDoc)
   radio.on('entity:update:claim', refreshSnapshot.fromDoc)
+  radio.on('entity:revert:edit', refreshSnapshot.fromDoc)
+  radio.on('entity:restore:version', refreshSnapshot.fromDoc)
   radio.on('entity:merge', updateSnapshotOnEntityMerge)
   radio.on('entity:revert:merge', refreshSnapshot.fromUri)
 }


### PR DESCRIPTION
namely, `revert-edit` and `restore-version`, which were not taken into account, leading to obsolete snapshot data after those operations.

The other commits are just small cleanups while being around