### PR TITLE
tasks: collect_entities: wait for CPUs load to be below 50% to run the worker

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -202,7 +202,7 @@ const config = module.exports = {
   jobs: {
     'inv:deduplicate': {
       run: true,
-      interval: 3000
+      nice: true,
     }
   },
 

--- a/config/tests-api-server.js
+++ b/config/tests-api-server.js
@@ -13,7 +13,7 @@ module.exports = {
   jobs: {
     'inv:deduplicate': {
       run: true,
-      interval: 0
+      nice: false,
     }
   }
 }

--- a/server/lib/os.js
+++ b/server/lib/os.js
@@ -1,0 +1,22 @@
+const { cpus, loadavg } = require('os')
+const { wait } = require('./promises')
+const assert_ = require('./utils/assert_types')
+const cpusCount = cpus().length
+
+const getCPUsAverageLoad = () => {
+  const [ last5MinutesAverageLoad ] = loadavg()
+  return last5MinutesAverageLoad / cpusCount
+}
+
+const waitForCPUsLoadToBeBelow = async ({ threshold, checkInterval = 10000 }) => {
+  assert_.number(threshold)
+  assert_.number(checkInterval)
+  if (getCPUsAverageLoad() > threshold) {
+    await wait(checkInterval)
+    return waitForCPUsLoadToBeBelow()
+  }
+}
+
+module.exports = {
+  waitForCPUsLoadToBeBelow,
+}


### PR DESCRIPTION
to let the priority to more urgent matters, such as answering users requests