### PR TITLE
Add support for actor url webfinger as resource

### DIFF
--- a/server/controllers/activitypub/webfinger.js
+++ b/server/controllers/activitypub/webfinger.js
@@ -1,4 +1,5 @@
-const { publicHost } = require('config')
+const fullPublicHost = require('config').fullPublicHost()
+const publicHost = fullPublicHost.split('://')[1]
 const error_ = require('lib/error/error')
 const { ControllerWrapper } = require('lib/controller_wrapper')
 const { makeUrl, getEntityUriFromActorName, getEntityActorName } = require('controllers/activitypub/lib/helpers')

--- a/server/lib/boolean_validations.js
+++ b/server/lib/boolean_validations.js
@@ -4,6 +4,7 @@ const wdk = require('wikidata-sdk')
 const regex_ = require('lib/regex')
 const { isNormalizedIsbn } = require('./isbn/isbn')
 const { PositiveInteger: PositiveIntegerPattern } = regex_
+const host = require('config').fullPublicHost()
 
 const bindedTest = regexName => regex_[regexName].test.bind(regex_[regexName])
 
@@ -84,5 +85,14 @@ const tests = module.exports = {
   isPositiveIntegerString: str => _.isString(str) && PositiveIntegerPattern.test(str),
   isStrictlyPositiveInteger: num => Number.isInteger(num) && num > 0,
   isExtendedUrl: str => tests.isUrl(str) || tests.isLocalImg(str),
-  isCollection: array => (_.typeOf(array) === 'array') && _.every(array, _.isPlainObject)
+  isCollection: array => (_.typeOf(array) === 'array') && _.every(array, _.isPlainObject),
+
+  isLocalActivityPubActorUrl: url => {
+    if (!tests.isUrl(url)) return false
+    const { origin, pathname, searchParams } = new URL(url)
+    if (origin !== host) return false
+    if (pathname !== '/api/activitypub') return false
+    if (searchParams.get('action') !== 'actor') return false
+    return isNonEmptyString(searchParams.get('name'))
+  }
 }

--- a/tests/api/activitypub/webfinger.test.js
+++ b/tests/api/activitypub/webfinger.test.js
@@ -128,15 +128,6 @@ describe('activitypub:webfinger', () => {
       const res2 = await publicReq('get', `${endpoint}${resourceAlias}`)
       res2.subject.should.equal(resource)
     })
-
-    it('should accept an actor URL as resource', async () => {
-      const username = createUsername()
-      await createUser({ username, fediversable: true })
-      const actorUrl = `${fullPublicHost}/api/activitypub?action=actor&name=${username}`
-      const res = await publicReq('get', `${endpoint}${encodeURIComponent(actorUrl)}`)
-      const { subject } = res
-      subject.should.equal(`acct:${username}@${publicHost}`)
-    })
   })
 
   describe('entities', () => {
@@ -152,16 +143,6 @@ describe('activitypub:webfinger', () => {
       aliases.should.matchAny(actorUrl)
       const firstLink = _.find(links, { rel: 'self' })
       firstLink.href.should.equal(actorUrl)
-    })
-
-    it('should accept an actor URL as resource', async () => {
-      const { uri } = await createHuman()
-      const actorName = getEntityActorName(uri)
-      const actorUrl = `${fullPublicHost}/api/activitypub?action=actor&name=${actorName}`
-      const resource = `acct:${actorName}@${publicHost}`
-      const res = await publicReq('get', `${endpoint}${encodeURIComponent(actorUrl)}`)
-      const { subject } = res
-      subject.should.equal(resource)
     })
   })
 
@@ -193,16 +174,16 @@ describe('activitypub:webfinger', () => {
       const firstLink = _.find(links, { rel: 'self' })
       decodeURIComponent(firstLink.href).should.equal(actorUrl)
     })
+  })
 
+  describe('actor URL as resource', () => {
     it('should accept an actor URL as resource', async () => {
-      const user = createUser({ fediversable: true })
-      const { shelf } = await createShelf(user)
-      const name = getActorName(shelf)
-      const resource = `acct:${name}@${publicHost}`
-      const actorUrl = `${fullPublicHost}/api/activitypub?action=actor&name=${name}`
+      const username = createUsername()
+      await createUser({ username, fediversable: true })
+      const actorUrl = `${fullPublicHost}/api/activitypub?action=actor&name=${username}`
       const res = await publicReq('get', `${endpoint}${encodeURIComponent(actorUrl)}`)
       const { subject } = res
-      subject.should.equal(resource)
+      subject.should.equal(`acct:${username}@${publicHost}`)
     })
   })
 })

--- a/tests/api/activitypub/webfinger.test.js
+++ b/tests/api/activitypub/webfinger.test.js
@@ -9,7 +9,7 @@ const { wait } = require('lib/promises')
 const { createHuman } = require('../fixtures/entities')
 const { getEntityActorName } = require('controllers/activitypub/lib/helpers')
 const fullPublicHost = CONFIG.fullPublicHost()
-const { publicHost } = CONFIG
+const publicHost = fullPublicHost.split('://')[1]
 const { createShelf } = require('../fixtures/shelves')
 const { getActorName } = require('../utils/shelves')
 
@@ -95,7 +95,6 @@ describe('activitypub:webfinger', () => {
       const resource = `acct:${username}@${publicHost}`
       const res = await publicReq('get', `${endpoint}${resource}`)
       const { subject, aliases, links } = res
-      res.should.be.an.Object()
       subject.should.equal(resource)
       const actorUrl = `${fullPublicHost}/api/activitypub?action=actor&name=${username}`
       aliases[0].should.equal(actorUrl)
@@ -129,6 +128,15 @@ describe('activitypub:webfinger', () => {
       const res2 = await publicReq('get', `${endpoint}${resourceAlias}`)
       res2.subject.should.equal(resource)
     })
+
+    it('should accept an actor URL as resource', async () => {
+      const username = createUsername()
+      await createUser({ username, fediversable: true })
+      const actorUrl = `${fullPublicHost}/api/activitypub?action=actor&name=${username}`
+      const res = await publicReq('get', `${endpoint}${encodeURIComponent(actorUrl)}`)
+      const { subject } = res
+      subject.should.equal(`acct:${username}@${publicHost}`)
+    })
   })
 
   describe('entities', () => {
@@ -138,13 +146,22 @@ describe('activitypub:webfinger', () => {
       const resource = `acct:${actorName}@${publicHost}`
       const res = await publicReq('get', `${endpoint}${resource}`)
       const { subject, aliases, links } = res
-      res.should.be.an.Object()
       subject.should.equal(resource)
       const actorUrl = `${fullPublicHost}/api/activitypub?action=actor&name=${actorName}`
       aliases[0].should.equal(actorUrl)
       aliases.should.matchAny(actorUrl)
       const firstLink = _.find(links, { rel: 'self' })
       firstLink.href.should.equal(actorUrl)
+    })
+
+    it('should accept an actor URL as resource', async () => {
+      const { uri } = await createHuman()
+      const actorName = getEntityActorName(uri)
+      const actorUrl = `${fullPublicHost}/api/activitypub?action=actor&name=${actorName}`
+      const resource = `acct:${actorName}@${publicHost}`
+      const res = await publicReq('get', `${endpoint}${encodeURIComponent(actorUrl)}`)
+      const { subject } = res
+      subject.should.equal(resource)
     })
   })
 
@@ -170,12 +187,22 @@ describe('activitypub:webfinger', () => {
       const resource = `acct:${name}@${publicHost}`
       const res = await publicReq('get', `${endpoint}${resource}`)
       const { subject, aliases, links } = res
-      res.should.be.an.Object()
       subject.should.equal(resource)
       const actorUrl = `${fullPublicHost}/api/activitypub?action=actor&name=${name}`
       decodeURIComponent(aliases[0]).should.equal(actorUrl)
       const firstLink = _.find(links, { rel: 'self' })
       decodeURIComponent(firstLink.href).should.equal(actorUrl)
+    })
+
+    it('should accept an actor URL as resource', async () => {
+      const user = createUser({ fediversable: true })
+      const { shelf } = await createShelf(user)
+      const name = getActorName(shelf)
+      const resource = `acct:${name}@${publicHost}`
+      const actorUrl = `${fullPublicHost}/api/activitypub?action=actor&name=${name}`
+      const res = await publicReq('get', `${endpoint}${encodeURIComponent(actorUrl)}`)
+      const { subject } = res
+      subject.should.equal(resource)
     })
   })
 })

--- a/tests/unit/libs/055-boolean_validations.js
+++ b/tests/unit/libs/055-boolean_validations.js
@@ -1,0 +1,38 @@
+require('should')
+const { isLocalActivityPubActorUrl } = require('lib/boolean_validations')
+const { buildUrl } = require('lib/utils/url')
+const host = require('config').fullPublicHost()
+
+describe('boolean validations', () => {
+  describe('isLocalActivityPubActorUrl', () => {
+    it('should reject an undefined url', () => {
+      isLocalActivityPubActorUrl().should.be.false()
+    })
+
+    it('should reject a non-url', () => {
+      isLocalActivityPubActorUrl('foo').should.be.false()
+    })
+
+    it('should reject a URL from another host', () => {
+      const url = buildUrl('http://example.org/api/activitypub', { action: 'actor', name: 'someusername' })
+      isLocalActivityPubActorUrl(url).should.be.false()
+    })
+
+    it('should reject a URL targeting another endpoint', () => {
+      const url = buildUrl(`${host}/api/tests`, { action: 'actor', name: 'someusername' })
+      isLocalActivityPubActorUrl(url).should.be.false()
+      const url2 = buildUrl(`${host}/tests`, { action: 'actor', name: 'someusername' })
+      isLocalActivityPubActorUrl(url2).should.be.false()
+    })
+
+    it('should reject a URL without a name parameter', () => {
+      const url = buildUrl(`${host}/api/activitypub`, { action: 'actor', name: '' })
+      isLocalActivityPubActorUrl(url).should.be.false()
+    })
+
+    it('should accept an actor URL', () => {
+      const url = buildUrl(`${host}/api/activitypub`, { action: 'actor', name: 'someusername' })
+      isLocalActivityPubActorUrl(url).should.be.true()
+    })
+  })
+})


### PR DESCRIPTION
Currently, only resources in the form `acct:georges@inventaire.io` are accepted, rejecting resources in the form `https://inventaire.io/api/activitypub?action=actor&name=georges`

By accepting resources in the URL form, this PR would allow to answer with a 200 instead of a 400 to requests such as
```
GET /.well-known/webfinger?resource=https%3A%2F%2Finventaire.io%2Fapi%2Factivitypub%3Faction%3Dactor%26name%3Dgeorges 400
```
Such requests can be seen in the server logs, with Friendica in their user agent: I hope solving this would solve the issues reported lately (in mastodon DM) with Friendica integration