### PR TITLE
createOccurrencesFromUnstructuredArticle: normalize terms using ascii folding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "email-addresses": "^2.0.1",
         "express": "^4.16.3",
         "express-oauth-server": "^2.0.0",
+        "fold-to-ascii": "^5.0.0",
         "formidable": "^1.0.17",
         "git-hooks": "^1.1.10",
         "gm": "^1.23.1",
@@ -2296,6 +2297,14 @@
       "version": "3.1.1",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fold-to-ascii": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fold-to-ascii/-/fold-to-ascii-5.0.0.tgz",
+      "integrity": "sha512-HjtRWXC9aVit47DOEqvorgaQDiIyeX+frV3tM22RlllposIxnPXRM/vYoE6y6pwW57RdgahSe32Cu0vf4/UX1Q==",
+      "engines": {
+        "node": ">= 6.3.1"
+      }
     },
     "node_modules/foreach": {
       "version": "2.0.5",
@@ -7621,6 +7630,11 @@
     "flatted": {
       "version": "3.1.1",
       "dev": true
+    },
+    "fold-to-ascii": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fold-to-ascii/-/fold-to-ascii-5.0.0.tgz",
+      "integrity": "sha512-HjtRWXC9aVit47DOEqvorgaQDiIyeX+frV3tM22RlllposIxnPXRM/vYoE6y6pwW57RdgahSe32Cu0vf4/UX1Q=="
     },
     "foreach": {
       "version": "2.0.5"

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "email-addresses": "^2.0.1",
     "express": "^4.16.3",
     "express-oauth-server": "^2.0.0",
+    "fold-to-ascii": "^5.0.0",
     "formidable": "^1.0.17",
     "git-hooks": "^1.1.10",
     "gm": "^1.23.1",

--- a/server/controllers/entities/lib/get_occurrences_from_external_sources.js
+++ b/server/controllers/entities/lib/get_occurrences_from_external_sources.js
@@ -15,6 +15,7 @@ const getOlAuthorWorksTitles = require('data/openlibrary/get_ol_author_works_tit
 const getEntityByUri = require('./get_entity_by_uri')
 const { normalizeTerm } = require('./terms_normalization')
 const { isWdEntityUri } = require('lib/boolean_validations')
+const ASCIIFolder = require('fold-to-ascii')
 
 // - worksLabels: labels from works of an author suspected
 //   to be the same as the wdAuthorUri author
@@ -89,10 +90,10 @@ const getKjkOccurrences = getAndCreateOccurrencesFromIds('wdt:P1006', getKjkAuth
 const getNdlOccurrences = getAndCreateOccurrencesFromIds('wdt:P349', getNdlAuthorWorksTitle)
 
 const createOccurrencesFromUnstructuredArticle = worksLabels => {
-  const worksLabelsPattern = new RegExp(worksLabels.join('|'), 'gi')
+  const worksLabelsPattern = new RegExp(worksLabels.map(normalize).join('|'), 'g')
   return article => {
     if (!article.extract) return
-    const matchedTitles = _.uniq(article.extract.match(worksLabelsPattern))
+    const matchedTitles = _.uniq(normalize(article.extract).match(worksLabelsPattern))
     if (matchedTitles.length <= 0) return
     return { url: article.url, matchedTitles, structuredDataSource: false }
   }
@@ -108,3 +109,7 @@ const createOccurrencesFromExactTitles = worksLabels => result => {
     }
   }
 }
+
+// Example of a case requiring ascii-folding:
+// when "’" is used on one side and "'" on the other
+const normalize = str => ASCIIFolder.foldMaintaining(str.toLowerCase().normalize())


### PR DESCRIPTION
Use-case: prevent missing occurrences of work titles in Wikipedia articles due to close but different characters being used by the different inputs. For instance, `Charte de l’environnement` is not the same as `Charte de l'environnement` and wouldn't count as an occurrence in the current implementation.

This PR introduces a new dependency, but a tiny one, and based on the same Lucene ASCIIFoldingFilter class we use through Elasticsearch `asciifolding` filter.