### PR TITLE
split update-claim endpoint into add-claim/update-claim/remove-claim

### DIFF
--- a/server/controllers/entities/add_claim.js
+++ b/server/controllers/entities/add_claim.js
@@ -1,0 +1,25 @@
+import { claimUpdatersByPrefix } from '#controllers/entities/update_claim'
+import { error_ } from '#lib/error/error'
+import { log } from '#lib/utils/logs'
+
+const sanitization = {
+  uri: {},
+  property: {},
+  value: {},
+}
+
+const controller = async (params, req) => {
+  const { uri, property, value } = params
+  const [ prefix, id ] = uri.split(':')
+  log(params, 'add-claim input')
+
+  const updater = claimUpdatersByPrefix[prefix]
+  if (updater == null) {
+    throw error_.new(`unsupported uri prefix: ${prefix}`, 400, uri)
+  }
+
+  await updater(req.user, id, property, null, value)
+  return { ok: true }
+}
+
+export default { sanitization, controller }

--- a/server/controllers/entities/add_claim.js
+++ b/server/controllers/entities/add_claim.js
@@ -1,6 +1,5 @@
 import { claimUpdatersByPrefix } from '#controllers/entities/update_claim'
 import { error_ } from '#lib/error/error'
-import { log } from '#lib/utils/logs'
 
 const sanitization = {
   uri: {},
@@ -11,7 +10,6 @@ const sanitization = {
 const controller = async (params, req) => {
   const { uri, property, value } = params
   const [ prefix, id ] = uri.split(':')
-  log(params, 'add-claim input')
 
   const updater = claimUpdatersByPrefix[prefix]
   if (updater == null) {

--- a/server/controllers/entities/entities.js
+++ b/server/controllers/entities/entities.js
@@ -1,3 +1,4 @@
+import addClaim from '#controllers/entities/add_claim'
 import ActionsControllers from '#lib/actions_controllers'
 import byUrisGet from './by_uris_get.js'
 import contributions from './contributions.js'
@@ -53,6 +54,7 @@ export default {
 
   put: ActionsControllers({
     authentified: {
+      'add-claim': addClaim,
       'update-claim': updateClaim,
       'update-label': updateLabel,
       'revert-edit': revertEdit,

--- a/server/controllers/entities/entities.js
+++ b/server/controllers/entities/entities.js
@@ -1,4 +1,5 @@
 import addClaim from '#controllers/entities/add_claim'
+import removeClaim from '#controllers/entities/remove_claim'
 import ActionsControllers from '#lib/actions_controllers'
 import byUrisGet from './by_uris_get.js'
 import contributions from './contributions.js'
@@ -56,6 +57,7 @@ export default {
     authentified: {
       'add-claim': addClaim,
       'update-claim': updateClaim,
+      'remove-claim': removeClaim,
       'update-label': updateLabel,
       'revert-edit': revertEdit,
       'restore-version': restoreVersion,

--- a/server/controllers/entities/remove_claim.js
+++ b/server/controllers/entities/remove_claim.js
@@ -1,17 +1,14 @@
+import { claimUpdatersByPrefix } from '#controllers/entities/update_claim'
 import { error_ } from '#lib/error/error'
-// TODO: accept ISBN URIs
-import inv from './lib/update_inv_claim.js'
-import wd from './lib/update_wd_claim.js'
 
 const sanitization = {
   uri: {},
   property: {},
-  'old-value': {},
-  'new-value': {},
+  value: {},
 }
 
 const controller = async (params, req) => {
-  const { uri, property, oldValue, newValue } = params
+  const { uri, property, value } = params
   const [ prefix, id ] = uri.split(':')
 
   const updater = claimUpdatersByPrefix[prefix]
@@ -19,13 +16,8 @@ const controller = async (params, req) => {
     throw error_.new(`unsupported uri prefix: ${prefix}`, 400, uri)
   }
 
-  await updater(req.user, id, property, oldValue, newValue)
+  await updater(req.user, id, property, value, null)
   return { ok: true }
-}
-
-export const claimUpdatersByPrefix = {
-  inv,
-  wd,
 }
 
 export default { sanitization, controller }

--- a/server/controllers/entities/update_claim.js
+++ b/server/controllers/entities/update_claim.js
@@ -16,7 +16,7 @@ const sanitization = {
 const controller = async (params, req) => {
   let { id, uri, property, oldValue, newValue } = params
   let prefix
-  log(params, 'update claim input')
+  log(params, 'update-claim input')
   if (_.isInvEntityId(id) && uri == null) uri = `inv:${id}`
 
   if (uri == null) throw error_.newMissingBody('uri')
@@ -29,7 +29,7 @@ const controller = async (params, req) => {
   newValue = parseEmptyValue(newValue)
 
   ;[ prefix, id ] = uri.split(':')
-  const updater = updaters[prefix]
+  const updater = claimUpdatersByPrefix[prefix]
   if (updater == null) {
     throw error_.new(`unsupported uri prefix: ${prefix}`, 400, uri)
   }
@@ -40,7 +40,7 @@ const controller = async (params, req) => {
 
 const parseEmptyValue = value => value === '' ? null : value
 
-const updaters = {
+export const claimUpdatersByPrefix = {
   inv,
   wd,
 }

--- a/tests/api/entities/add_claim.test.js
+++ b/tests/api/entities/add_claim.test.js
@@ -2,7 +2,8 @@ import 'should'
 import { createWork, someOpenLibraryId } from '../fixtures/entities.js'
 import { getByUri, addClaim } from '../utils/entities.js'
 
-describe('entities:add-claim', () => {
+// For the internals, see ./add_update_remove_claim.test.js
+describe('entities:add-claim interface', () => {
   it('should add a claim', async () => {
     const { uri } = await createWork()
     const openlibraryId = someOpenLibraryId('work')

--- a/tests/api/entities/add_claim.test.js
+++ b/tests/api/entities/add_claim.test.js
@@ -1,0 +1,14 @@
+import 'should'
+import { createWork, someOpenLibraryId } from '../fixtures/entities.js'
+import { getByUri, addClaim } from '../utils/entities.js'
+
+describe('entities:add-claim', () => {
+  it('should add a claim', async () => {
+    const { uri } = await createWork()
+    const openlibraryId = someOpenLibraryId('work')
+    const res = await addClaim({ uri, property: 'wdt:P648', value: openlibraryId })
+    res.ok.should.be.true()
+    const updatedEntity = await getByUri(uri)
+    updatedEntity.claims['wdt:P648'][0].should.equal(openlibraryId)
+  })
+})

--- a/tests/api/entities/add_update_remove_claim.test.js
+++ b/tests/api/entities/add_update_remove_claim.test.js
@@ -1,0 +1,197 @@
+import should from 'should'
+import { shouldNotBeCalled } from '#tests/unit/utils'
+import { createWork, createEdition, createHuman, someOpenLibraryId, someFakeUri } from '../fixtures/entities.js'
+import { getByUri, addClaim, updateClaim, removeClaim, merge } from '../utils/entities.js'
+
+// Testing the common internals behind the individual endpoints
+describe('entities:add/update/remove-claim common internals', () => {
+  it('should reject an unknown entity', async () => {
+    await updateClaim({ uri: someFakeUri, property: 'wdt:P1104', oldValue: '1', newValue: '2' })
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.body.status_verbose.should.equal('entity not found')
+      err.statusCode.should.equal(400)
+    })
+  })
+
+  it('should reject an unknown entity value', async () => {
+    const work = await createWork()
+    const fakeUri = 'inv:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    await addClaim({ uri: work.uri, property: 'wdt:P50', value: fakeUri })
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.body.status_verbose.should.equal('entity not found')
+      err.statusCode.should.equal(400)
+    })
+  })
+
+  it('should reject an update with an inappropriate property', async () => {
+    const work = await createWork()
+    // A work entity should not have pages count
+    await addClaim({ uri: work.uri, property: 'wdt:P1104', value: 124 })
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.body.status_verbose.should.equal("works can't have a property wdt:P1104")
+      err.statusCode.should.equal(400)
+    })
+  })
+
+  it('should reject an update with an inappropriate property datatype', async () => {
+    const work = await createWork()
+    await addClaim({ uri: work.uri, property: 'wdt:P50', value: 124 })
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.body.status_verbose.should.equal('invalid value type: expected string, got number')
+      err.statusCode.should.equal(400)
+    })
+  })
+
+  it('should reject adding an extra value to a property that accepts only one value', async () => {
+    const edition = await createEdition()
+    // An edition entity should have only one date of publication
+    await addClaim({ uri: edition.uri, property: 'wdt:P577', value: '2010' })
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.body.status_verbose.should.equal('this property accepts only one value')
+      err.statusCode.should.equal(400)
+    })
+  })
+
+  it('should reject an update with an invalid property value', async () => {
+    const edition = await createEdition()
+    await addClaim({ uri: edition.uri, property: 'wdt:P123', value: 'not an entity uri' })
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.body.status_verbose.should.equal('invalid property value')
+      err.statusCode.should.equal(400)
+    })
+  })
+
+  it('should reject an update removing a critical claim', async () => {
+    const edition = await createEdition()
+    const oldValue = edition.claims['wdt:P629'][0]
+    // An edition entity should always have at least one wdt:P629 claim
+    await removeClaim({ uri: edition.uri, property: 'wdt:P629', value: oldValue })
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.body.status_verbose.should.equal('an edition should have an associated work (wdt:P629)')
+      err.statusCode.should.equal(400)
+    })
+  })
+
+  it('should reject an update on an unexisting claim (property with no claim)', async () => {
+    const edition = await createEdition()
+    await updateClaim({ uri: edition.uri, property: 'wdt:P655', oldValue: 'wd:Q23', newValue: 'wd:Q42' })
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.statusCode.should.equal(400)
+      err.body.status_verbose.should.equal('claim property value not found')
+    })
+  })
+
+  it('should reject an update on an unexisting claim (property with claims)', async () => {
+    const edition = await createEdition()
+    await addClaim({ uri: edition.uri, property: 'wdt:P655', value: 'wd:Q535' })
+    await updateClaim({ uri: edition.uri, property: 'wdt:P655', oldValue: 'wd:Q23', newValue: 'wd:Q42' })
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.statusCode.should.equal(400)
+      err.body.status_verbose.should.equal('claim property value not found')
+    })
+  })
+
+  it('should reject an update on an obsolete entity', async () => {
+    const [ workA, workB ] = await Promise.all([
+      createWork(),
+      createWork(),
+    ])
+    await merge(workA.uri, workB.uri)
+    await addClaim({ uri: workA.uri, property: 'wdt:P50', value: 'wd:Q535' })
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.statusCode.should.equal(400)
+      err.body.status_verbose.should.equal('this entity is obsolete')
+    })
+  })
+
+  it('should accept rapid updates on the same entity', async () => {
+    const authorsUris = [ 'wd:Q192214', 'wd:Q206685' ]
+    const work = await createWork()
+    const responses = await Promise.all(authorsUris.map(uri => {
+      return addClaim({
+        uri: work.uri,
+        property: 'wdt:P50',
+        value: uri,
+      })
+    }))
+    responses.forEach(res => res.ok.should.be.true())
+    const updatedWork = await getByUri(work.uri)
+    const addedAuthorsUris = updatedWork.claims['wdt:P50']
+    authorsUris.forEach(uri => should(addedAuthorsUris.includes(uri)).be.true())
+  })
+
+  it('should accept a non-duplicated concurrent value', async () => {
+    const human = await createHuman()
+    const res = await addClaim({ uri: human._id, property: 'wdt:P648', value: someOpenLibraryId() })
+    res.ok.should.be.true()
+  })
+
+  it('should reject an invalid value for a type-specific value format', async () => {
+    const human = await createHuman()
+    await addClaim({ uri: human.uri, property: 'wdt:P648', value: someOpenLibraryId('work') })
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.statusCode.should.equal(400)
+      err.body.status_verbose.should.equal('invalid property value for entity type "human"')
+    })
+  })
+
+  it('should accept an allowlisted value for a constrained property', async () => {
+    const edition = await createEdition()
+    const res = await addClaim({ uri: edition.uri, property: 'wdt:P437', value: 'wd:Q128093' })
+    res.ok.should.be.true()
+  })
+
+  it('should reject a non-allowlisted value for a constrained property', async () => {
+    const edition = await createEdition()
+    await addClaim({ uri: edition.uri, property: 'wdt:P437', value: 'wd:Q123' })
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.statusCode.should.equal(400)
+      err.body.status_verbose.should.equal('invalid property value for entity type "edition"')
+    })
+  })
+
+  it('should reject a non-allowlisted value for a given entity type', async () => {
+    const edition = await createEdition()
+    await updateClaim({ uri: edition.uri, property: 'wdt:P31', oldValue: 'wd:Q3331189', newValue: 'wd:Q5' })
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.statusCode.should.equal(400)
+      err.body.status_verbose.should.equal('invalid property value for entity type "edition"')
+    })
+  })
+
+  it('should reject an update with a duplicated concurrent value', async () => {
+    const id = someOpenLibraryId()
+    const human = await createHuman()
+    const res = await addClaim({ uri: human.uri, property: 'wdt:P648', value: id })
+    res.ok.should.be.true()
+    const human2 = await createHuman()
+    await addClaim({ uri: human2.uri, property: 'wdt:P648', value: id })
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.statusCode.should.equal(400)
+      err.body.status_verbose.should.equal('this property value is already used')
+    })
+  })
+
+  it('should accept a recoverable ISNI', async () => {
+    const human = await createHuman()
+    const someValidIsni = `0000 0000 ${Math.random().toString().slice(2, 6)} 123X`
+    const someRecoverableIsni = someValidIsni.replace(/\s/g, '')
+    await addClaim({ uri: human.uri, property: 'wdt:P213', value: someRecoverableIsni })
+    const updatedHuman = await getByUri(human.uri)
+    updatedHuman.claims['wdt:P213'].should.deepEqual([ someValidIsni ])
+  })
+})

--- a/tests/api/entities/remove_claim.test.js
+++ b/tests/api/entities/remove_claim.test.js
@@ -1,0 +1,16 @@
+import should from 'should'
+import { createWork, someOpenLibraryId } from '../fixtures/entities.js'
+import { getByUri, addClaim, removeClaim } from '../utils/entities.js'
+
+// For the internals, see ./add_update_remove_claim.test.js
+describe('entities:remove-claim interface', () => {
+  it('should remove a claim', async () => {
+    const { uri } = await createWork()
+    const openlibraryId = someOpenLibraryId('work')
+    await addClaim({ uri, property: 'wdt:P648', value: openlibraryId })
+    const res = await removeClaim({ uri, property: 'wdt:P648', value: openlibraryId })
+    res.ok.should.be.true()
+    const updatedEntity = await getByUri(uri)
+    should(updatedEntity.claims['wdt:P648']).not.be.ok()
+  })
+})

--- a/tests/api/entities/update_claim.test.js
+++ b/tests/api/entities/update_claim.test.js
@@ -1,9 +1,10 @@
-import should from 'should'
+import 'should'
 import { shouldNotBeCalled } from '#tests/unit/utils'
-import { createWork, createEdition, createHuman, someOpenLibraryId, someFakeUri } from '../fixtures/entities.js'
-import { getByUri, addClaim, updateClaim, removeClaim, merge } from '../utils/entities.js'
+import { createHuman, someOpenLibraryId, someFakeUri } from '../fixtures/entities.js'
+import { addClaim, updateClaim } from '../utils/entities.js'
 
-describe('entities:update-claim', () => {
+// For the internals, see ./add_update_remove_claim.test.js
+describe('entities:update-claim interface', () => {
   it('should reject without uri', async () => {
     await updateClaim({ property: 'wdt:P123' })
     .then(shouldNotBeCalled)
@@ -22,12 +23,22 @@ describe('entities:update-claim', () => {
     })
   })
 
-  it('should reject without old-value or new-value', async () => {
+  it('should reject without old-value', async () => {
     const property = 'wdt:P1104'
-    await updateClaim({ uri: someFakeUri, property })
+    await updateClaim({ uri: someFakeUri, property, newValue: 125 })
     .then(shouldNotBeCalled)
     .catch(err => {
-      err.body.status_verbose.should.equal('missing parameter in body: old-value or new-value')
+      err.body.status_verbose.should.equal('missing parameter in body: old-value')
+      err.statusCode.should.equal(400)
+    })
+  })
+
+  it('should reject without new-value', async () => {
+    const property = 'wdt:P1104'
+    await updateClaim({ uri: someFakeUri, property, oldValue: 213 })
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.body.status_verbose.should.equal('missing parameter in body: new-value')
       err.statusCode.should.equal(400)
     })
   })
@@ -35,8 +46,7 @@ describe('entities:update-claim', () => {
   it('should reject invalid uri prefix', async () => {
     const uri = 'invalidprefix:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
     const property = 'wdt:P1104'
-    const oldValue = '1312'
-    await updateClaim({ uri, property, oldValue })
+    await updateClaim({ uri, property, oldValue: 1312 })
     .then(shouldNotBeCalled)
     .catch(err => {
       err.body.status_verbose.should.startWith('invalid uri')
@@ -44,195 +54,11 @@ describe('entities:update-claim', () => {
     })
   })
 
-  it('should reject an unknown entity', async () => {
-    const property = 'wdt:P1104'
-    const oldValue = '1312'
-    await updateClaim({ uri: someFakeUri, property, oldValue })
-    .then(shouldNotBeCalled)
-    .catch(err => {
-      err.body.status_verbose.should.equal('entity not found')
-      err.statusCode.should.equal(400)
-    })
-  })
-
-  it('should reject an unknown entity value', async () => {
-    const work = await createWork()
-    const fakeUri = 'inv:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-    await updateClaim({ uri: work.uri, property: 'wdt:P50', oldValue: null, newValue: fakeUri })
-    .then(shouldNotBeCalled)
-    .catch(err => {
-      err.body.status_verbose.should.equal('entity not found')
-      err.statusCode.should.equal(400)
-    })
-  })
-
-  it('should reject an update with an inappropriate property', async () => {
-    const work = await createWork()
-    // A work entity should not have pages count
-    await addClaim({ uri: work.uri, property: 'wdt:P1104', value: 124 })
-    .then(shouldNotBeCalled)
-    .catch(err => {
-      err.body.status_verbose.should.equal("works can't have a property wdt:P1104")
-      err.statusCode.should.equal(400)
-    })
-  })
-
-  it('should reject an update with an inappropriate property datatype', async () => {
-    const work = await createWork()
-    await addClaim({ uri: work.uri, property: 'wdt:P50', value: 124 })
-    .then(shouldNotBeCalled)
-    .catch(err => {
-      err.body.status_verbose.should.equal('invalid value type: expected string, got number')
-      err.statusCode.should.equal(400)
-    })
-  })
-
-  it('should reject adding an extra value to a property that accepts only one value', async () => {
-    const edition = await createEdition()
-    // An edition entity should have only one date of publication
-    await addClaim({ uri: edition.uri, property: 'wdt:P577', value: '2010' })
-    .then(shouldNotBeCalled)
-    .catch(err => {
-      err.body.status_verbose.should.equal('this property accepts only one value')
-      err.statusCode.should.equal(400)
-    })
-  })
-
-  it('should reject an update with an invalid property value', async () => {
-    const edition = await createEdition()
-    await addClaim({ uri: edition.uri, property: 'wdt:P123', value: 'not an entity uri' })
-    .then(shouldNotBeCalled)
-    .catch(err => {
-      err.body.status_verbose.should.equal('invalid property value')
-      err.statusCode.should.equal(400)
-    })
-  })
-
-  it('should reject an update removing a critical claim', async () => {
-    const edition = await createEdition()
-    const oldValue = edition.claims['wdt:P629'][0]
-    // An edition entity should always have at least one wdt:P629 claim
-    await removeClaim({ uri: edition.uri, property: 'wdt:P629', value: oldValue })
-    .then(shouldNotBeCalled)
-    .catch(err => {
-      err.body.status_verbose.should.equal('an edition should have an associated work (wdt:P629)')
-      err.statusCode.should.equal(400)
-    })
-  })
-
-  it('should reject an update on an unexisting claim (property with no claim)', async () => {
-    const edition = await createEdition()
-    await updateClaim({ uri: edition.uri, property: 'wdt:P655', oldValue: 'wd:Q23', newValue: 'wd:Q42' })
-    .then(shouldNotBeCalled)
-    .catch(err => {
-      err.statusCode.should.equal(400)
-      err.body.status_verbose.should.equal('claim property value not found')
-    })
-  })
-
-  it('should reject an update on an unexisting claim (property with claims)', async () => {
-    const edition = await createEdition()
-    await addClaim({ uri: edition.uri, property: 'wdt:P655', value: 'wd:Q535' })
-    await updateClaim({ uri: edition.uri, property: 'wdt:P655', oldValue: 'wd:Q23', newValue: 'wd:Q42' })
-    .then(shouldNotBeCalled)
-    .catch(err => {
-      err.statusCode.should.equal(400)
-      err.body.status_verbose.should.equal('claim property value not found')
-    })
-  })
-
-  it('should reject an update on an obsolete entity', async () => {
-    const [ workA, workB ] = await Promise.all([
-      createWork(),
-      createWork(),
-    ])
-    await merge(workA.uri, workB.uri)
-    await addClaim({ uri: workA.uri, property: 'wdt:P50', value: 'wd:Q535' })
-    .then(shouldNotBeCalled)
-    .catch(err => {
-      err.statusCode.should.equal(400)
-      err.body.status_verbose.should.equal('this entity is obsolete')
-    })
-  })
-
-  it('should accept rapid updates on the same entity', async () => {
-    const authorsUris = [ 'wd:Q192214', 'wd:Q206685' ]
-    const work = await createWork()
-    const responses = await Promise.all(authorsUris.map(uri => {
-      return addClaim({
-        uri: work.uri,
-        property: 'wdt:P50',
-        value: uri,
-      })
-    }))
-    responses.forEach(res => res.ok.should.be.true())
-    const updatedWork = await getByUri(work.uri)
-    const addedAuthorsUris = updatedWork.claims['wdt:P50']
-    authorsUris.forEach(uri => should(addedAuthorsUris.includes(uri)).be.true())
-  })
-
-  it('should accept a non-duplicated concurrent value', async () => {
+  it('should update a claim', async () => {
+    const openlibraryIdA = someOpenLibraryId()
+    const openlibraryIdB = someOpenLibraryId()
     const human = await createHuman()
-    const res = await addClaim({ uri: human._id, property: 'wdt:P648', value: someOpenLibraryId() })
-    res.ok.should.be.true()
-  })
-
-  it('should reject an invalid value for a type-specific value format', async () => {
-    const human = await createHuman()
-    await updateClaim({ uri: human.uri, property: 'wdt:P648', newValue: someOpenLibraryId('work') })
-    .then(shouldNotBeCalled)
-    .catch(err => {
-      err.statusCode.should.equal(400)
-      err.body.status_verbose.should.equal('invalid property value for entity type "human"')
-    })
-  })
-
-  it('should accept an allowlisted value for a constrained property', async () => {
-    const edition = await createEdition()
-    const res = await updateClaim({ uri: edition.uri, property: 'wdt:P437', newValue: 'wd:Q128093' })
-    res.ok.should.be.true()
-  })
-
-  it('should reject a non-allowlisted value for a constrained property', async () => {
-    const edition = await createEdition()
-    await updateClaim({ uri: edition.uri, property: 'wdt:P437', newValue: 'wd:Q123' })
-    .then(shouldNotBeCalled)
-    .catch(err => {
-      err.statusCode.should.equal(400)
-      err.body.status_verbose.should.equal('invalid property value for entity type "edition"')
-    })
-  })
-
-  it('should reject a non-allowlisted value for a given entity type', async () => {
-    const edition = await createEdition()
-    await updateClaim({ uri: edition.uri, property: 'wdt:P31', oldValue: 'wd:Q3331189', newValue: 'wd:Q5' })
-    .then(shouldNotBeCalled)
-    .catch(err => {
-      err.statusCode.should.equal(400)
-      err.body.status_verbose.should.equal('invalid property value for entity type "edition"')
-    })
-  })
-
-  it('should reject an update with a duplicated concurrent value', async () => {
-    const id = someOpenLibraryId()
-    const human = await createHuman()
-    const res = await addClaim({ uri: human.uri, property: 'wdt:P648', value: id })
-    res.ok.should.be.true()
-    const human2 = await createHuman()
-    await addClaim({ uri: human2.uri, property: 'wdt:P648', value: id })
-    .then(shouldNotBeCalled)
-    .catch(err => {
-      err.statusCode.should.equal(400)
-      err.body.status_verbose.should.equal('this property value is already used')
-    })
-  })
-
-  it('should accept a recoverable ISNI', async () => {
-    const human = await createHuman()
-    const someValidIsni = `0000 0000 ${Math.random().toString().slice(2, 6)} 123X`
-    const someRecoverableIsni = someValidIsni.replace(/\s/g, '')
-    await addClaim({ uri: human.uri, property: 'wdt:P213', value: someRecoverableIsni })
-    const updatedHuman = await getByUri(human.uri)
-    updatedHuman.claims['wdt:P213'].should.deepEqual([ someValidIsni ])
+    await addClaim({ uri: human.uri, property: 'wdt:P648', value: openlibraryIdA })
+    await updateClaim({ uri: human.uri, property: 'wdt:P648', oldValue: openlibraryIdA, newValue: openlibraryIdB })
   })
 })

--- a/tests/api/entities/update_claim.test.js
+++ b/tests/api/entities/update_claim.test.js
@@ -3,7 +3,7 @@ import { shouldNotBeCalled } from '#tests/unit/utils'
 import { createWork, createEdition, createHuman, someOpenLibraryId, someFakeUri } from '../fixtures/entities.js'
 import { getByUri, addClaim, updateClaim, removeClaim, merge } from '../utils/entities.js'
 
-describe('entities:update-claims', () => {
+describe('entities:update-claim', () => {
   it('should reject without uri', async () => {
     await updateClaim({ property: 'wdt:P123' })
     .then(shouldNotBeCalled)

--- a/tests/api/utils/entities.js
+++ b/tests/api/utils/entities.js
@@ -95,7 +95,9 @@ export const updateClaim = ({ uri, property, oldValue, newValue, user }) => {
 }
 
 export const addClaim = ({ user, uri, property, value }) => {
-  return updateClaim({ user, uri, property, newValue: value })
+  uri = normalizeUri(uri)
+  user = user || getUser()
+  return customAuthReq(user, 'put', '/api/entities?action=add-claim', { uri, property, value })
 }
 
 export const removeClaim = ({ user, uri, property, value }) => {

--- a/tests/api/utils/entities.js
+++ b/tests/api/utils/entities.js
@@ -88,10 +88,12 @@ export const updateLabel = ({ uri, lang, value, user }) => {
 export const updateClaim = ({ uri, property, oldValue, newValue, user }) => {
   uri = normalizeUri(uri)
   user = user || getUser()
-  const body = { uri, property }
-  if (oldValue) body['old-value'] = oldValue
-  if (newValue) body['new-value'] = newValue
-  return customAuthReq(user, 'put', '/api/entities?action=update-claim', body)
+  return customAuthReq(user, 'put', '/api/entities?action=update-claim', {
+    uri,
+    property,
+    'old-value': oldValue,
+    'new-value': newValue,
+  })
 }
 
 export const addClaim = ({ user, uri, property, value }) => {
@@ -101,7 +103,9 @@ export const addClaim = ({ user, uri, property, value }) => {
 }
 
 export const removeClaim = ({ user, uri, property, value }) => {
-  return updateClaim({ user, uri, property, oldValue: value })
+  uri = normalizeUri(uri)
+  user = user || getUser()
+  return customAuthReq(user, 'put', '/api/entities?action=remove-claim', { uri, property, value })
 }
 
 export const getRefreshedPopularityByUris = uris => {


### PR DESCRIPTION
Addressing #98 

I gave it a shot, I like how that removes all the `optional` from the parameter sanitization, and allows removing a validation step in the `update-claim` controller.

This would be an API breaking change. I thus also took the occasion to remove the legacy `id` parameter from the `update-claim` controller.