### PR TITLE
Be more tolerant on BNF ids format

### DIFF
--- a/server/controllers/entities/lib/properties/properties_config_builders.js
+++ b/server/controllers/entities/lib/properties/properties_config_builders.js
@@ -53,3 +53,11 @@ export const allowedPropertyValues = property => {
     },
   })
 }
+
+export const externalIdWithFormatter = ({ regex, format }) => {
+  return Object.assign({}, concurrentString, {
+    validate: regex.test.bind(regex),
+    format,
+    isExternalId: true,
+  })
+}

--- a/server/controllers/entities/lib/properties/properties_values_constraints.js
+++ b/server/controllers/entities/lib/properties/properties_values_constraints.js
@@ -54,7 +54,7 @@ export default {
   'wdt:P212': isbnProperty(13),
   // ISNI
   'wdt:P213': externalIdWithFormatter({
-    regex: /^\d{4} ?\d{4} ?\d{4} ?\d{3}[0-9X]$/,
+    regex: /^\d{4} \d{4} \d{4} \d{3}[0-9X]$/,
     format: id => {
       id = id.replace(/\s/g, '')
       return `${id.slice(0, 4)} ${id.slice(4, 8)} ${id.slice(8, 12)} ${id.slice(12)}`

--- a/server/controllers/entities/lib/properties/properties_values_constraints.js
+++ b/server/controllers/entities/lib/properties/properties_values_constraints.js
@@ -69,7 +69,10 @@ export default {
   // Library of Congress authority ID
   'wdt:P244': externalId(/^(gf|n|nb|nr|no|ns|sh|sj)([4-9][0-9]|00|20[0-2][0-9])[0-9]{6}$/),
   // BNF id
-  'wdt:P268': externalId(/^\d{8}[0-9bcdfghjkmnpqrstvwxz]$/),
+  'wdt:P268': externalIdWithFormatter({
+    regex: /^\d{8}[0-9bcdfghjkmnpqrstvwxz]$/,
+    format: id => id.replace(/^cb/, ''),
+  }),
   // SUDOC authorities ID
   'wdt:P269': externalId(/^\d{8}[\dX]$/),
   // language of work

--- a/server/controllers/entities/lib/properties/properties_values_constraints.js
+++ b/server/controllers/entities/lib/properties/properties_values_constraints.js
@@ -21,7 +21,7 @@ import {
 import { collectionEntity, entity, humanEntity, imageHash, ordinal, positiveInteger, serieEntity, uniqueSimpleDay, uniqueString, url, workEntity } from './properties_config_bases.js'
 // Builders are functions to generate config objects tailored as closely
 // as possible to the property exact needs
-import { isbnProperty, externalId, typedExternalId, allowedPropertyValues } from './properties_config_builders.js'
+import { isbnProperty, externalId, typedExternalId, allowedPropertyValues, externalIdWithFormatter } from './properties_config_builders.js'
 
 // Make sure to not mutate the base, while letting the last word to the extension
 const extend = (base, extension) => Object.assign({}, base, extension)
@@ -53,7 +53,8 @@ export default {
   // ISBN 13
   'wdt:P212': isbnProperty(13),
   // ISNI
-  'wdt:P213': extend(externalId(/^\d{4} ?\d{4} ?\d{4} ?\d{3}[0-9X]$/), {
+  'wdt:P213': externalIdWithFormatter({
+    regex: /^\d{4} ?\d{4} ?\d{4} ?\d{3}[0-9X]$/,
     format: id => {
       id = id.replace(/\s/g, '')
       return `${id.slice(0, 4)} ${id.slice(4, 8)} ${id.slice(8, 12)} ${id.slice(12)}`

--- a/server/controllers/entities/lib/validate_claim_value_sync.js
+++ b/server/controllers/entities/lib/validate_claim_value_sync.js
@@ -12,14 +12,20 @@ export default (property, value, entityType) => {
     throw error_.new(message, 400, { property, value })
   }
 
-  if (properties[property].typeSpecificValidation) {
-    if (!properties[property].validate(value, entityType)) {
+  const { datatype, typeSpecificValidation, validate, format } = properties[property]
+
+  if (format) {
+    value = format(value)
+  }
+
+  if (typeSpecificValidation) {
+    if (!validate(value, entityType)) {
       const message = `invalid property value for entity type "${entityType}"`
       throw error_.new(message, 400, { entityType, property, value })
     }
   } else {
-    if (!properties[property].validate(value)) {
-      if (properties[property].datatype === 'entity' && isEntityId(value)) {
+    if (!validate(value)) {
+      if (datatype === 'entity' && isEntityId(value)) {
         throw error_.new('invalid property value: missing entity uri prefix', 400, { property, value })
       } else {
         throw error_.new('invalid property value', 400, { property, value })

--- a/tests/api/entities/update_inv_claims.test.js
+++ b/tests/api/entities/update_inv_claims.test.js
@@ -1,6 +1,6 @@
 import should from 'should'
 import { shouldNotBeCalled } from '#tests/unit/utils'
-import { createWork, createEdition, createHuman, someOpenLibraryId, someFakeUri } from '../fixtures/entities.js'
+import { createWork, createEdition, createHuman, someOpenLibraryId, someFakeUri, someBnfId } from '../fixtures/entities.js'
 import { getByUri, addClaim, updateClaim, removeClaim, merge } from '../utils/entities.js'
 
 describe('entities:update-claims:inv', () => {
@@ -254,5 +254,14 @@ describe('entities:update-claims:inv', () => {
     await addClaim({ uri: human.uri, property: 'wdt:P213', value: someRecoverableIsni })
     const updatedHuman = await getByUri(human.uri)
     updatedHuman.claims['wdt:P213'].should.deepEqual([ someValidIsni ])
+  })
+
+  it('should accept a recoverable BNF id', async () => {
+    const human = await createHuman()
+    const someValidBnfId = someBnfId()
+    const recoverableBnfId = `cb${someValidBnfId}`
+    await addClaim({ uri: human.uri, property: 'wdt:P268', value: recoverableBnfId })
+    const updatedHuman = await getByUri(human.uri)
+    updatedHuman.claims['wdt:P268'].should.deepEqual([ someValidBnfId ])
   })
 })

--- a/tests/api/fixtures/entities.js
+++ b/tests/api/fixtures/entities.js
@@ -146,6 +146,8 @@ export const createItemFromEntityUri = ({ user, uri, item = {} }) => {
 
 export const someFakeUri = 'inv:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 
+export const someBnfId = () => `1${Math.random().toString().slice(2, 9)}p`
+
 export const someOpenLibraryId = (type = 'human') => {
   const numbers = Math.random().toString().slice(2, 6)
   const typeLetter = openLibraryTypeLetters[type]


### PR DESCRIPTION
Currently, if you enter a BNF id with its `cb` prefix (ex: `cb10317178p`), it is refused. This PR fixes that by adding a `format` function.