### PR TITLE
entities by-uris: set editions and collections terms from claims

### DIFF
--- a/server/controllers/entities/lib/entities.js
+++ b/server/controllers/entities/lib/entities.js
@@ -108,10 +108,6 @@ const entities_ = module.exports = {
 
   getUrlFromEntityImageHash: getUrlFromImageHash.bind(null, 'entities'),
 
-  firstClaim: (entity, property) => {
-    if (entity.claims[property] != null) return entity.claims[property][0]
-  },
-
   uniqByUri: entities => _.uniqBy(entities, getUri),
 
   imageIsUsed: async imageHash => {
@@ -122,3 +118,20 @@ const entities_ = module.exports = {
 }
 
 const getUri = entity => entity.uri
+
+const firstClaim = entities_.firstClaim = (entity, property) => {
+  if (entity.claims[property] != null) return entity.claims[property][0]
+}
+
+entities_.setTermsFromClaims = entity => {
+  const title = firstClaim(entity, 'wdt:P1476')
+  const subtitle = firstClaim(entity, 'wdt:P1680')
+  if (title) {
+    entity.labels = entity.labels || {}
+    entity.labels.fromclaims = title
+  }
+  if (subtitle) {
+    entity.descriptions = entity.descriptions || {}
+    entity.descriptions.fromclaims = subtitle
+  }
+}

--- a/server/controllers/entities/lib/format_entity_common.js
+++ b/server/controllers/entities/lib/format_entity_common.js
@@ -1,6 +1,7 @@
 // Gathering entity formatting steps common to all the consumers
 // Keep in sync with get_wikidata_enriched_entities formatting
 const getOriginalLang = require('lib/wikidata/get_original_lang')
+const { setTermsFromClaims } = require('./entities')
 const getEntityImagesFromClaims = require('./get_entity_images_from_claims')
 
 module.exports = entity => {
@@ -9,6 +10,10 @@ module.exports = entity => {
   // Matching Wikidata entities format for images
   // Here we are missing license, credits, and author attributes
   entity.image = { url: getEntityImagesFromClaims(entity)[0] }
+
+  if (entity.type === 'edition' || entity.type === 'collection') {
+    setTermsFromClaims(entity)
+  }
 
   return entity
 }

--- a/server/db/elasticsearch/formatters/entity.js
+++ b/server/db/elasticsearch/formatters/entity.js
@@ -4,7 +4,7 @@ const { simplify } = wdk
 const { getEntityId } = require('./entity_helpers')
 const { activeI18nLangs } = require('../helpers')
 const getEntityImagesFromClaims = require('controllers/entities/lib/get_entity_images_from_claims')
-const { firstClaim } = require('controllers/entities/lib/entities')
+const { setTermsFromClaims } = require('controllers/entities/lib/entities')
 const getEntityType = require('controllers/entities/lib/get_entity_type')
 const { indexedEntitiesTypes } = require('db/elasticsearch/indexes')
 const specialEntityImagesGetter = require('controllers/entities/lib/special_entity_images_getter')
@@ -137,17 +137,6 @@ const getType = ({ claims, type }) => {
 const dropPlural = type => {
   if (type) {
     return type.replace(/s$/, '')
-  }
-}
-
-const setTermsFromClaims = entity => {
-  const title = firstClaim(entity, 'wdt:P1476')
-  const subtitle = firstClaim(entity, 'wdt:P1680')
-  if (title) {
-    entity.labels = { fromclaims: title }
-  }
-  if (subtitle) {
-    entity.descriptions = { fromclaims: subtitle }
   }
 }
 

--- a/tests/api/entities/get_by_uris.test.js
+++ b/tests/api/entities/get_by_uris.test.js
@@ -1,7 +1,7 @@
 const should = require('should')
 const { authReq, shouldNotBeCalled, rethrowShouldNotBeCalledErrors, publicReq } = require('../utils/utils')
 
-const { createEditionWithIsbn, createWorkWithAuthor, createEditionWithWorkAuthorAndSerie, createHuman, someFakeUri, generateIsbn13 } = require('../fixtures/entities')
+const { createEditionWithIsbn, createWorkWithAuthor, createEditionWithWorkAuthorAndSerie, createHuman, someFakeUri, generateIsbn13, createEdition } = require('../fixtures/entities')
 const { getByUris, merge, deleteByUris } = require('../utils/entities')
 const workWithAuthorPromise = createWorkWithAuthor()
 const getWdEntity = require('data/wikidata/get_entity')
@@ -69,6 +69,14 @@ describe('entities:get:by-uris', () => {
     entity.uri.should.equal(uri)
   })
 
+  it('should set terms from claims on editions', async () => {
+    const { uri, claims } = await createEdition()
+    const { entities } = await getByUris(uri)
+    const entity = entities[uri]
+    entity.labels.fromclaims.should.equal(claims['wdt:P1476'][0])
+    entity.descriptions.fromclaims.should.equal(claims['wdt:P1680'][0])
+  })
+
   describe('attributes', () => {
     it("should return only the requested 'attributes'", async () => {
       const work = await workWithAuthorPromise
@@ -109,7 +117,7 @@ describe('entities:get:by-uris', () => {
       const work = entities.find(entity => entity.type === 'work')
       const serie = entities.find(entity => entity.type === 'serie')
       const human = entities.find(entity => entity.type === 'human')
-      edition.labels.should.be.ok()
+      edition.labels.fromclaims.should.be.ok()
       work.labels.en.should.be.ok()
       serie.labels.en.should.be.ok()
       human.labels.en.should.be.ok()


### PR DESCRIPTION
to allow not over-fetching claims but still get a label when requesting `attributes=labels`

Useful for https://github.com/inventaire/inventaire-client/pull/311