### PR TITLE
entities: update-label: allow to delete a label

### DIFF
--- a/server/controllers/entities/entities.js
+++ b/server/controllers/entities/entities.js
@@ -1,3 +1,4 @@
+import removeLabel from '#controllers/entities/remove_label'
 import ActionsControllers from '#lib/actions_controllers'
 import byUrisGet from './by_uris_get.js'
 import contributions from './contributions.js'
@@ -55,6 +56,7 @@ export default {
     authentified: {
       'update-claim': updateClaim,
       'update-label': updateLabel,
+      'remove-label': removeLabel,
       'revert-edit': revertEdit,
       'restore-version': restoreVersion,
       'move-to-wikidata': moveToWikidata,

--- a/server/controllers/entities/remove_label.js
+++ b/server/controllers/entities/remove_label.js
@@ -1,0 +1,23 @@
+import { labelUpdatersByPrefix } from '#controllers/entities/update_label'
+import { error_ } from '#lib/error/error'
+
+const sanitization = {
+  uri: {},
+  lang: {},
+}
+
+const controller = async (params, req) => {
+  const { uri, lang } = params
+
+  const [ prefix, id ] = uri.split(':')
+  const updater = labelUpdatersByPrefix[prefix]
+
+  if (updater == null) {
+    throw error_.new(`unsupported uri prefix: ${prefix}`, 400, params)
+  }
+
+  await updater(req.user, id, lang, null)
+  return { ok: true }
+}
+
+export default { sanitization, controller }

--- a/server/controllers/entities/update_label.js
+++ b/server/controllers/entities/update_label.js
@@ -7,7 +7,7 @@ const sanitization = {
   uri: { optional: true },
   id: { optional: true },
   lang: {},
-  value: { type: 'string' },
+  value: { type: 'string', optional: true },
 }
 
 const controller = async (params, req) => {
@@ -18,6 +18,8 @@ const controller = async (params, req) => {
 
   if (uri) id = unprefixify(uri)
 
+  // Let value=null through to allow to delete a label
+  if (value === undefined) throw error_.newMissingBody('value')
   if (value === '') throw error_.new('invalid value', 400, params)
 
   if (updater == null) {

--- a/server/controllers/entities/update_label.js
+++ b/server/controllers/entities/update_label.js
@@ -7,19 +7,17 @@ const sanitization = {
   uri: { optional: true },
   id: { optional: true },
   lang: {},
-  value: { type: 'string', optional: true },
+  value: { type: 'string' },
 }
 
 const controller = async (params, req) => {
   let { uri, id, value, lang } = params
 
   const prefix = getPrefix(uri, id)
-  const updater = updaters[prefix]
+  const updater = labelUpdatersByPrefix[prefix]
 
   if (uri) id = unprefixify(uri)
 
-  // Let value=null through to allow to delete a label
-  if (value === undefined) throw error_.newMissingBody('value')
   if (value === '') throw error_.new('invalid value', 400, params)
 
   if (updater == null) {
@@ -35,7 +33,7 @@ const getPrefix = (uri, id) => {
   if (id) return 'inv'
 }
 
-const updaters = {
+export const labelUpdatersByPrefix = {
   inv,
   wd,
 }

--- a/server/models/entity.js
+++ b/server/models/entity.js
@@ -49,7 +49,6 @@ const Entity = {
   setLabel: (doc, lang, value) => {
     assert_.object(doc)
     assert_.string(lang)
-    assert_.string(value)
 
     if (!wikimediaLanguageCodes.has(lang)) {
       throw error_.new('invalid lang', 400, { doc, lang, value })
@@ -57,13 +56,18 @@ const Entity = {
 
     Entity.preventRedirectionEdit(doc, 'setLabel')
 
-    value = _.superTrim(value)
+    if (value === null) {
+      deleteLabel(doc, lang)
+    } else {
+      assert_.string(value)
+      value = _.superTrim(value)
 
-    if (doc.labels[lang] === value) {
-      throw error_.new('already up-to-date', 400, { doc, lang, value })
+      if (doc.labels[lang] === value) {
+        throw error_.new('already up-to-date', 400, { doc, lang, value })
+      }
+
+      doc.labels[lang] = value
     }
-
-    doc.labels[lang] = value
 
     return doc
   },
@@ -288,4 +292,16 @@ const setPossiblyEmptyPropertyArray = (doc, property, propertyArray) => {
   } else {
     doc.claims[property] = propertyArray
   }
+}
+
+const deleteLabel = (doc, lang) => {
+  if (doc.labels[lang] == null) {
+    throw error_.new('can not delete a non-existant label', 400, { doc, lang })
+  }
+
+  if (Object.keys(doc.labels).length === 1) {
+    throw error_.new('can not delete the last label', 400, { doc, lang })
+  }
+
+  delete doc.labels[lang]
 }

--- a/tests/api/entities/remove_label.test.js
+++ b/tests/api/entities/remove_label.test.js
@@ -1,0 +1,35 @@
+import should from 'should'
+import { createHuman } from '#fixtures/entities'
+import { getRandomString } from '#lib/utils/random_string'
+import { shouldNotBeCalled } from '#tests/unit/utils'
+import { getByUri, removeLabel } from '../utils/entities.js'
+
+describe('entities:remove-labels', () => {
+  it('should remove a label', async () => {
+    const value = getRandomString(15)
+    const { uri } = await createHuman({
+      labels: {
+        en: value,
+        fr: value,
+      },
+    })
+    await removeLabel({ uri, lang: 'fr' })
+    const updatedHuman = await getByUri(uri)
+    should(updatedHuman.labels.fr).not.be.ok()
+  })
+
+  it('should reject removing the last label', async () => {
+    const value = getRandomString(15)
+    const { uri } = await createHuman({
+      labels: {
+        en: value,
+      },
+    })
+    await removeLabel({ uri, lang: 'en' })
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.statusCode.should.equal(400)
+      err.body.status_verbose.should.equal('can not delete the last label')
+    })
+  })
+})

--- a/tests/api/entities/update_inv_labels.test.js
+++ b/tests/api/entities/update_inv_labels.test.js
@@ -109,12 +109,4 @@ describe('entities:update-labels:inv', () => {
     const updatedHuman = await getByUri(uri)
     langs.forEach(lang => updatedHuman.labels[lang].should.equal(name))
   })
-
-  it('should remove a label', async () => {
-    const { _id, uri } = await humanPromise
-    const value = randomString(15)
-    await updateLabel({ uri: _id, lang: 'fr', value })
-    const updatedHuman = await getByUri(uri)
-    updatedHuman.labels.fr.should.equal(value)
-  })
 })

--- a/tests/api/entities/update_inv_labels.test.js
+++ b/tests/api/entities/update_inv_labels.test.js
@@ -11,7 +11,7 @@ describe('entities:update-labels:inv', () => {
   it('should reject without value', async () => {
     const { _id } = await humanPromise
     try {
-      await updateLabel({ uri: _id, lang: 'fr', value: null }).then(shouldNotBeCalled)
+      await updateLabel({ uri: _id, lang: 'fr' }).then(shouldNotBeCalled)
     } catch (err) {
       rethrowShouldNotBeCalledErrors(err)
       err.body.status_verbose.should.equal('missing parameter in body: value')
@@ -108,5 +108,13 @@ describe('entities:update-labels:inv', () => {
     responses.forEach(res => should(res.ok).be.true())
     const updatedHuman = await getByUri(uri)
     langs.forEach(lang => updatedHuman.labels[lang].should.equal(name))
+  })
+
+  it('should remove a label', async () => {
+    const { _id, uri } = await humanPromise
+    const value = randomString(15)
+    await updateLabel({ uri: _id, lang: 'fr', value })
+    const updatedHuman = await getByUri(uri)
+    updatedHuman.labels.fr.should.equal(value)
   })
 })

--- a/tests/api/utils/entities.js
+++ b/tests/api/utils/entities.js
@@ -85,6 +85,12 @@ export const updateLabel = ({ uri, lang, value, user }) => {
   return customAuthReq(user, 'put', '/api/entities?action=update-label', { uri, lang, value })
 }
 
+export const removeLabel = ({ uri, lang, user }) => {
+  user = user || getUser()
+  uri = normalizeUri(uri)
+  return customAuthReq(user, 'put', '/api/entities?action=remove-label', { uri, lang })
+}
+
 export const updateClaim = ({ uri, property, oldValue, newValue, user }) => {
   uri = normalizeUri(uri)
   user = user || getUser()

--- a/tests/unit/models/024-entity.js
+++ b/tests/unit/models/024-entity.js
@@ -1,6 +1,7 @@
 import should from 'should'
 import { superTrim } from '#lib/utils/base'
 import Entity from '#models/entity'
+import { shouldNotBeCalled } from '#tests/unit/utils'
 
 const workDoc = () => {
   const doc = Entity.create()
@@ -229,6 +230,38 @@ describe('entity model', () => {
         const entityDoc = workDoc()
         Entity.setLabel(entityDoc, 'fr', nonTrimmedString)
         entityDoc.labels.fr.should.equal('foo bar')
+      })
+
+      it('should delete the label in the given lang', () => {
+        const entityDoc = workDoc()
+        Entity.setLabel(entityDoc, 'fr', 'hello')
+        Entity.setLabel(entityDoc, 'de', 'hello')
+        should(entityDoc.labels.de).be.ok()
+        Entity.setLabel(entityDoc, 'de', null)
+        should(entityDoc.labels.de).not.be.ok()
+      })
+
+      it('should reject deleting a non-existant label', () => {
+        const entityDoc = workDoc()
+        should(entityDoc.labels.de).not.be.ok()
+        try {
+          const doc = Entity.setLabel(entityDoc, 'de', null)
+          shouldNotBeCalled(doc)
+        } catch (err) {
+          err.statusCode.should.equal(400)
+        }
+      })
+
+      it('should reject deleting the last label', () => {
+        const entityDoc = workDoc()
+        Entity.setLabel(entityDoc, 'de', 'hello')
+        Object.keys(entityDoc.labels).length.should.equal(1)
+        try {
+          const doc = Entity.setLabel(entityDoc, 'de', null)
+          shouldNotBeCalled(doc)
+        } catch (err) {
+          err.statusCode.should.equal(400)
+        }
       })
     })
 


### PR DESCRIPTION
This is currently not possible, which can be an issue in cases where a label was set in a language where there is no label for a given work. Example: [this work](https://inventaire.io/api/entities?action=by-uris&uris=inv:320d4c7c453886081a4da182e3d1e512) has a label in Catalan but no know label in Spanish, thus the attempt by a contributor to delete the Spanish label.