### PR TITLE
prevent the creation of several editions with the same isbn, when in autocreate mode

### DIFF
--- a/server/lib/temporarily_memoize.js
+++ b/server/lib/temporarily_memoize.js
@@ -1,0 +1,25 @@
+const assert_ = require('lib/utils/assert_types')
+
+module.exports = ({ fn, ttlAfterFunctionCallReturned }) => {
+  assert_.function(fn)
+  assert_.number(ttlAfterFunctionCallReturned)
+  const cache = {}
+  return async (...args) => {
+    if (args.length !== 1) throw new Error('only single argument functions are supported')
+    const arg = args[0]
+    if (cache[arg] != null) {
+      return cache[arg]
+    } else {
+      try {
+        const promise = fn(arg)
+        cache[arg] = promise
+        const res = await promise
+        setTimeout(() => delete cache[arg], ttlAfterFunctionCallReturned)
+        return res
+      } catch (err) {
+        setTimeout(() => delete cache[arg], ttlAfterFunctionCallReturned)
+        throw err
+      }
+    }
+  }
+}

--- a/tests/api/entities/get_by_uris.test.js
+++ b/tests/api/entities/get_by_uris.test.js
@@ -233,32 +233,34 @@ describe('entities:get:by-isbns', () => {
     should(res.notFound).not.be.ok()
   })
 
-  it('should return editions isbn in notFound array when autocreation is false', async () => {
-    const uri = `isbn:${generateIsbn13()}`
-    const res = await authReq('get', `/api/entities?action=by-uris&uris=${uri}&autocreate=false`)
-    res.entities.should.deepEqual({})
-    res.notFound[0].should.equal(uri)
-  })
+  describe('autocreate', () => {
+    it('should return editions isbn in notFound array when autocreation is false', async () => {
+      const uri = `isbn:${generateIsbn13()}`
+      const res = await authReq('get', `/api/entities?action=by-uris&uris=${uri}&autocreate=false`)
+      res.entities.should.deepEqual({})
+      res.notFound[0].should.equal(uri)
+    })
 
-  it('should return editions isbn in notFound array when autocreation is true', async () => {
-    const isbnUnknownBySeedsSources = '9783981898743'
-    const uri = `isbn:${isbnUnknownBySeedsSources}`
-    const res = await authReq('get', `/api/entities?action=by-uris&uris=${uri}&autocreate=true`)
-    res.entities.should.deepEqual({})
-    res.notFound[0].should.equal(uri)
-  })
+    it('should return editions isbn in notFound array when autocreation is true', async () => {
+      const isbnUnknownBySeedsSources = '9783981898743'
+      const uri = `isbn:${isbnUnknownBySeedsSources}`
+      const res = await authReq('get', `/api/entities?action=by-uris&uris=${uri}&autocreate=true`)
+      res.entities.should.deepEqual({})
+      res.notFound[0].should.equal(uri)
+    })
 
-  it('should autocreate from seed when autocreation is true', async () => {
-    const isbnKnownBySeedsSources = '9782207116746'
-    const uri = `isbn:${isbnKnownBySeedsSources}`
-    await deleteByUris([ uri ])
-    const { notFound } = await authReq('get', `/api/entities?action=by-uris&uris=${uri}&autocreate=false`)
-    notFound.should.deepEqual([ uri ])
-    const res = await authReq('get', `/api/entities?action=by-uris&uris=${uri}&autocreate=true`)
-    const entity = res.entities[uri]
-    entity.should.be.an.Object()
-    entity.uri.should.equal(uri)
-    should(res.notFound).not.be.ok()
+    it('should autocreate from seed when autocreation is true', async () => {
+      const isbnKnownBySeedsSources = '9782207116746'
+      const uri = `isbn:${isbnKnownBySeedsSources}`
+      await deleteByUris([ uri ])
+      const { notFound } = await authReq('get', `/api/entities?action=by-uris&uris=${uri}&autocreate=false`)
+      notFound.should.deepEqual([ uri ])
+      const res = await authReq('get', `/api/entities?action=by-uris&uris=${uri}&autocreate=true`)
+      const entity = res.entities[uri]
+      entity.should.be.an.Object()
+      entity.uri.should.equal(uri)
+      should(res.notFound).not.be.ok()
+    })
   })
 })
 

--- a/tests/unit/libs/056-temporarily_memoize.js
+++ b/tests/unit/libs/056-temporarily_memoize.js
@@ -1,0 +1,60 @@
+require('should')
+const { wait } = require('lib/promises')
+const temporarilyMemoize = require('lib/temporarily_memoize')
+const ttlAfterFunctionCallReturned = 200
+
+describe('temporarily memoize', () => {
+  it('should memoize calls with the same argument', async () => {
+    const fn = async () => Math.random()
+    const memoizedFn = temporarilyMemoize({ fn, ttlAfterFunctionCallReturned })
+    const promiseA = memoizedFn('foo')
+    const promiseB = memoizedFn('foo')
+    promiseA.should.be.a.Promise()
+    promiseB.should.be.a.Promise()
+    ;(await promiseA).should.equal(await promiseB)
+  })
+
+  it('should not mixup calls', async () => {
+    const fn = async arg => arg.toUpperCase()
+    const memoizedFn = temporarilyMemoize({ fn, ttlAfterFunctionCallReturned })
+    const promiseA = memoizedFn('a')
+    const promiseB = memoizedFn('b')
+    ;(await promiseA).should.equal('A')
+    ;(await promiseB).should.equal('B')
+  })
+
+  it('should clear the cache after a delay', async () => {
+    const fn = async () => Math.random()
+    const memoizedFn = temporarilyMemoize({ fn, ttlAfterFunctionCallReturned })
+    const [ a, b ] = await Promise.all([
+      memoizedFn('foo'),
+      memoizedFn('foo'),
+    ])
+    const cPromise = memoizedFn('foo')
+    await wait(ttlAfterFunctionCallReturned + 10)
+    const dPromise = memoizedFn('foo')
+    a.should.equal(b)
+    a.should.equal(await cPromise)
+    a.should.not.equal(await dPromise)
+  })
+
+  it('should clear the cache after a failed call', async () => {
+    let count = 0
+    const throwOnOddCalls = async () => {
+      count++
+      if (count % 2 === 0) return 'yep'
+      else throw new Error('failed')
+    }
+    const memoizedFn = temporarilyMemoize({ fn: throwOnOddCalls, ttlAfterFunctionCallReturned })
+    const failPromiseA = memoizedFn('foo').catch(catchAndReturnErr)
+    const failPromiseB = memoizedFn('foo').catch(catchAndReturnErr)
+    const errA = await failPromiseA
+    const errB = await failPromiseB
+    errA.should.equal(errB)
+    await wait(ttlAfterFunctionCallReturned + 10)
+    const successRes = await memoizedFn('foo')
+    successRes.should.equal('yep')
+  })
+})
+
+const catchAndReturnErr = err => err


### PR DESCRIPTION
Making several calls to `GET /api/entities?action=by-uris` with `autocreate=true` can trigger the creation of duplicated edition entities. There seem to currently be more than 1600 in the production database. The reason for that is likely to be that the importer now seems to regularly trigger simultaneous requests for the same isbn-identified edition. Requests examples:

```
Sep 26 11:47:50 prod: GET /api/entities?action=by-uris&uris=isbn:9782738108074&refresh=false&autocreate=true 200 4465ms
Sep 26 11:47:50 prod: GET /api/entities?action=by-uris&uris=isbn:9782738108074&refresh=false&relatives=wdt:P629|wdt:P50&autocreate=true 200 664ms
```

which produces the following entities:
https://inventaire.io/entity/inv:76a0f40371636ef9184d3fdccd5778b5/history
https://inventaire.io/entity/inv:76a0f40371636ef9184d3fdccd578162/history

Investigating why simulatneous requests are sent by the client could make sense, but would then be less urgent if this problem is already solved on the server side.

The proposed implementation is to use a temporary memoization mechanism, so the first call to `getResolvedEntry` works as usual, and immediatly following calls get that same result promise. The memoization cache is then cleared once the first call returned, and after a short delay to let CouchDB views (which usually play the role of guard against duplicates) have the time to update.

Fortunately, the remediation to the current duplicates should be fairly simple: simply group the editions by isbns, and merge the duplicates.