### PR TITLE
Prevent over-fetching when fetching entities basic info

### DIFF
--- a/server/controllers/entities/by_uris_get.js
+++ b/server/controllers/entities/by_uris_get.js
@@ -1,14 +1,19 @@
 const getEntitiesByUris = require('./lib/get_entities_by_uris')
 const addRelatives = require('./lib/add_relatives')
-
-const validRelativesProperties = [
-  'wdt:P50',
-  'wdt:P179',
-  'wdt:P629'
-]
+const pickProps = require('./lib/pick_props')
 
 const sanitization = {
   uris: {},
+  // Mimicking Wikibase wbgetentities props parameter
+  props: {
+    allowlist: [
+      'labels',
+      'descriptions',
+      'claims',
+      'sitelinks',
+    ],
+    optional: true
+  },
   refresh: { optional: true },
   autocreate: {
     generic: 'boolean',
@@ -16,15 +21,20 @@ const sanitization = {
     default: false
   },
   relatives: {
-    allowlist: validRelativesProperties,
+    allowlist: [
+      'wdt:P50',
+      'wdt:P179',
+      'wdt:P629',
+    ],
     optional: true
   }
 }
 
-const controller = async ({ uris, refresh, relatives, autocreate }) => {
-  const results = await getEntitiesByUris({ uris, refresh, autocreate })
-  if (relatives) return addRelatives(results, relatives, refresh)
-  else return results
+const controller = async ({ uris, props, refresh, relatives, autocreate }) => {
+  let results = await getEntitiesByUris({ uris, refresh, autocreate })
+  if (relatives) results = addRelatives(results, relatives, refresh)
+  if (props) results.entities = pickProps(results.entities, props)
+  return results
 }
 
 module.exports = { sanitization, controller }

--- a/server/controllers/entities/by_uris_get.js
+++ b/server/controllers/entities/by_uris_get.js
@@ -1,11 +1,10 @@
 const getEntitiesByUris = require('./lib/get_entities_by_uris')
 const addRelatives = require('./lib/add_relatives')
-const pickProps = require('./lib/pick_props')
+const pickAttributes = require('./lib/pick_attributes')
 
 const sanitization = {
   uris: {},
-  // Mimicking Wikibase wbgetentities props parameter
-  props: {
+  attributes: {
     allowlist: [
       'labels',
       'descriptions',
@@ -35,10 +34,10 @@ const sanitization = {
   }
 }
 
-const controller = async ({ uris, props, lang, refresh, relatives, autocreate }) => {
+const controller = async ({ uris, attributes, lang, refresh, relatives, autocreate }) => {
   let results = await getEntitiesByUris({ uris, refresh, autocreate })
   if (relatives) results = addRelatives(results, relatives, refresh)
-  if (props) results.entities = pickProps(results.entities, props, lang)
+  if (attributes) results.entities = pickAttributes(results.entities, attributes, lang)
   return results
 }
 

--- a/server/controllers/entities/by_uris_get.js
+++ b/server/controllers/entities/by_uris_get.js
@@ -11,6 +11,8 @@ const sanitization = {
       'descriptions',
       'claims',
       'sitelinks',
+      'image',
+      'originalLang',
     ],
     optional: true
   },

--- a/server/controllers/entities/by_uris_get.js
+++ b/server/controllers/entities/by_uris_get.js
@@ -14,6 +14,9 @@ const sanitization = {
     ],
     optional: true
   },
+  lang: {
+    optional: true
+  },
   refresh: { optional: true },
   autocreate: {
     generic: 'boolean',
@@ -30,10 +33,10 @@ const sanitization = {
   }
 }
 
-const controller = async ({ uris, props, refresh, relatives, autocreate }) => {
+const controller = async ({ uris, props, lang, refresh, relatives, autocreate }) => {
   let results = await getEntitiesByUris({ uris, refresh, autocreate })
   if (relatives) results = addRelatives(results, relatives, refresh)
-  if (props) results.entities = pickProps(results.entities, props)
+  if (props) results.entities = pickProps(results.entities, props, lang)
   return results
 }
 

--- a/server/controllers/entities/lib/pick_attributes.js
+++ b/server/controllers/entities/lib/pick_attributes.js
@@ -2,13 +2,13 @@ const { pick } = require('lodash')
 const getBestLangValue = require('lib/get_best_lang_value')
 const getOriginalLang = require('lib/wikidata/get_original_lang')
 
-module.exports = (entities, props, lang) => {
+module.exports = (entities, attributes, lang) => {
   const formattedEntities = {}
   for (const key of Object.keys(entities)) {
     const entity = entities[key]
     const formattedEntity = {
       uri: entity.uri,
-      ...pick(entity, props)
+      ...pick(entity, attributes)
     }
     if (lang != null) {
       const originalLang = getOriginalLang(entity.claims)

--- a/server/controllers/entities/lib/pick_props.js
+++ b/server/controllers/entities/lib/pick_props.js
@@ -1,0 +1,13 @@
+const { pick } = require('lodash')
+
+module.exports = (entities, props) => {
+  const formattedEntities = {}
+  for (const key of Object.keys(entities)) {
+    const entity = entities[key]
+    formattedEntities[key] = {
+      uri: entity.uri,
+      ...pick(entity, props)
+    }
+  }
+  return formattedEntities
+}

--- a/server/controllers/entities/lib/pick_props.js
+++ b/server/controllers/entities/lib/pick_props.js
@@ -1,13 +1,39 @@
 const { pick } = require('lodash')
+const getBestLangValue = require('lib/get_best_lang_value')
+const getOriginalLang = require('lib/wikidata/get_original_lang')
 
-module.exports = (entities, props) => {
+module.exports = (entities, props, lang) => {
   const formattedEntities = {}
   for (const key of Object.keys(entities)) {
     const entity = entities[key]
-    formattedEntities[key] = {
+    const formattedEntity = {
       uri: entity.uri,
       ...pick(entity, props)
     }
+    if (lang != null) {
+      const originalLang = getOriginalLang(entity.claims)
+      pickLanguages(lang, originalLang, formattedEntity)
+    }
+    formattedEntities[key] = formattedEntity
   }
   return formattedEntities
+}
+
+const pickLanguages = (lang, originalLang, formattedEntity) => {
+  if (formattedEntity.labels) {
+    formattedEntity.labels = pickLanguage(lang, originalLang, formattedEntity.labels)
+  }
+  if (formattedEntity.descriptions) {
+    formattedEntity.descriptions = pickLanguage(lang, originalLang, formattedEntity.descriptions)
+  }
+  if (formattedEntity.aliases) {
+    formattedEntity.aliases = pickLanguage(lang, originalLang, formattedEntity.aliases)
+  }
+}
+
+const pickLanguage = (lang, originalLang, data) => {
+  const { lang: pickedLang, value } = getBestLangValue(lang, originalLang, data)
+  return {
+    [pickedLang]: value
+  }
 }

--- a/server/lib/sanitize/parameters.js
+++ b/server/lib/sanitize/parameters.js
@@ -202,6 +202,7 @@ module.exports = {
   '@context': allowlistedStrings,
   actor: nonEmptyString,
   attribute: nonEmptyString,
+  attributes: allowlistedStrings,
   bbox: {
     format: value => {
       return JSON.parse(value)
@@ -271,7 +272,6 @@ module.exports = {
   },
   prefix: allowlistedString,
   property: { validate: _.isPropertyUri },
-  props: allowlistedStrings,
   range: Object.assign({}, positiveInteger, {
     default: 50,
     max: 500

--- a/server/lib/sanitize/parameters.js
+++ b/server/lib/sanitize/parameters.js
@@ -271,6 +271,7 @@ module.exports = {
   },
   prefix: allowlistedString,
   property: { validate: _.isPropertyUri },
+  props: allowlistedStrings,
   range: Object.assign({}, positiveInteger, {
     default: 50,
     max: 500

--- a/tests/api/entities/get_by_uris.test.js
+++ b/tests/api/entities/get_by_uris.test.js
@@ -96,6 +96,36 @@ describe('entities:get:by-uris', () => {
     })
   })
 
+  describe('lang', () => {
+    it('should return only the requested lang', async () => {
+      const wdHumanUri = 'wd:Q2300248'
+      const { uri: invHumanUri } = await createHuman({ labels: { es: 'foo', fr: 'bar' } })
+      const url = buildPath('/api/entities', {
+        action: 'by-uris',
+        uris: `${invHumanUri}|${wdHumanUri}`,
+        props: 'labels',
+        lang: 'es'
+      })
+      const { entities } = await publicReq('get', url)
+      Object.keys(entities[invHumanUri].labels).should.deepEqual([ 'es' ])
+      entities[invHumanUri].labels.es.should.equal('foo')
+      Object.keys(entities[wdHumanUri].labels).should.deepEqual([ 'es' ])
+    })
+
+    it('should fallback on what is available', async () => {
+      const { uri: invHumanUri } = await createHuman({ labels: { es: 'foo' } })
+      const url = buildPath('/api/entities', {
+        action: 'by-uris',
+        uris: `${invHumanUri}`,
+        props: 'labels',
+        lang: 'fr'
+      })
+      const { entities } = await publicReq('get', url)
+      Object.keys(entities[invHumanUri].labels).should.deepEqual([ 'es' ])
+      entities[invHumanUri].labels.es.should.equal('foo')
+    })
+  })
+
   describe('relatives', () => {
     it("should accept a 'relatives' parameter", async () => {
       const work = await workWithAuthorPromise

--- a/tests/api/entities/get_by_uris.test.js
+++ b/tests/api/entities/get_by_uris.test.js
@@ -1,10 +1,11 @@
 const should = require('should')
-const { authReq, shouldNotBeCalled, rethrowShouldNotBeCalledErrors } = require('../utils/utils')
+const { authReq, shouldNotBeCalled, rethrowShouldNotBeCalledErrors, publicReq } = require('../utils/utils')
 
 const { createEditionWithIsbn, createWorkWithAuthor, createEditionWithWorkAuthorAndSerie, createHuman, someFakeUri, generateIsbn13 } = require('../fixtures/entities')
 const { getByUris, merge, deleteByUris } = require('../utils/entities')
 const workWithAuthorPromise = createWorkWithAuthor()
 const getWdEntity = require('data/wikidata/get_entity')
+const { buildPath } = require('lib/utils/base')
 
 describe('entities:get:by-uris', () => {
   it('should reject invalid uri', async () => {
@@ -66,6 +67,33 @@ describe('entities:get:by-uris', () => {
     const { entities } = await getByUris(uri)
     const entity = entities[uri]
     entity.uri.should.equal(uri)
+  })
+
+  describe('props', () => {
+    it("should return only the requested 'props'", async () => {
+      const work = await workWithAuthorPromise
+      const { uri: invWorkUri } = work
+      const invAuthorUri = work.claims['wdt:P50'][0]
+      const wdUri = 'wd:Q2300248'
+      const url = buildPath('/api/entities', {
+        action: 'by-uris',
+        uris: `${invWorkUri}|${invAuthorUri}|${wdUri}`,
+        props: 'labels|descriptions',
+      })
+      const { entities } = await publicReq('get', url)
+      entities[invWorkUri].uri.should.be.ok()
+      entities[invAuthorUri].uri.should.be.ok()
+      entities[wdUri].uri.should.be.ok()
+      entities[invWorkUri].labels.should.be.ok()
+      entities[invAuthorUri].labels.should.be.ok()
+      entities[wdUri].labels.should.be.ok()
+      entities[wdUri].descriptions.should.be.ok()
+      should(entities[invWorkUri].claims).not.be.ok()
+      should(entities[invAuthorUri].claims).not.be.ok()
+      should(entities[wdUri].aliases).not.be.ok()
+      should(entities[wdUri].claims).not.be.ok()
+      should(entities[wdUri].sitelinks).not.be.ok()
+    })
   })
 
   describe('relatives', () => {

--- a/tests/api/entities/get_by_uris.test.js
+++ b/tests/api/entities/get_by_uris.test.js
@@ -69,8 +69,8 @@ describe('entities:get:by-uris', () => {
     entity.uri.should.equal(uri)
   })
 
-  describe('props', () => {
-    it("should return only the requested 'props'", async () => {
+  describe('attributes', () => {
+    it("should return only the requested 'attributes'", async () => {
       const work = await workWithAuthorPromise
       const { uri: invWorkUri } = work
       const invAuthorUri = work.claims['wdt:P50'][0]
@@ -78,7 +78,7 @@ describe('entities:get:by-uris', () => {
       const url = buildPath('/api/entities', {
         action: 'by-uris',
         uris: `${invWorkUri}|${invAuthorUri}|${wdUri}`,
-        props: 'labels|descriptions',
+        attributes: 'labels|descriptions',
       })
       const { entities } = await publicReq('get', url)
       entities[invWorkUri].uri.should.be.ok()
@@ -103,7 +103,7 @@ describe('entities:get:by-uris', () => {
       const url = buildPath('/api/entities', {
         action: 'by-uris',
         uris: `${invHumanUri}|${wdHumanUri}`,
-        props: 'labels',
+        attributes: 'labels',
         lang: 'es'
       })
       const { entities } = await publicReq('get', url)
@@ -117,7 +117,7 @@ describe('entities:get:by-uris', () => {
       const url = buildPath('/api/entities', {
         action: 'by-uris',
         uris: `${invHumanUri}`,
-        props: 'labels',
+        attributes: 'labels',
         lang: 'fr'
       })
       const { entities } = await publicReq('get', url)


### PR DESCRIPTION
Currently, when a piece of UI wants to display some basic info on an entity (typically a label, a description, a uri, and an image), it has to fetch the whole formatted entity, which might include way more data than needed (ex: https://inventaire.io/api/entities?action=by-uris&uris=wd:Q535).

This PR suggests to add a ~`props`~ [edit: `attributes`] and a `lang` parameter to the `/api/entities?action=by-uris` endpoint to let the client request just what it needs.