### PR TITLE
/api/entities?action=by-uris: attach entities popularities when requested

### DIFF
--- a/server/controllers/entities/by_uris_get.js
+++ b/server/controllers/entities/by_uris_get.js
@@ -1,3 +1,4 @@
+import { addEntitiesPopularities } from '#controllers/entities/lib/popularity'
 import addRelatives from './lib/add_relatives.js'
 import getEntitiesByUris from './lib/get_entities_by_uris.js'
 import { pickAttributes, pickLanguages } from './lib/pick_attributes.js'
@@ -12,6 +13,7 @@ const sanitization = {
       'claims',
       'sitelinks',
       'image',
+      'popularity',
     ],
     optional: true,
   },
@@ -42,7 +44,15 @@ const sanitization = {
 const controller = async ({ uris, attributes, lang, refresh, relatives, autocreate }) => {
   let results = await getEntitiesByUris({ uris, refresh, autocreate })
   if (relatives) results = await addRelatives(results, relatives, refresh)
-  if (attributes) results.entities = pickAttributes(results.entities, attributes)
+  if (attributes) {
+    results.entities = pickAttributes(results.entities, attributes)
+    if (attributes.includes('popularity')) {
+      await addEntitiesPopularities({
+        entities: Object.values(results.entities),
+        refresh,
+      })
+    }
+  }
   if (lang) results.entities = pickLanguages(results.entities, lang)
   return results
 }

--- a/server/controllers/entities/lib/popularity.js
+++ b/server/controllers/entities/lib/popularity.js
@@ -1,4 +1,5 @@
 import CONFIG from 'config'
+import { map } from 'lodash-es'
 import { initJobQueue } from '#db/level/jobs'
 import { isEntityUri } from '#lib/boolean_validations'
 import { cache_ } from '#lib/cache'
@@ -83,3 +84,11 @@ async function popularityWorker (jobId, uri) {
 }
 
 const popularityJobQueue = initJobQueue('entity:popularity', popularityWorker, 1)
+
+export async function addEntitiesPopularities ({ entities, refresh }) {
+  const uris = map(entities, 'uri')
+  const scoresByUri = await getEntitiesPopularities({ uris, refresh })
+  entities.forEach(entity => {
+    entity.popularity = scoresByUri[entity.uri]
+  })
+}

--- a/tests/api/utils/entities.js
+++ b/tests/api/utils/entities.js
@@ -27,6 +27,18 @@ export const getByUri = (uri, refresh) => {
   .then(res => res.entities[uri])
 }
 
+export async function getEntitiesAttributesByUris ({ uris, attributes, relatives, refresh }) {
+  const query = {
+    action: 'by-uris',
+    uris: forceArray(uris).join('|'),
+    attributes: forceArray(attributes).join('|'),
+    refresh,
+  }
+  if (relatives) query.relatives = forceArray(relatives).join('|')
+  const { entities } = await publicReq('get', buildUrl('/api/entities', query))
+  return entities
+}
+
 export const findOrIndexEntities = async (uris, index = 'wikidata') => {
   const ids = map(uris, unprefixify)
   const results = await Promise.all(ids.map(id => getIndexedDoc(index, id)))


### PR DESCRIPTION
This would allow to simplify code such as `getAndAssignPopularity` in https://github.com/inventaire/inventaire-client/pull/384 by getting popularities straight from the call to `getEntitiesAttributesByUris`:

ex: `GET /api/entities?action=by-uris&attributes=type|labels|popularity&uris=wd:Q535`