### PR TITLE
remove shelf id from item.shelves when deleting a shelf

### DIFF
--- a/server/controllers/shelves/by_ids.js
+++ b/server/controllers/shelves/by_ids.js
@@ -19,7 +19,7 @@ const controller = async ({ ids, withItems, reqUserId }, req, res) => {
   const foundShelvesIds = map(foundShelves, '_id')
   checkNotFoundShelves(ids, foundShelves, foundShelvesIds, res)
   let authorizedShelves = await filterVisibleDocs(foundShelves, reqUserId)
-  checkUnauthorizedShelves(ids, authorizedShelves, foundShelvesIds, req, res)
+  checkUnauthorizedShelves(authorizedShelves, foundShelvesIds, req, res)
   authorizedShelves = authorizedShelves.map(filterPrivateAttributes(reqUserId))
   const shelves = keyBy(authorizedShelves, '_id')
   return { shelves }
@@ -33,11 +33,11 @@ const checkNotFoundShelves = (ids, foundShelves, foundShelvesIds, res) => {
   }
 }
 
-const checkUnauthorizedShelves = (ids, authorizedShelves, foundShelvesIds, req, res) => {
+const checkUnauthorizedShelves = (authorizedShelves, foundShelvesIds, req, res) => {
   if (authorizedShelves.length === 0) {
     throw error_.unauthorized(req, 'unauthorized shelves access', { ids: foundShelvesIds })
   }
-  if (authorizedShelves.length !== ids.length) {
+  if (authorizedShelves.length !== foundShelvesIds.length) {
     const authorizedShelvesIds = map(authorizedShelves, '_id')
     const unauthorizedShelvesIds = difference(foundShelvesIds, authorizedShelvesIds)
     addWarning(res, `unauthorized shelves access: ${unauthorizedShelvesIds.join(', ')}`)

--- a/tests/api/shelves/delete.test.js
+++ b/tests/api/shelves/delete.test.js
@@ -1,3 +1,4 @@
+import should from 'should'
 import { shouldNotBeCalled, rethrowShouldNotBeCalledErrors } from '#tests/unit/utils'
 import { createShelf, createShelfWithItem } from '../fixtures/shelves.js'
 import { authReq, authReqB } from '../utils/utils.js'
@@ -35,8 +36,10 @@ describe('shelves:delete', () => {
     .catch(err => {
       err.statusCode.should.equal(404)
     })
-    const getItemsRes = await authReq('get', `/api/items?action=by-ids&ids=${item._id}`)
-    Object.values(getItemsRes.items).length.should.not.equal(0)
+    const { items } = await authReq('get', `/api/items?action=by-ids&ids=${item._id}`)
+    const updatedItem = items[0]
+    should(updatedItem).be.ok()
+    updatedItem.shelves.should.deepEqual([])
   })
 
   describe('with-items', () => {


### PR DESCRIPTION
~Based on #664 to avoid conflicts.~

After merge:
* check prod items database for obsolete shelf ids