### PR TITLE
Add collection images special getter

### DIFF
--- a/server/controllers/entities/lib/special_entity_images_getter.js
+++ b/server/controllers/entities/lib/special_entity_images_getter.js
@@ -24,9 +24,9 @@ module.exports = {
   },
 
   collection: async entity => {
-    entity.images = {}
+    const images = { claims: getEntityImagesFromClaims(entity) }
     return entities_.byClaim('wdt:P195', entity.uri, true, true)
-    .then(addEditionsImages(entity.images))
+    .then(addEditionsImages(images))
   }
 }
 

--- a/server/controllers/entities/lib/special_entity_images_getter.js
+++ b/server/controllers/entities/lib/special_entity_images_getter.js
@@ -21,6 +21,12 @@ module.exports = {
     const worksUris = _.map(parts, 'uri')
     const worksImages = await Promise.all(worksUris.map(getOneWorkImagePerLang))
     return worksImages.reduce(aggregateWorkImages, images)
+  },
+
+  collection: async entity => {
+    entity.images = {}
+    return entities_.byClaim('wdt:P195', entity.uri, true, true)
+    .then(addEditionsImages(entity.images))
   }
 }
 

--- a/server/db/elasticsearch/formatters/entity.js
+++ b/server/db/elasticsearch/formatters/entity.js
@@ -48,7 +48,7 @@ module.exports = async (entity, options = {}) => {
     entity.uri = 'inv:' + entity._id
   }
 
-  // Take images from claims if no images object was set by add_entities_images,
+  // Take images from claims if no images object was set by addEntitiesImages,
   // that is, for every entity types but works and series
   if (!entity.images) {
     if (specialEntityImagesGetter[entity.type]) {


### PR DESCRIPTION
Client publisher layout needs to illustrate a preview of collection covers:
![2022-12-04_09-08](https://user-images.githubusercontent.com/5363918/205480627-299e4168-f948-46a0-92c2-4d687570443c.png)

Following the work and series way to do it

This is a make it work implementation.

A server delivering already crafted images object is nice, but at the cost of querying all editions... Maybe having the client request editions covers would make more sense to take advantage of caching the editions (?)