### PR TITLE
Allow to search by position with a bbox overlapping the anti-meridian

### DIFF
--- a/server/lib/elasticsearch.js
+++ b/server/lib/elasticsearch.js
@@ -2,7 +2,6 @@ import CONFIG from 'config'
 import { indexesNamesByBaseNames } from '#db/elasticsearch/indexes'
 import { error_ } from '#lib/error/error'
 import { requests_ } from '#lib/requests'
-import { LogErrorAndRethrow } from '#lib/utils/logs'
 import { assert_ } from './utils/assert_types.js'
 
 const { origin: elasticOrigin } = CONFIG.elasticsearch
@@ -20,7 +19,6 @@ export const buildSearcher = params => {
     return requests_.post(url, { body })
     .then(parseResponse)
     .catch(formatError)
-    .catch(LogErrorAndRethrow(`${index} search err`))
   }
 }
 

--- a/server/lib/sanitize/parameters.js
+++ b/server/lib/sanitize/parameters.js
@@ -247,7 +247,12 @@ export default {
       }
       const [ minLng, minLat, maxLng, maxLat ] = bbox
       if (minLng >= maxLng || minLat >= maxLat) return false
-      if (minLng < -180 || maxLng > 180 || minLat < -90 || maxLat > 90) return false
+      if (minLat < -90 || maxLat > 90) return false
+      // Let through bbox overlapping the anti-meridian (minLng < -180 || maxLng > 180)
+      // but do not let through bboxes overlapping on both sides
+      if (minLng < -180 && maxLng > 180) return false
+      // or overlapping twice
+      if (minLng < -(360 + 180) || maxLng > (360 + 180)) return false
       return true
     },
   },

--- a/server/lib/search_by_position.js
+++ b/server/lib/search_by_position.js
@@ -33,21 +33,28 @@ const queryBuilder = ([ minLng, minLat, maxLng, maxLat ]) => {
 }
 
 const splitBboxOnAntiMeridian = ([ minLng, minLat, maxLng, maxLat ]) => {
-  if (minLng < -180) {
+  if (minLng < -180 && maxLng > -180) {
     return [
       [ -180, minLat, maxLng, maxLat ],
-      [ (360 + minLng), minLat, 180, maxLat ],
+      [ normalizeLongitude(minLng), minLat, 180, maxLat ],
     ]
-  } else if (maxLng > 180) {
+  } else if (maxLng > 180 && minLng < 180) {
     return [
       [ minLng, minLat, 180, maxLat ],
-      [ -180, minLat, (maxLng - 360), maxLat ],
+      [ -180, minLat, normalizeLongitude(maxLng), maxLat ],
     ]
   } else {
     return [
-      [ minLng, minLat, maxLng, maxLat ],
+      // Normalizing for the case where both minLng and maxLng are out of the [ -180, 180 ] range
+      [ normalizeLongitude(minLng), minLat, normalizeLongitude(maxLng), maxLat ],
     ]
   }
+}
+
+const normalizeLongitude = lng => {
+  if (lng < -180) return lng + 360
+  if (lng > 180) return lng - 360
+  return lng
 }
 
 const buildGeoBoundingBoxClause = ([ minLng, minLat, maxLng, maxLat ]) => {

--- a/tests/api/fixtures/users.js
+++ b/tests/api/fixtures/users.js
@@ -90,12 +90,12 @@ export const getTwoFriends = () => {
 
 export const getRandomPosition = () => {
   return [
-    // Latitude
-    randomCoordinate(-90, 90),
-    // Longitude
-    randomCoordinate(-180, 180),
+    getRandomLatitude(),
+    getRandomLongitude(),
   ]
 }
+export const getRandomLatitude = () => randomCoordinate(-90, 90)
+export const getRandomLongitude = () => randomCoordinate(-180, 180)
 
 const _getTwoFriends = async () => {
   const [ userA, userB ] = await Promise.all([

--- a/tests/api/users/search_by_position.test.js
+++ b/tests/api/users/search_by_position.test.js
@@ -1,7 +1,9 @@
+import { map } from 'lodash-es'
 import should from 'should'
 import { fixedEncodeURIComponent } from '#lib/utils/url'
 import { customAuthReq } from '#tests/api/utils/request'
-import { createUser, getRandomPosition } from '../fixtures/users.js'
+import { shouldNotBeCalled } from '#tests/unit/utils'
+import { createUser, getRandomLatitude, getRandomPosition } from '../fixtures/users.js'
 import { makeFriends } from '../utils/relations.js'
 import { waitForIndexation } from '../utils/search.js'
 import { publicReq, getUser } from '../utils/utils.js'
@@ -9,18 +11,19 @@ import { publicReq, getUser } from '../utils/utils.js'
 const position = getRandomPosition()
 const [ lat, lng ] = position
 const someUserWithPosition = createUser({ position })
-const bbox = fixedEncodeURIComponent(JSON.stringify([
+const encodeBbox = bbox => fixedEncodeURIComponent(JSON.stringify(bbox))
+const bboxIncludingUser = encodeBbox([
   lng - 1, // minLng
   lat - 1, // minLat
   lng + 1, // maxLng
   lat + 1, // maxLat
-]))
+])
 
 describe('users:search-by-position', () => {
   it('should get users by position', async () => {
     const user = await someUserWithPosition
     await waitForIndexation('users', user._id)
-    const { users } = await publicReq('get', `/api/users?action=search-by-position&bbox=${bbox}`)
+    const { users } = await publicReq('get', `/api/users?action=search-by-position&bbox=${bboxIncludingUser}`)
     users.should.be.an.Array()
     const foundUser = users.find(userDoc => userDoc._id === user._id)
     should(foundUser).be.ok()
@@ -32,7 +35,7 @@ describe('users:search-by-position', () => {
     const requestingUser = await getUser()
     await makeFriends(user, requestingUser)
     await waitForIndexation('users', user._id)
-    const { users } = await customAuthReq(requestingUser, 'get', `/api/users?action=search-by-position&bbox=${bbox}`)
+    const { users } = await customAuthReq(requestingUser, 'get', `/api/users?action=search-by-position&bbox=${bboxIncludingUser}`)
     users.should.be.an.Array()
     const foundUser = users.find(userDoc => userDoc._id === user._id)
     should(foundUser).be.ok()
@@ -43,12 +46,51 @@ describe('users:search-by-position', () => {
   it('should get private data if requested user is requester', async () => {
     const user = await someUserWithPosition
     await waitForIndexation('users', user._id)
-    const { users } = await customAuthReq(user, 'get', `/api/users?action=search-by-position&bbox=${bbox}`)
+    const { users } = await customAuthReq(user, 'get', `/api/users?action=search-by-position&bbox=${bboxIncludingUser}`)
     users.should.be.an.Array()
     const foundUser = users.find(userDoc => userDoc._id === user._id)
     should(foundUser).be.ok()
     foundUser.snapshot.public.should.be.an.Object()
     foundUser.snapshot.network.should.be.an.Object()
     foundUser.snapshot.private.should.be.an.Object()
+  })
+
+  it('should support requests overlapping the anti-meridian', async () => {
+    const latitude = getRandomLatitude()
+    const extremeWestLatLng = [ latitude, -175 ]
+    const extremeEastLatLng = [ latitude, 175 ]
+    const [ extremeWestUser, extremeEastUser ] = await Promise.all([
+      createUser({ position: extremeWestLatLng }),
+      createUser({ position: extremeEastLatLng }),
+    ])
+    await Promise.all([
+      waitForIndexation('users', extremeWestUser._id),
+      waitForIndexation('users', extremeEastUser._id),
+    ])
+    const bbox = [
+      -190, // minLng
+      latitude - 1, // minLat
+      -170, // maxLng
+      latitude + 1, // maxLat
+    ]
+    const { users } = await publicReq('get', `/api/users?action=search-by-position&bbox=${encodeBbox(bbox)}`)
+    const foundUsersIds = map(users, '_id')
+    foundUsersIds.should.containEql(extremeWestUser._id)
+    foundUsersIds.should.containEql(extremeEastUser._id)
+  })
+
+  it('should reject requests overlapping the anti-meridian twice', async () => {
+    const bbox = [
+      -190 - 360, // minLng
+      -1, // minLat
+      0, // maxLng
+      1, // maxLat
+    ]
+    await publicReq('get', `/api/users?action=search-by-position&bbox=${encodeBbox(bbox)}`)
+    .then(shouldNotBeCalled)
+    .catch(err => {
+      err.statusCode.should.equal(400)
+      err.body.error_name.should.equal('invalid_bbox')
+    })
   })
 })


### PR DESCRIPTION
to make the map usable by people on the [Taveuni island](https://www.openstreetmap.org/#map=10/-16.8151/-179.8325), or more generally, to display users/groups/items between islands in the Pacific ocean.

Useful map to make sense of all those latitude/longitude coordinates:
![lat lng](https://s3.us-east-2.amazonaws.com/journeynorth.org/images/graphics/mclass/Lat_Long.gif)

This PR generally assumes that we are only supporting people sharing books on Earth.