### PR TITLE
entities summaries: ignore sitelinks that are redirections

### DIFF
--- a/server/controllers/data/lib/summaries/sitelinks.js
+++ b/server/controllers/data/lib/summaries/sitelinks.js
@@ -5,7 +5,8 @@ export const getWikipediaSitelinksData = sitelinks => {
   return Object.entries(sitelinks).map(getWikipediaSummaryData)
 }
 
-const getWikipediaSummaryData = ([ key, title ]) => {
+const getWikipediaSummaryData = ([ key, { title, badges } ]) => {
+  if (badges.includes(redirectionBadge)) return
   const { lang, project } = getSitelinkData(key)
   if (project === 'wikipedia') {
     const link = getSitelinkUrl({ site: key, title })
@@ -21,3 +22,5 @@ const getWikipediaSummaryData = ([ key, title ]) => {
     }
   }
 }
+
+const redirectionBadge = 'Q70893996'

--- a/server/controllers/entities/lib/add_image_data.js
+++ b/server/controllers/entities/lib/add_image_data.js
@@ -14,7 +14,7 @@ export default async entity => {
 
 const findAnImage = entity => {
   const commonsFilename = getCommonsFilenamesFromClaims(entity.claims)[0]
-  const enwikiTitle = entity.sitelinks.enwiki
+  const enwikiTitle = entity.sitelinks.enwiki?.title
   const { claims } = entity
   const openLibraryId = claims['wdt:P648'] && claims['wdt:P648'][0]
   return pickBestPic(entity, commonsFilename, enwikiTitle, openLibraryId)

--- a/server/controllers/entities/lib/get_occurrences_from_external_sources.js
+++ b/server/controllers/entities/lib/get_occurrences_from_external_sources.js
@@ -68,7 +68,7 @@ const getMostRelevantWikipediaArticles = (authorEntity, worksLabelsLangs) => {
 }
 
 const getArticleParams = sitelinks => lang => {
-  const title = sitelinks[`${lang}wiki`]
+  const title = sitelinks[`${lang}wiki`]?.title
   if (title) return { lang, title }
 }
 

--- a/server/controllers/entities/lib/get_wikidata_enriched_entities.js
+++ b/server/controllers/entities/lib/get_wikidata_enriched_entities.js
@@ -85,7 +85,7 @@ const formatValidEntity = async entity => {
   entity.labels = simplifyLabels(entity.labels)
   entity.aliases = simplifyAliases(entity.aliases)
   entity.descriptions = simplifyDescriptions(entity.descriptions)
-  entity.sitelinks = simplifySitelinks(entity.sitelinks)
+  entity.sitelinks = simplifySitelinks(entity.sitelinks, { keepBadges: true })
   entity.claims = formatClaims(entity.claims)
   entity.originalLang = getOriginalLang(entity.claims)
 

--- a/tests/api/data/summaries.test.js
+++ b/tests/api/data/summaries.test.js
@@ -136,6 +136,17 @@ describe('summaries', () => {
         },
       })
     })
+
+    it('should ignore sitelinks that are redirections', async () => {
+      const uri = 'wd:Q3020076'
+      const entity = await getByUri(uri)
+      if (!entity.sitelinks.frwiki?.badges.includes('Q70893996')) {
+        throw new Error('Obsolete test: this test depends on the fact that wd:Q3020076 frwiki sitelink has a Q70893996 badge')
+      }
+      const { summaries } = await publicReq('get', `${endpoint}&uri=${uri}`)
+      const frwikiSitelinkData = summaries.find(summaryData => summaryData.key === 'frwiki')
+      should(frwikiSitelinkData).not.be.ok()
+    })
   })
 
   it('should return a tailored subset when passed langs parameters', async () => {


### PR DESCRIPTION
Example: this summary should not be displayed https://inventaire.io/entity/wd:Q3020076?lang=fr

TODO post-PR-merge, invalidate Wikidata entities cache:
```sh
lev db/leveldb_cache-prod --prefix 'wd:enriched:' --del | lev db/leveldb_cache-prod --batch
```