### PR TITLE
Entities images harmonization

### DIFF
--- a/server/controllers/entities/images.js
+++ b/server/controllers/entities/images.js
@@ -48,7 +48,7 @@ export default async (req, res) => {
 }
 
 const findRawImage = async (uri, images, width, height) => {
-  const image = images[uri] && images[uri][0]
+  const image = images[uri]?.claims[0]
   if (image == null) {
     const err = error_.notFound({ uri })
     err.quiet = true

--- a/server/controllers/entities/lib/get_entities_images.js
+++ b/server/controllers/entities/lib/get_entities_images.js
@@ -16,7 +16,13 @@ const getEntityImages = entities => (promises, id) => {
   const entity = entities[id]
   // All entities type that don't have a specialEntityImagesGetter will
   // simply return their first wdt:P18 claim value, if any
-  const getter = specialEntityImagesGetter[entity.type] || getEntityImagesFromClaims
+  const getter = specialEntityImagesGetter[entity.type] || defaultEntityImageGetter
   promises[id] = getter(entity)
   return promises
+}
+
+const defaultEntityImageGetter = entity => {
+  return {
+    claims: getEntityImagesFromClaims(entity),
+  }
 }

--- a/tests/api/entities/images.test.js
+++ b/tests/api/entities/images.test.js
@@ -2,7 +2,14 @@ import CONFIG from 'config'
 import 'should'
 import { fixedEncodeURIComponent } from '#lib/utils/url'
 import { shouldNotBeCalled } from '#tests/unit/utils'
-import { createEdition } from '../fixtures/entities.js'
+import {
+  createEdition,
+  createEditionWithIsbn,
+  createCollection,
+  createSerie,
+  createWork,
+  someImageHash,
+} from '../fixtures/entities.js'
 import { rawRequest } from '../utils/request.js'
 import { publicReq } from '../utils/utils.js'
 
@@ -11,10 +18,13 @@ const encodedCommonsUrlChunk = fixedEncodeURIComponent('https://commons.wikimedi
 
 describe('entities:images', () => {
   it('should return an array of images associated with the passed uri', async () => {
-    const res = await publicReq('get', '/api/entities?action=images&uris=wd:Q535')
+    const uri = 'wd:Q535'
+    const res = await publicReq('get', `/api/entities?action=images&uris=${uri}`)
     res.images.should.be.an.Object()
-    res.images['wd:Q535'].should.be.an.Array()
-    res.images['wd:Q535'][0].should.be.a.String()
+    const imagesRes = res.images[uri]
+    imagesRes.should.be.an.Object()
+    imagesRes.claims.should.be.a.Array()
+    imagesRes.claims.length.should.equal(1)
   })
 
   it('should reject redirect requests with multiple URIs', async () => {
@@ -33,12 +43,40 @@ describe('entities:images', () => {
     headers.location.should.containEql(`href=${encodedCommonsUrlChunk}`)
   })
 
-  it('should return images from inventaire based uris', async () => {
-    const edition = await createEdition()
-    const uri = edition.claims['wdt:P629'][0]
-    const res = await publicReq('get', `/api/entities?action=images&uris=${uri}`)
-    const imagesRes = res.images[uri]
-    imagesRes.should.be.an.Object()
-    imagesRes.en.length.should.equal(1)
+  describe('inventaire:entities', () => {
+    it('should return images from isbn based uris', async () => {
+      const { uri } = await createEditionWithIsbn({ claims: { 'invp:P2': [ someImageHash ] } })
+      const res = await publicReq('get', `/api/entities?action=images&uris=${uri}`)
+      const imagesRes = res.images[uri]
+      imagesRes.should.be.an.Object()
+      imagesRes.claims.should.be.a.Array()
+      imagesRes.claims.length.should.equal(1)
+    })
+
+    it('should return images from inventaire work', async () => {
+      const edition = await createEdition()
+      const uri = edition.claims['wdt:P629'][0]
+      const res = await publicReq('get', `/api/entities?action=images&uris=${uri}`)
+      const imagesRes = res.images[uri]
+      imagesRes.claims.should.deepEqual([])
+      imagesRes.en.length.should.equal(1)
+    })
+
+    it('should return images from inventaire collection', async () => {
+      const { uri } = await createCollection()
+      await createEdition({ claims: { 'wdt:P195': [ uri ] } })
+      const res = await publicReq('get', `/api/entities?action=images&uris=${uri}`)
+      const imagesRes = res.images[uri]
+      imagesRes.en.length.should.equal(1)
+    })
+
+    it('should return images from inventaire serie', async () => {
+      const { uri } = await createSerie()
+      const work = await createWork({ claims: { 'wdt:P179': [ uri ] } })
+      await createEdition({ work })
+      const res = await publicReq('get', `/api/entities?action=images&uris=${uri}`)
+      const imagesRes = res.images[uri]
+      imagesRes.en.length.should.equal(1)
+    })
   })
 })

--- a/tests/api/entities/images.test.js
+++ b/tests/api/entities/images.test.js
@@ -2,6 +2,7 @@ import CONFIG from 'config'
 import 'should'
 import { fixedEncodeURIComponent } from '#lib/utils/url'
 import { shouldNotBeCalled } from '#tests/unit/utils'
+import { createEdition } from '../fixtures/entities.js'
 import { rawRequest } from '../utils/request.js'
 import { publicReq } from '../utils/utils.js'
 
@@ -30,5 +31,14 @@ describe('entities:images', () => {
     statusCode.should.equal(302)
     headers.location.should.startWith(`${host}/img/remote/32x1600/`)
     headers.location.should.containEql(`href=${encodedCommonsUrlChunk}`)
+  })
+
+  it('should return images from inventaire based uris', async () => {
+    const edition = await createEdition()
+    const uri = edition.claims['wdt:P629'][0]
+    const res = await publicReq('get', `/api/entities?action=images&uris=${uri}`)
+    const imagesRes = res.images[uri]
+    imagesRes.should.be.an.Object()
+    imagesRes.en.length.should.equal(1)
   })
 })

--- a/tests/api/fixtures/entities.js
+++ b/tests/api/fixtures/entities.js
@@ -66,18 +66,19 @@ export const createEdition = async (params = {}) => {
 }
 
 export const createEditionWithIsbn = async (params = {}) => {
-  const { publisher, publicationDate } = params
+  const { publisher, publicationDate, claims } = params
   const work = await createWork()
   const isbn13h = generateIsbn13h()
-  const claims = {
+  const editionClaims = Object.assign({
     'wdt:P31': [ 'wd:Q3331189' ],
     'wdt:P629': [ work.uri ],
     'wdt:P212': [ isbn13h ],
     'wdt:P1476': [ randomLabel() ],
-  }
-  if (publisher) claims['wdt:P123'] = [ publisher ]
-  if (publicationDate !== null) claims['wdt:P577'] = [ publicationDate || '2020' ]
-  const edition = await authReq('post', '/api/entities?action=create', { claims })
+    'invp:P2': [ someImageHash ],
+  }, claims)
+  if (publisher) editionClaims['wdt:P123'] = [ publisher ]
+  if (publicationDate !== null) editionClaims['wdt:P577'] = [ publicationDate || '2020' ]
+  const edition = await authReq('post', '/api/entities?action=create', { claims: editionClaims })
   edition.isbn = edition.uri.split(':')[1]
   edition.invUri = `inv:${edition._id}`
   edition.isbn13h = isbn13h


### PR DESCRIPTION
This PR updates the API endpoint `/entities?action=images` so that entities with a special getter (work, collection and series) which previously responded with

```
"wd:Q535": [ 'Victor Hugo by Étienne Carjat 1876 - full.jpg' ]
```
are now responding with:
```
"wd:Q535": { claims: [ 'Victor Hugo by Étienne Carjat 1876 - full.jpg' ] }
```
