### PR TITLE
entities search: prevent exact match to include non-exact matches due to edge n-gram tokens

### DIFF
--- a/server/controllers/search/lib/entities_query_builder.js
+++ b/server/controllers/search/lib/entities_query_builder.js
@@ -88,8 +88,8 @@ const exactMatchEntitiesFields = userLang => {
   ]
   if (userLang) {
     fields.push(
-      `fullLabels.${userLang}^2`,
-      `fullAliases.${userLang}`
+      `fullLabels.${userLang}^4`,
+      `fullAliases.${userLang}^2`
     )
   }
   return fields
@@ -107,8 +107,8 @@ const autoCompleteEntitiesFields = userLang => {
   ]
   if (userLang) {
     fields.push(
-      `labels.${userLang}^2`,
-      `aliases.${userLang}`
+      `labels.${userLang}^4`,
+      `aliases.${userLang}^2`
     )
   }
   return fields

--- a/server/db/elasticsearch/formatters/entity.js
+++ b/server/db/elasticsearch/formatters/entity.js
@@ -22,7 +22,7 @@ module.exports = async (entity, options = {}) => {
 
   let { claims, type } = entity
 
-  if (isRawWikidataClaims(claims)) {
+  if (claims != null && isRawWikidataClaims(claims)) {
     claims = formatClaims(claims)
   }
 

--- a/server/db/elasticsearch/formatters/entity.js
+++ b/server/db/elasticsearch/formatters/entity.js
@@ -102,6 +102,10 @@ module.exports = async (entity, options = {}) => {
 
   if (Object.keys(entity.labels).length === 0) setTermsFromClaims(entity)
 
+  // Duplicating labels and aliases to have a different analyzer applied
+  entity.fullLabels = entity.labels
+  entity.fullAliases = entity.aliases
+
   entity.relationsTerms = await getRelationsTerms(entity)
 
   entity.claim = getFlattenedClaims(claims)

--- a/server/db/elasticsearch/mappings/entities.js
+++ b/server/db/elasticsearch/mappings/entities.js
@@ -1,11 +1,13 @@
-const { flattenedTerms, integer, keyword, date, objectNotIndexed, terms } = require('./mappings_datatypes')
+const { flattenedTerms, integer, keyword, date, objectNotIndexed, autocompleteTerms, fullTerms } = require('./mappings_datatypes')
 
 module.exports = {
   properties: {
     type: keyword,
-    labels: terms,
-    aliases: terms,
-    descriptions: terms,
+    labels: autocompleteTerms,
+    aliases: autocompleteTerms,
+    fullLabels: fullTerms,
+    fullAliases: fullTerms,
+    descriptions: autocompleteTerms,
     flattenedLabels: flattenedTerms,
     flattenedAliases: flattenedTerms,
     flattenedDescriptions: flattenedTerms,

--- a/server/db/elasticsearch/mappings/mappings_datatypes.js
+++ b/server/db/elasticsearch/mappings/mappings_datatypes.js
@@ -14,12 +14,19 @@ const autocompleteText = {
   // See https://www.elastic.co/guide/en/elasticsearch/guide/current/scoring-theory.html
 }
 
-const getTermsProperties = () => {
+const fullText = {
+  type: 'text',
+  // This analyzer won't produce ngram tokens, and can thus be used for exact match.
+  // Ex: Searching for "fruit" won't produce a hit on document with "fruitful"
+  analyzer: 'standard_full',
+}
+
+const getTermsProperties = datatype => {
   const properties = {}
   activeI18nLangs.forEach(lang => {
-    properties[lang] = autocompleteText
+    properties[lang] = datatype
   })
-  properties.fromclaims = autocompleteText
+  properties.fromclaims = datatype
   return properties
 }
 
@@ -32,7 +39,8 @@ module.exports = {
   keyword: { type: 'keyword' },
   // See https://www.elastic.co/guide/en/elasticsearch/reference/current/enabled.html
   objectNotIndexed: { type: 'object', enabled: false },
-  terms: { properties: getTermsProperties() },
+  autocompleteTerms: { properties: getTermsProperties(autocompleteText) },
+  fullTerms: { properties: getTermsProperties(fullText) },
   text: { type: 'text' },
   flattenedTerms: autocompleteText,
 }

--- a/server/db/elasticsearch/settings/analyzers.js
+++ b/server/db/elasticsearch/settings/analyzers.js
@@ -1,0 +1,36 @@
+module.exports = {
+  autocomplete: {
+    type: 'custom',
+    // define standard stop words
+    // See https://www.elastic.co/guide/en/elasticsearch/reference/7.10/analysis-standard-tokenizer.html
+    tokenizer: 'standard',
+    filter: [
+      // The 'standard' tokenizer does not imply lowercase
+      // https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-tokenizer.html
+      // not to be confused with the 'standard' analyzer, which does
+      // https://www.elastic.co/guide/en/elasticsearch/reference/7.10/analysis-standard-analyzer.html
+      'lowercase',
+      'asciifolding',
+      'autocomplete_filter'
+    ]
+  },
+  standard_truncated: {
+    type: 'custom',
+    // define standard stop words
+    // See https://www.elastic.co/guide/en/elasticsearch/reference/7.10/analysis-standard-tokenizer.html
+    tokenizer: 'standard',
+    filter: [
+      'lowercase',
+      'asciifolding',
+      'truncate_to_max_gram'
+    ]
+  },
+  standard_full: {
+    type: 'custom',
+    tokenizer: 'standard',
+    filter: [
+      'lowercase',
+      'asciifolding',
+    ]
+  },
+}

--- a/server/db/elasticsearch/settings/filters.js
+++ b/server/db/elasticsearch/settings/filters.js
@@ -11,6 +11,7 @@ module.exports = {
   },
   // Applies the edge_ngram filter to terms above minNgram. Terms below the minNgram
   // will generate a single unmodified token
+  // See https://www.elastic.co/guide/en/elasticsearch/reference/7.17/analysis-condition-tokenfilter.html
   autocomplete_filter: {
     type: 'condition',
     filter: [ 'edge_ngram' ],

--- a/server/db/elasticsearch/settings/filters.js
+++ b/server/db/elasticsearch/settings/filters.js
@@ -1,0 +1,27 @@
+const minNgram = 2
+const maxGram = 10
+
+module.exports = {
+  // Emits edge N-grams of each word
+  // See: https://www.elastic.co/guide/en/elasticsearch/reference/7.10/analysis-edgengram-tokenizer.html
+  edge_ngram: {
+    type: 'edge_ngram',
+    min_gram: minNgram,
+    max_gram: maxGram,
+  },
+  // Applies the edge_ngram filter to terms above minNgram. Terms below the minNgram
+  // will generate a single unmodified token
+  autocomplete_filter: {
+    type: 'condition',
+    filter: [ 'edge_ngram' ],
+    script: {
+      source: `token.getTerm().length() > ${minNgram}`
+    }
+  },
+  // An analyzer to apply at search time to match the autocomplete analyzer used at index time
+  // See: https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-truncate-tokenfilter.html
+  truncate_to_max_gram: {
+    type: 'truncate',
+    length: maxGram
+  }
+}

--- a/server/db/elasticsearch/settings/settings.js
+++ b/server/db/elasticsearch/settings/settings.js
@@ -9,73 +9,12 @@
 // - Reopen index
 //   curl -XPOST ${elastic_host}/${index_name}/_open
 
-const minNgram = 2
-const maxGram = 10
-
 module.exports = {
   // use number_of_shards in testing environment only
   // See: https://www.elastic.co/guide/en/elasticsearch/guide/current/relevance-is-broken.html
   // number_of_shards: 1,
   analysis: {
-    filter: {
-      // Emits ege N-grams of each word
-      // See: https://www.elastic.co/guide/en/elasticsearch/reference/7.10/analysis-edgengram-tokenizer.html
-      edge_ngram: {
-        type: 'edge_ngram',
-        min_gram: minNgram,
-        max_gram: maxGram,
-      },
-      // Applies the edge_ngram filter to terms above minNgram. Terms below the minNgram
-      // will generate a single unmodified token
-      autocomplete_filter: {
-        type: 'condition',
-        filter: [ 'edge_ngram' ],
-        script: {
-          source: `token.getTerm().length() > ${minNgram}`
-        }
-      },
-      // An analyzer to apply at search time to match the autocomplete analyzer used at index time
-      // See: https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-truncate-tokenfilter.html
-      truncate_to_max_gram: {
-        type: 'truncate',
-        length: maxGram
-      }
-    },
-    analyzer: {
-      autocomplete: {
-        type: 'custom',
-        // define standard stop words
-        // See https://www.elastic.co/guide/en/elasticsearch/reference/7.10/analysis-standard-tokenizer.html
-        tokenizer: 'standard',
-        filter: [
-          // The 'standard' tokenizer does not imply lowercase
-          // https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-tokenizer.html
-          // not to be confused with the 'standard' analyzer, which does
-          // https://www.elastic.co/guide/en/elasticsearch/reference/7.10/analysis-standard-analyzer.html
-          'lowercase',
-          'asciifolding',
-          'autocomplete_filter'
-        ]
-      },
-      standard_truncated: {
-        type: 'custom',
-        // define standard stop words
-        // See https://www.elastic.co/guide/en/elasticsearch/reference/7.10/analysis-standard-tokenizer.html
-        tokenizer: 'standard',
-        filter: [
-          'lowercase',
-          'asciifolding',
-          'truncate_to_max_gram'
-        ]
-      },
-      standard_full: {
-        type: 'custom',
-        tokenizer: 'standard',
-        filter: [
-          'lowercase',
-          'asciifolding',
-        ]
-      },
-    }
+    filter: require('./filters'),
+    analyzer: require('./analyzers'),
   }
 }

--- a/server/db/elasticsearch/settings/settings.js
+++ b/server/db/elasticsearch/settings/settings.js
@@ -58,6 +58,14 @@ module.exports = {
           'truncate_to_max_gram'
         ]
       },
+      standard_full: {
+        type: 'custom',
+        tokenizer: 'standard',
+        filter: [
+          'lowercase',
+          'asciifolding',
+        ]
+      },
     }
   }
 }

--- a/tests/api/search/search_entities.test.js
+++ b/tests/api/search/search_entities.test.js
@@ -5,6 +5,7 @@ const { randomLongWord, randomWords } = require('../fixtures/text')
 const { getByUris } = require('../utils/entities')
 const { shouldNotBeCalled } = require('../utils/utils')
 const { search, waitForIndexation, getIndexedDoc } = require('../utils/search')
+const randomString = require('lib/utils/random_string')
 const wikidataUris = [ 'wd:Q184226', 'wd:Q180736', 'wd:Q8337', 'wd:Q225946', 'wd:Q3409094', 'wd:Q3236382' ]
 const assert_ = require('lib/utils/assert_types')
 const { max_gram: maxGram } = require('db/elasticsearch/settings/settings').analysis.filter.edge_ngram
@@ -108,6 +109,14 @@ describe('search:entities', () => {
         _.map(results, 'uri').should.containEql(work.uri)
       })
 
+      it('should find a label with single letter words', async () => {
+        const label = randomString(1)
+        const work = await createWork({ labels: { en: label } })
+        await waitForIndexation('entities', work._id)
+        const results = await search({ types: 'works', search: label, lang: 'en', exact: true })
+        _.map(results, 'uri').should.containEql(work.uri)
+      })
+
       it('should ignore the case', async () => {
         // Insert random words in the middle to mitigate a too low score due to a high term frequency
         // when running the tests several times without emptying the database
@@ -134,6 +143,14 @@ describe('search:entities', () => {
         const firstTwoFlattenedLabelsWords = doc._source.flattenedLabels.split(' ').slice(0, 2).join(' ')
         const results = await search({ types: 'series', search: firstTwoFlattenedLabelsWords })
         _.map(results, 'uri').should.containEql('wd:Q8337')
+      })
+
+      it('should find a label with single letter words', async () => {
+        const label = randomString(1)
+        const work = await createWork({ labels: { en: label } })
+        await waitForIndexation('entities', work._id)
+        const results = await search({ types: 'works', search: label, lang: 'en' })
+        _.map(results, 'uri').should.containEql(work.uri)
       })
     })
 

--- a/tests/api/search/search_entities.test.js
+++ b/tests/api/search/search_entities.test.js
@@ -135,6 +135,26 @@ describe('search:entities', () => {
         const results = await search({ types: 'works', search: label, lang: 'de', exact: true })
         _.map(results, 'uri').should.containEql(work.uri)
       })
+
+      it('should favor matches in the requested language', async () => {
+        const label = randomWords(2)
+        const [ workEs, workFr ] = await Promise.all([
+          createWork({ labels: { es: label } }),
+          createWork({ labels: { fr: label } }),
+        ])
+        await Promise.all([
+          waitForIndexation('entities', workEs._id),
+          waitForIndexation('entities', workFr._id),
+        ])
+        const [ resultsEs, resultsFr ] = await Promise.all([
+          search({ types: 'works', search: label, lang: 'es', exact: true }),
+          search({ types: 'works', search: label, lang: 'fr', exact: true }),
+        ])
+        const resultsEsUris = _.map(resultsEs, 'uri')
+        const resultsFrUris = _.map(resultsFr, 'uri')
+        resultsEsUris.indexOf(workEs.uri).should.be.below(resultsEsUris.indexOf(workFr.uri))
+        resultsFrUris.indexOf(workEs.uri).should.be.above(resultsFrUris.indexOf(workFr.uri))
+      })
     })
 
     describe('not exact', () => {
@@ -151,6 +171,26 @@ describe('search:entities', () => {
         await waitForIndexation('entities', work._id)
         const results = await search({ types: 'works', search: label, lang: 'en' })
         _.map(results, 'uri').should.containEql(work.uri)
+      })
+
+      it('should favor matches in the requested language', async () => {
+        const label = randomWords(2)
+        const [ workEs, workFr ] = await Promise.all([
+          createWork({ labels: { es: label } }),
+          createWork({ labels: { fr: label } }),
+        ])
+        await Promise.all([
+          waitForIndexation('entities', workEs._id),
+          waitForIndexation('entities', workFr._id),
+        ])
+        const [ resultsEs, resultsFr ] = await Promise.all([
+          search({ types: 'works', search: label, lang: 'es' }),
+          search({ types: 'works', search: label, lang: 'fr' }),
+        ])
+        const resultsEsUris = _.map(resultsEs, 'uri')
+        const resultsFrUris = _.map(resultsFr, 'uri')
+        resultsEsUris.indexOf(workEs.uri).should.be.below(resultsEsUris.indexOf(workFr.uri))
+        resultsFrUris.indexOf(workEs.uri).should.be.above(resultsFrUris.indexOf(workFr.uri))
       })
     })
 

--- a/tests/api/search/search_entities.test.js
+++ b/tests/api/search/search_entities.test.js
@@ -38,6 +38,19 @@ describe('search:entities', () => {
 
   describe('parameters', () => {
     describe('exact', () => {
+      it('should return results that contains the exact searched words', async () => {
+        const humanLabel = human.labels.en
+        const results = await search({ types: 'humans', search: humanLabel, exact: true })
+        _.map(results, 'uri').should.containEql(human.uri)
+      })
+
+      it('should not return results that do not contain the exact searched words', async () => {
+        const humanLabel = human.labels.en
+        const humanLabelWithoutLastLetter = humanLabel.slice(0, -1)
+        const results = await search({ types: 'humans', search: humanLabelWithoutLastLetter, exact: true })
+        _.map(results, 'uri').should.not.containEql(human.uri)
+      })
+
       it('should reject types that are not entity related', async () => {
         try {
           await search({ types: [ 'groups', 'users' ], search: 'foo', exact: true }).then(shouldNotBeCalled)
@@ -47,10 +60,6 @@ describe('search:entities', () => {
         }
       })
 
-      // Ex: when requesting 'Myron Howe', 'Myron W Howe' will be considered an exact match
-      // This test might occasionnally fail as the current implementation uses an edge_ngram analyzer
-      // at indexation, leading to subparts of terms being considered a match.
-      // Ex: an exact search for "Charles Ben" will find "Charles Bent" as one of its generated tokens is "Ben"
       it('should return only results including exact matches of each words', async () => {
         const humanLabel = human.labels.en
         const results = await search({ types: 'humans', search: humanLabel, lang: 'en', exact: true })
@@ -62,13 +71,6 @@ describe('search:entities', () => {
             resultLabelWords.includes(word).should.be.true()
           })
         })
-      })
-
-      it('should not return results that do not contain the exact searched words', async () => {
-        const humanLabel = human.labels.en
-        const humanLabelWithoutLastLetter = humanLabel.slice(0, -1)
-        const results = await search({ types: 'humans', search: humanLabelWithoutLastLetter, exact: true })
-        _.map(results, 'uri').should.not.containEql(human.uri)
       })
 
       it('should accept a different word order', async () => {

--- a/tests/api/utils/search.js
+++ b/tests/api/utils/search.js
@@ -31,6 +31,23 @@ const getIndexedDoc = async (index, id, options = {}) => {
   }
 }
 
+const getAnalyze = async ({ indexBaseName, text, analyzer }) => {
+  assert_.string(indexBaseName)
+  assert_.string(text)
+  assert_.string(analyzer)
+  const index = indexesNamesByBaseNames[indexBaseName]
+  const url = `${elasticHost}/${index}/_analyze`
+  const { body } = await rawRequest('post', url, {
+    body: { text, analyzer }
+  })
+  return JSON.parse(body)
+}
+
+const getAnalyzedTokens = async ({ indexBaseName, text, analyzer }) => {
+  const analyze = await getAnalyze({ indexBaseName, text, analyzer })
+  return _.map(analyze.tokens, 'token')
+}
+
 const waitForIndexation = async (indexBaseName, id) => {
   assert_.string(indexBaseName)
   const index = indexesNamesByBaseNames[indexBaseName]
@@ -66,6 +83,9 @@ module.exports = {
   },
 
   getIndexedDoc,
+
+  getAnalyze,
+  getAnalyzedTokens,
 
   waitForIndexation,
 

--- a/tests/integration/elasticsearch/entities_analyzers.js
+++ b/tests/integration/elasticsearch/entities_analyzers.js
@@ -23,6 +23,11 @@ describe('entities analyzers', () => {
       const tokens = await getAnalyzedTokens({ indexBaseName, text: 'charleshenrydecomptesponville', analyzer })
       tokens.should.deepEqual([ 'ch', 'cha', 'char', 'charl', 'charle', 'charles', 'charlesh', 'charleshe', 'charleshen' ])
     })
+
+    it('should generate a single letter token', async () => {
+      const tokens = await getAnalyzedTokens({ indexBaseName, text: 'o', analyzer })
+      tokens.should.deepEqual([ 'o' ])
+    })
   })
 
   describe('standard_truncated', () => {
@@ -46,6 +51,11 @@ describe('entities analyzers', () => {
       const tokens = await getAnalyzedTokens({ indexBaseName, text: 'charleshenrydecomptesponville', analyzer })
       tokens.should.deepEqual([ 'charleshen' ])
     })
+
+    it('should generate a single letter token', async () => {
+      const tokens = await getAnalyzedTokens({ indexBaseName, text: 'o', analyzer })
+      tokens.should.deepEqual([ 'o' ])
+    })
   })
 
   describe('standard_full', () => {
@@ -68,6 +78,11 @@ describe('entities analyzers', () => {
     it('should not truncate tokens', async () => {
       const tokens = await getAnalyzedTokens({ indexBaseName, text: 'charleshenrydecomptesponville', analyzer })
       tokens.should.deepEqual([ 'charleshenrydecomptesponville' ])
+    })
+
+    it('should generate a single letter token', async () => {
+      const tokens = await getAnalyzedTokens({ indexBaseName, text: 'o', analyzer })
+      tokens.should.deepEqual([ 'o' ])
     })
   })
 })

--- a/tests/integration/elasticsearch/entities_analyzers.js
+++ b/tests/integration/elasticsearch/entities_analyzers.js
@@ -5,8 +5,11 @@ describe('entities analyzers', () => {
   describe('autocomplete', () => {
     const analyzer = 'autocomplete'
     it('should generate edge-ngrams tokens', async () => {
-      const tokens = await getAnalyzedTokens({ indexBaseName, text: 'charles', analyzer })
-      tokens.should.deepEqual([ 'ch', 'cha', 'char', 'charl', 'charle', 'charles' ])
+      const tokens = await getAnalyzedTokens({ indexBaseName, text: 'charles dickens', analyzer })
+      tokens.should.deepEqual([
+        'ch', 'cha', 'char', 'charl', 'charle', 'charles',
+        'di', 'dic', 'dick', 'dicke', 'dicken', 'dickens',
+      ])
     })
 
     it('should generate lowercased tokens', async () => {

--- a/tests/integration/elasticsearch/entities_analyzers.js
+++ b/tests/integration/elasticsearch/entities_analyzers.js
@@ -28,6 +28,11 @@ describe('entities analyzers', () => {
       const tokens = await getAnalyzedTokens({ indexBaseName, text: 'o', analyzer })
       tokens.should.deepEqual([ 'o' ])
     })
+
+    it('should drop dashes', async () => {
+      const tokens = await getAnalyzedTokens({ indexBaseName, text: 'foo-bar', analyzer })
+      tokens.should.deepEqual([ 'fo', 'foo', 'ba', 'bar' ])
+    })
   })
 
   describe('standard_truncated', () => {
@@ -56,6 +61,11 @@ describe('entities analyzers', () => {
       const tokens = await getAnalyzedTokens({ indexBaseName, text: 'o', analyzer })
       tokens.should.deepEqual([ 'o' ])
     })
+
+    it('should drop dashes', async () => {
+      const tokens = await getAnalyzedTokens({ indexBaseName, text: 'foo-bar', analyzer })
+      tokens.should.deepEqual([ 'foo', 'bar' ])
+    })
   })
 
   describe('standard_full', () => {
@@ -83,6 +93,11 @@ describe('entities analyzers', () => {
     it('should generate a single letter token', async () => {
       const tokens = await getAnalyzedTokens({ indexBaseName, text: 'o', analyzer })
       tokens.should.deepEqual([ 'o' ])
+    })
+
+    it('should drop dashes', async () => {
+      const tokens = await getAnalyzedTokens({ indexBaseName, text: 'foo-bar', analyzer })
+      tokens.should.deepEqual([ 'foo', 'bar' ])
     })
   })
 })

--- a/tests/integration/elasticsearch/entities_analyzers.js
+++ b/tests/integration/elasticsearch/entities_analyzers.js
@@ -1,0 +1,73 @@
+const { getAnalyzedTokens } = require('tests/api/utils/search')
+const indexBaseName = 'entities'
+
+describe('entities analyzers', () => {
+  describe('autocomplete', () => {
+    const analyzer = 'autocomplete'
+    it('should generate edge-ngrams tokens', async () => {
+      const tokens = await getAnalyzedTokens({ indexBaseName, text: 'charles', analyzer })
+      tokens.should.deepEqual([ 'ch', 'cha', 'char', 'charl', 'charle', 'charles' ])
+    })
+
+    it('should generate lowercased tokens', async () => {
+      const tokens = await getAnalyzedTokens({ indexBaseName, text: 'ChArLes', analyzer })
+      tokens.should.deepEqual([ 'ch', 'cha', 'char', 'charl', 'charle', 'charles' ])
+    })
+
+    it('should generate asciifolded tokens', async () => {
+      const tokens = await getAnalyzedTokens({ indexBaseName, text: 'chärlés', analyzer })
+      tokens.should.deepEqual([ 'ch', 'cha', 'char', 'charl', 'charle', 'charles' ])
+    })
+
+    it('should not generate tokens above the max ngram of 10', async () => {
+      const tokens = await getAnalyzedTokens({ indexBaseName, text: 'charleshenrydecomptesponville', analyzer })
+      tokens.should.deepEqual([ 'ch', 'cha', 'char', 'charl', 'charle', 'charles', 'charlesh', 'charleshe', 'charleshen' ])
+    })
+  })
+
+  describe('standard_truncated', () => {
+    const analyzer = 'standard_truncated'
+    it('should not generate edge-ngrams tokens', async () => {
+      const tokens = await getAnalyzedTokens({ indexBaseName, text: 'charles', analyzer })
+      tokens.should.deepEqual([ 'charles' ])
+    })
+
+    it('should generate a lowercased token', async () => {
+      const tokens = await getAnalyzedTokens({ indexBaseName, text: 'ChArLes', analyzer })
+      tokens.should.deepEqual([ 'charles' ])
+    })
+
+    it('should generate an asciifolded token', async () => {
+      const tokens = await getAnalyzedTokens({ indexBaseName, text: 'chärlés', analyzer })
+      tokens.should.deepEqual([ 'charles' ])
+    })
+
+    it('should truncate above the max ngram of 10', async () => {
+      const tokens = await getAnalyzedTokens({ indexBaseName, text: 'charleshenrydecomptesponville', analyzer })
+      tokens.should.deepEqual([ 'charleshen' ])
+    })
+  })
+
+  describe('standard_full', () => {
+    const analyzer = 'standard_full'
+    it('should not generate edge-ngrams tokens', async () => {
+      const tokens = await getAnalyzedTokens({ indexBaseName, text: 'charles', analyzer })
+      tokens.should.deepEqual([ 'charles' ])
+    })
+
+    it('should generate a lowercased token', async () => {
+      const tokens = await getAnalyzedTokens({ indexBaseName, text: 'ChArLes', analyzer })
+      tokens.should.deepEqual([ 'charles' ])
+    })
+
+    it('should generate an asciifolded token', async () => {
+      const tokens = await getAnalyzedTokens({ indexBaseName, text: 'chärlés', analyzer })
+      tokens.should.deepEqual([ 'charles' ])
+    })
+
+    it('should not truncate tokens', async () => {
+      const tokens = await getAnalyzedTokens({ indexBaseName, text: 'charleshenrydecomptesponville', analyzer })
+      tokens.should.deepEqual([ 'charleshenrydecomptesponville' ])
+    })
+  })
+})

--- a/tests/integration/elasticsearch/entities_analyzers.js
+++ b/tests/integration/elasticsearch/entities_analyzers.js
@@ -40,20 +40,7 @@ describe('entities analyzers', () => {
 
   describe('standard_truncated', () => {
     const analyzer = 'standard_truncated'
-    it('should not generate edge-ngrams tokens', async () => {
-      const tokens = await getAnalyzedTokens({ indexBaseName, text: 'charles', analyzer })
-      tokens.should.deepEqual([ 'charles' ])
-    })
-
-    it('should generate a lowercased token', async () => {
-      const tokens = await getAnalyzedTokens({ indexBaseName, text: 'ChArLes', analyzer })
-      tokens.should.deepEqual([ 'charles' ])
-    })
-
-    it('should generate an asciifolded token', async () => {
-      const tokens = await getAnalyzedTokens({ indexBaseName, text: 'chärlés', analyzer })
-      tokens.should.deepEqual([ 'charles' ])
-    })
+    standardAnalyzersCommonTests(analyzer)
 
     it('should truncate above the max ngram of 10', async () => {
       const tokens = await getAnalyzedTokens({ indexBaseName, text: 'charleshenrydecomptesponville', analyzer })
@@ -73,20 +60,7 @@ describe('entities analyzers', () => {
 
   describe('standard_full', () => {
     const analyzer = 'standard_full'
-    it('should not generate edge-ngrams tokens', async () => {
-      const tokens = await getAnalyzedTokens({ indexBaseName, text: 'charles', analyzer })
-      tokens.should.deepEqual([ 'charles' ])
-    })
-
-    it('should generate a lowercased token', async () => {
-      const tokens = await getAnalyzedTokens({ indexBaseName, text: 'ChArLes', analyzer })
-      tokens.should.deepEqual([ 'charles' ])
-    })
-
-    it('should generate an asciifolded token', async () => {
-      const tokens = await getAnalyzedTokens({ indexBaseName, text: 'chärlés', analyzer })
-      tokens.should.deepEqual([ 'charles' ])
-    })
+    standardAnalyzersCommonTests(analyzer)
 
     it('should not truncate tokens', async () => {
       const tokens = await getAnalyzedTokens({ indexBaseName, text: 'charleshenrydecomptesponville', analyzer })
@@ -104,3 +78,21 @@ describe('entities analyzers', () => {
     })
   })
 })
+
+// eslint-disable-next-line prefer-arrow/prefer-arrow-functions
+function standardAnalyzersCommonTests (analyzer) {
+  it('should not generate edge-ngrams tokens', async () => {
+    const tokens = await getAnalyzedTokens({ indexBaseName, text: 'charles', analyzer })
+    tokens.should.deepEqual([ 'charles' ])
+  })
+
+  it('should generate a lowercased token', async () => {
+    const tokens = await getAnalyzedTokens({ indexBaseName, text: 'ChArLes', analyzer })
+    tokens.should.deepEqual([ 'charles' ])
+  })
+
+  it('should generate an asciifolded token', async () => {
+    const tokens = await getAnalyzedTokens({ indexBaseName, text: 'chärlés', analyzer })
+    tokens.should.deepEqual([ 'charles' ])
+  })
+}


### PR DESCRIPTION
This is done by indexing entities' labels and aliases a second time, but this time without applying the edge n-gram filter, to be able to perform exact search on them.

Example of a failed exact search (that should be fixed by this PR): [an exact search for "Norberto bob"](https://inventaire.io/api/search?types=humans&search=Norberto%20bob&lang=en&exact=true) should not find "Norberto Bobbio" (`wd:Q332693`)

While duplicating labels and aliases does have a cost in terms of index size, it would greatly improve features depending on exact search such as "merge suggestion" in the client or the resolver on the server.

This PR also addresses the single-word issue previously addressed in #517

