### PR TITLE
Implement context tailored listings

### DIFF
--- a/server/controllers/items/by_users.js
+++ b/server/controllers/items/by_users.js
@@ -5,7 +5,8 @@ const sanitization = {
   users: {},
   limit: { optional: true },
   offset: { optional: true },
-  filter: {
+  context: {
+    generic: 'allowlist',
     allowlist: validFilters,
     optional: true
   },

--- a/server/controllers/items/by_users.js
+++ b/server/controllers/items/by_users.js
@@ -1,4 +1,3 @@
-const { validFilters } = require('./lib/queries_commons')
 const getItemsByUsers = require('./lib/get_items_by_users')
 
 const sanitization = {
@@ -6,8 +5,6 @@ const sanitization = {
   limit: { optional: true },
   offset: { optional: true },
   context: {
-    generic: 'allowlist',
-    allowlist: validFilters,
     optional: true
   },
   'include-users': {

--- a/server/controllers/items/lib/queries_commons.js
+++ b/server/controllers/items/lib/queries_commons.js
@@ -2,14 +2,7 @@ const _ = require('builders/utils')
 const user_ = require('controllers/user/lib/user')
 const { setItemsBusyFlag } = require('controllers/transactions/lib/transactions')
 const snapshot_ = require('./snapshot/snapshot')
-
-const filters = {
-  // Prevent showing private items in group context to avoid giving the false
-  // impression that those are visible by other members of the group
-  group: item => item.visibility.length > 0
-}
-
-const validFilters = Object.keys(filters)
+const { isVisibilityGroupKey } = require('lib/boolean_validations')
 
 const addUsersData = async (page, reqParams) => {
   const { reqUserId, includeUsers } = reqParams
@@ -33,7 +26,6 @@ const addItemsSnapshots = items => {
 }
 
 module.exports = {
-  validFilters,
   addItemsSnapshots,
 
   addAssociatedData: async (page, reqParams) => {
@@ -48,7 +40,9 @@ module.exports = {
   paginate: (items, params) => {
     let { limit, offset, context } = params
     items = items.sort(byCreationDate)
-    if (context != null) items = items.filter(filters[context])
+    if (context != null) {
+      items = items.filter(canBeDisplayedInContext(context))
+    }
     const total = items.length
     if (offset == null) offset = 0
     const last = offset + limit
@@ -65,3 +59,16 @@ module.exports = {
 }
 
 const byCreationDate = (a, b) => b.created - a.created
+
+const canBeDisplayedInContext = context => item => {
+  if (isVisibilityGroupKey(context)) {
+    const { visibility } = item
+    if (visibility.includes('public') || visibility.includes('groups') || visibility.includes(context)) {
+      return true
+    } else {
+      return false
+    }
+  } else {
+    return true
+  }
+}

--- a/server/controllers/items/lib/queries_commons.js
+++ b/server/controllers/items/lib/queries_commons.js
@@ -46,20 +46,20 @@ module.exports = {
   },
 
   paginate: (items, params) => {
-    let { limit, offset, filter } = params
+    let { limit, offset, context } = params
     items = items.sort(byCreationDate)
-    if (filter != null) items = items.filter(filters[filter])
+    if (context != null) items = items.filter(filters[context])
     const total = items.length
     if (offset == null) offset = 0
     const last = offset + limit
 
     if (limit != null) {
       items = items.slice(offset, last)
-      const data = { items, total, offset, filter }
+      const data = { items, total, offset, context }
       if (last < total) data.continue = last
       return data
     } else {
-      return { items, total, offset, filter }
+      return { items, total, offset, context }
     }
   }
 }

--- a/server/controllers/listings/by_creators.js
+++ b/server/controllers/listings/by_creators.js
@@ -12,12 +12,16 @@ const sanitization = {
   'with-elements': {
     optional: true,
     generic: 'boolean',
-  }
+  },
+  context: {
+    optional: true
+  },
 }
-const controller = async ({ users, offset, limit, withElements, reqUserId }) => {
+
+const controller = async ({ users, offset, limit, context, withElements, reqUserId }) => {
   const foundListings = await listings_.byCreators(users)
   const allVisibleListings = await filterVisibleDocs(foundListings, reqUserId)
-  const { items: authorizedListings } = paginate(allVisibleListings, { offset, limit })
+  const { items: authorizedListings } = paginate(allVisibleListings, { offset, limit, context })
   if (withElements && isNonEmptyArray(authorizedListings)) {
     await assignElementsToLists(authorizedListings)
   }

--- a/server/lib/sanitize/parameters.js
+++ b/server/lib/sanitize/parameters.js
@@ -140,7 +140,7 @@ const arrayOfNumbers = {
 }
 
 const imgUrl = {
-  format: (value, name, config) => {
+  format: value => {
     let decodedUrl = decodeURIComponent(value)
     if (decodedUrl[0] === '/') decodedUrl = `${origin}${decodedUrl}`
     return decodedUrl
@@ -171,7 +171,7 @@ const allowlistedStrings = {
 
 const lang = {
   default: 'en',
-  validate: (value, name, config) => {
+  validate: (value, config) => {
     if (config.type === 'wikimedia') {
       return isWikimediaLanguageCode(value)
     } else {
@@ -235,7 +235,7 @@ module.exports = {
     format: value => {
       return JSON.parse(value)
     },
-    validate: (bbox, name, config) => {
+    validate: bbox => {
       if (_.typeOf(bbox) !== 'array') return false
       if (bbox.length !== 4) return false
       for (const coordinate of bbox) {
@@ -259,7 +259,7 @@ module.exports = {
     validate: _.isColorHexCode
   },
   context: {
-    validate: (value, name, config) => {
+    validate: value => {
       if (!isVisibilityKey(value)) {
         throw error_.new(`invalid context: ${value}`, 400, { value })
       }

--- a/server/lib/sanitize/parameters.js
+++ b/server/lib/sanitize/parameters.js
@@ -8,6 +8,7 @@ const { truncateLatLng } = require('lib/geo')
 const { isValidIsbn } = require('lib/isbn/isbn')
 const { normalizeString } = require('lib/utils/base')
 const { isWikimediaLanguageCode } = require('lib/wikimedia')
+const { isVisibilityKey, isVisibilityKeyArray } = require('models/validations/visibility')
 
 // Parameters attributes:
 // - format (optional)
@@ -18,7 +19,7 @@ const { isWikimediaLanguageCode } = require('lib/wikimedia')
 const validations = {
   common: require('models/validations/common'),
   user: require('models/validations/user'),
-  visibility: require('models/validations/visibility'),
+  visibility: isVisibilityKeyArray,
 }
 
 const parseNumberString = value => {
@@ -256,6 +257,14 @@ module.exports = {
       }
     },
     validate: _.isColorHexCode
+  },
+  context: {
+    validate: (value, name, config) => {
+      if (!isVisibilityKey(value)) {
+        throw error_.new(`invalid context: ${value}`, 400, { value })
+      }
+      return true
+    }
   },
   email: { validate: validations.common.email },
   emails,

--- a/server/models/validations/item.js
+++ b/server/models/validations/item.js
@@ -1,6 +1,7 @@
 const _ = require('builders/utils')
 const { pass, itemId, userId, entityUri, BoundedString, imgUrl } = require('./common')
 const { constrained } = require('../attributes/item')
+const { isVisibilityKeyArray } = require('models/validations/visibility')
 const constrainedAttributes = Object.keys(constrained)
 
 module.exports = {
@@ -14,7 +15,7 @@ module.exports = {
   transaction: transaction => {
     return constrained.transaction.possibilities.includes(transaction)
   },
-  visibility: require('./visibility'),
+  visibility: isVisibilityKeyArray,
   details: _.isString,
   notes: _.isString,
   snapshotValidations: {

--- a/server/models/validations/listing.js
+++ b/server/models/validations/listing.js
@@ -1,9 +1,10 @@
+const { isVisibilityKeyArray } = require('models/validations/visibility')
 const { pass, BoundedString, userId } = require('./common')
 
 module.exports = {
   pass,
   description: BoundedString(0, 5000),
-  visibility: require('./visibility'),
+  visibility: isVisibilityKeyArray,
   creator: userId,
   name: BoundedString(0, 128),
 }

--- a/server/models/validations/shelf.js
+++ b/server/models/validations/shelf.js
@@ -1,10 +1,11 @@
 const { pass, BoundedString, userId } = require('./common')
 const { isColorHexCode } = require('lib/boolean_validations')
+const { isVisibilityKeyArray } = require('models/validations/visibility')
 
 module.exports = {
   pass,
   description: BoundedString(0, 5000),
-  visibility: require('./visibility'),
+  visibility: isVisibilityKeyArray,
   owner: userId,
   name: BoundedString(0, 128),
   color: isColorHexCode

--- a/server/models/validations/visibility.js
+++ b/server/models/validations/visibility.js
@@ -7,11 +7,16 @@ const keywordValues = [
   'public',
 ]
 
-const isValidVisibilityValue = value => {
+const isVisibilityKey = value => {
   if (!_.isString(value)) return false
   if (keywordValues.includes(value)) return true
   if (isVisibilityGroupKey(value)) return true
   return false
 }
 
-module.exports = arr => _.isArray(arr) && arr.every(isValidVisibilityValue)
+const isVisibilityKeyArray = arr => _.isArray(arr) && arr.every(isVisibilityKey)
+
+module.exports = {
+  isVisibilityKey,
+  isVisibilityKeyArray,
+}

--- a/tests/api/items/get_by_users.test.js
+++ b/tests/api/items/get_by_users.test.js
@@ -40,7 +40,7 @@ describe('items:get-by-users', () => {
       createItem(getUser(), { visibility: [ 'friends' ] }),
     ])
     const userId = groupsItem.owner
-    const { items } = await authReq('get', `${endpoint}&users=${userId}&filter=group`)
+    const { items } = await authReq('get', `${endpoint}&users=${userId}&context=group`)
     const resUserId = _.map(items, 'owner')
     resUserId.should.containEql(userId)
     const resItemsIds = items.map(_.property('_id'))

--- a/tests/api/items/get_by_users.test.js
+++ b/tests/api/items/get_by_users.test.js
@@ -3,8 +3,9 @@ require('should')
 const { getUser, authReq, publicReq, getUserGetter } = require('tests/api/utils/utils')
 const { shouldNotBeCalled } = require('tests/unit/utils')
 const { createItem } = require('../fixtures/items')
-const { getSomeGroup, addMember } = require('../fixtures/groups')
+const { getSomeGroup, addMember, createGroup } = require('../fixtures/groups')
 const { humanName } = require('../fixtures/entities')
+const { getGroupVisibilityKey } = require('lib/visibility/visibility')
 const userPromise = getUserGetter(humanName())()
 
 const endpoint = '/api/items?action=by-users'
@@ -31,22 +32,24 @@ describe('items:get-by-users', () => {
     resItemsIds.should.containDeep(itemsIds)
   })
 
-  it('should not get private own user items in a group context', async () => {
-    // to avoid giving the false impression that those are visible by other members of the group
+  it('should not return the requesting user private and friend-only items in a group context', async () => {
+    const user = await getUser()
+    const group = await createGroup({ user })
+    const groupVisibilityKey = getGroupVisibilityKey(group._id)
     const [ groupsItem, privateItem, publicItem, friendsItem ] = await Promise.all([
-      createItem(getUser(), { visibility: [ 'groups' ] }),
-      createItem(getUser(), { visibility: [] }),
-      createItem(getUser(), { visibility: [ 'public' ] }),
-      createItem(getUser(), { visibility: [ 'friends' ] }),
+      createItem(user, { visibility: [ 'groups' ] }),
+      createItem(user, { visibility: [] }),
+      createItem(user, { visibility: [ 'public' ] }),
+      createItem(user, { visibility: [ 'friends' ] }),
     ])
     const userId = groupsItem.owner
-    const { items } = await authReq('get', `${endpoint}&users=${userId}&context=group`)
+    const { items } = await authReq('get', `${endpoint}&users=${userId}&context=${groupVisibilityKey}`)
     const resUserId = _.map(items, 'owner')
     resUserId.should.containEql(userId)
     const resItemsIds = items.map(_.property('_id'))
     resItemsIds.should.containEql(publicItem._id)
     resItemsIds.should.containEql(groupsItem._id)
-    resItemsIds.should.containEql(friendsItem._id)
+    resItemsIds.should.not.containEql(friendsItem._id)
     resItemsIds.should.not.containEql(privateItem._id)
   })
 

--- a/tests/api/listings/by_creators.test.js
+++ b/tests/api/listings/by_creators.test.js
@@ -84,7 +84,18 @@ describe('listings:by-creators', () => {
   })
 
   describe('context', () => {
+    it('should reject invalid visibility key', async () => {
+      const user = await getReservedUser()
+      return customAuthReq(user, 'get', `${endpoint}&users=${user._id}&context=''`)
+      .then(shouldNotBeCalled)
+      .catch(err => {
+        err.statusCode.should.equal(400)
+        err.body.status_verbose.should.startWith('invalid context')
+      })
+    })
+
     it('should not return the requesting user private listings in a group context', async () => {
+      // to avoid giving the false impression that those are visible by other members of the group
       const user = await getReservedUser()
       const group = await createGroup({ user })
       const groupVisibilityKey = getGroupVisibilityKey(group._id)

--- a/tests/api/listings/by_creators.test.js
+++ b/tests/api/listings/by_creators.test.js
@@ -1,8 +1,11 @@
 const should = require('should')
-const { shouldNotBeCalled, rethrowShouldNotBeCalledErrors } = require('tests/api/utils/utils')
+const { shouldNotBeCalled, rethrowShouldNotBeCalledErrors, customAuthReq } = require('tests/api/utils/utils')
 const { publicReq, authReq, getUserB, getReservedUser } = require('../utils/utils')
 const { createListing, createElement } = require('../fixtures/listings')
 const { map } = require('lodash')
+const { createGroupWithAMember, createGroup, addMember } = require('tests/api/fixtures/groups')
+const { getTwoFriends } = require('tests/api/fixtures/users')
+const { getGroupVisibilityKey } = require('lib/visibility/visibility')
 
 const endpoint = '/api/lists?action=by-creators'
 
@@ -77,6 +80,43 @@ describe('listings:by-creators', () => {
       const { listing } = await createElement({})
       const res = await publicReq('get', `${endpoint}&users=${listing.creator}&with-elements=true`)
       res.lists[0].elements.should.be.an.Array()
+    })
+  })
+
+  describe('context', () => {
+    it('should not return the requesting user private listings in a group context', async () => {
+      const user = await getReservedUser()
+      const group = await createGroup({ user })
+      const groupVisibilityKey = getGroupVisibilityKey(group._id)
+      const { listing: privateListing } = await createListing(user, { visibility: [] })
+      const { lists: listings } = await customAuthReq(user, 'get', `${endpoint}&users=${user._id}&context=${groupVisibilityKey}`)
+      const listingsIds = map(listings, '_id')
+      listingsIds.should.not.containEql(privateListing._id)
+    })
+
+    it('should not return friends-only listings in a group context', async () => {
+      const [ userA, userB ] = await getTwoFriends()
+      const group = await createGroup({ user: userA })
+      await addMember(group, userB)
+      const groupVisibilityKey = getGroupVisibilityKey(group._id)
+      const { listing: friendsOnlyListing } = await createListing(userA, { visibility: [ 'friends' ] })
+      const { lists: listings } = await customAuthReq(userB, 'get', `${endpoint}&users=${userA._id}&context=${groupVisibilityKey}&limit=1000`)
+      const listingsIds = map(listings, '_id')
+      listingsIds.should.not.containEql(friendsOnlyListing._id)
+    })
+
+    it('should not return group-specific listings in another group', async () => {
+      const { group: groupA, admin: userA, member: userB } = await createGroupWithAMember()
+      const groupB = await createGroup({ user: userA })
+      await addMember(groupB, userB)
+      const groupAVisibilityKey = getGroupVisibilityKey(groupA._id)
+      const groupBVisibilityKey = getGroupVisibilityKey(groupB._id)
+      const { listing: groupSpecificListing } = await createListing(userA, {
+        visibility: [ groupAVisibilityKey ]
+      })
+      const { lists: listings } = await customAuthReq(userB, 'get', `${endpoint}&users=${userA._id}&context=${groupBVisibilityKey}&limit=1000`)
+      const listingsIds = map(listings, '_id')
+      listingsIds.should.not.containEql(groupSpecificListing._id)
     })
   })
 })


### PR DESCRIPTION
Currently, the main user private listings are displayed in every contexts, which can be confusing. This PR proposes to update the former `filter` parameter used for items into a `context` parameter, that takes a visibility key, and deduces what items or listings should not be returned for a given query, even if the requesting user has access rights.