### PR TITLE
patches: do not anonymize patches from the requesting user

### DIFF
--- a/server/controllers/entities/contributions.js
+++ b/server/controllers/entities/contributions.js
@@ -18,7 +18,7 @@ const sanitization = {
 }
 
 const controller = async (params, req) => {
-  const { userId, limit, offset, filter } = params
+  const { userId, limit, offset, filter, reqUserId } = params
   const reqUserHasAdminAccess = hasAdminAccess(req.user)
 
   if (filter != null && !(isPropertyUri(filter) || isLang(filter))) {
@@ -28,7 +28,8 @@ const controller = async (params, req) => {
   if (userId != null && !reqUserHasAdminAccess) await checkPublicContributionsStatus(userId)
 
   const patchesPage = await getPatchesPage({ userId, limit, offset, reqUserHasAdminAccess, filter })
-  if (!reqUserHasAdminAccess) await anonymizePatches(patchesPage.patches)
+  const { patches } = patchesPage
+  if (!reqUserHasAdminAccess) await anonymizePatches({ patches, reqUserId })
 
   return patchesPage
 }

--- a/server/controllers/entities/history.js
+++ b/server/controllers/entities/history.js
@@ -8,9 +8,9 @@ const sanitization = {
 }
 
 const controller = async (params, req) => {
-  const { id } = params
+  const { id, reqUserId } = params
   const patches = await patches_.getWithSnapshots(id)
-  if (!hasAdminAccess(req.user)) await anonymizePatches(patches)
+  if (!hasAdminAccess(req.user)) await anonymizePatches({ patches, reqUserId })
   return { patches }
 }
 

--- a/server/controllers/entities/lib/anonymize_patches.js
+++ b/server/controllers/entities/lib/anonymize_patches.js
@@ -2,12 +2,14 @@ const _ = require('builders/utils')
 const user_ = require('controllers/user/lib/user')
 const { shouldBeAnonymized } = require('models/user')
 
-module.exports = async patches => {
+module.exports = async ({ patches, reqUserId }) => {
   const usersIds = _.uniq(_.map(patches, 'user'))
   const users = await user_.byIds(usersIds)
   const deanonymizedUsersIds = getDeanonymizedUsersIds(users)
   patches.forEach(patch => {
-    if (!deanonymizedUsersIds.has(patch.user)) anonymizePatch(patch)
+    if (patch.user === reqUserId) return
+    if (deanonymizedUsersIds.has(patch.user)) return
+    anonymizePatch(patch)
   })
 }
 

--- a/tests/api/entities/contributions.test.js
+++ b/tests/api/entities/contributions.test.js
@@ -1,5 +1,5 @@
 const should = require('should')
-const { adminReq, getUser, getReservedUser, authReq, shouldNotBeCalled, getDeanonymizedUser } = require('../utils/utils')
+const { adminReq, getUser, getReservedUser, authReq, shouldNotBeCalled, getDeanonymizedUser, customAuthReq } = require('../utils/utils')
 const { createWork } = require('../fixtures/entities')
 const endpoint = '/api/entities?action=contributions'
 const { wait } = require('lib/promises')
@@ -135,6 +135,14 @@ describe('entities:contributions', () => {
       should(patches.find(isEntityPatch(workA)).user).not.be.ok()
       should(patches.find(isEntityPatch(workB)).user).not.be.ok()
       patches.find(isEntityPatch(workC)).user.should.equal(deanonymizedUser._id)
+    })
+
+    it('should not anonymize contributions when the patch author is the requesting user', async () => {
+      const user = await getReservedUser()
+      const { _id: workId } = await createWork({ user })
+      const { patches } = await customAuthReq(user, 'get', `${endpoint}&limit=1`)
+      patches[0]._id.should.startWith(workId)
+      patches[0].user.should.equal(user._id)
     })
   })
 })

--- a/tests/api/entities/history.test.js
+++ b/tests/api/entities/history.test.js
@@ -1,5 +1,5 @@
 const should = require('should')
-const { adminReq, dataadminReq, publicReq, authReq, shouldNotBeCalled } = require('../utils/utils')
+const { adminReq, dataadminReq, publicReq, authReq, shouldNotBeCalled, getReservedUser } = require('../utils/utils')
 const { createHuman } = require('../fixtures/entities')
 const { getDeanonymizedUser, customAuthReq } = require('../utils/utils')
 const { deleteByUris } = require('../utils/entities')
@@ -74,6 +74,21 @@ describe('entities:history', () => {
       value: 'foo'
     })
     const { patches } = await publicReq('get', `${endpoint}&id=${human._id}`)
+    should(patches[0].user).not.be.ok()
+    patches[1].user.should.equal(user._id)
+  })
+
+  it('should not anonymize patches when the author is the requesting user', async () => {
+    const [ user, human ] = await Promise.all([
+      getReservedUser(),
+      createHuman()
+    ])
+    await customAuthReq(user, 'put', '/api/entities?action=update-label', {
+      uri: human.uri,
+      lang: 'es',
+      value: 'foo'
+    })
+    const { patches } = await customAuthReq(user, 'get', `${endpoint}&id=${human._id}`)
     should(patches[0].user).not.be.ok()
     patches[1].user.should.equal(user._id)
   })


### PR DESCRIPTION
do not anonymize patches from the requesting user when requested by the history and contributions endpoints, so that the requesting user can see their contributions, even when their privacy settings do not let other user see them