### PR TITLE
users: add admin-only endpoint to fetch the latest created users

### DIFF
--- a/server/controllers/user/lib/authorized_user_data_pickers.js
+++ b/server/controllers/user/lib/authorized_user_data_pickers.js
@@ -14,7 +14,7 @@ export const ownerSafeData = user => {
 }
 
 // Adapts the result to the requester authorization level
-export const omitPrivateData = (reqUserId, networkIds, extraAttribute) => {
+export const omitPrivateData = (reqUserId, networkIds = [], extraAttribute) => {
   const attributes = getAttributes(extraAttribute)
   return userDoc => {
     if (userDoc.type === 'deletedUser') return userDoc

--- a/server/controllers/user/lib/is_reserved_word.js
+++ b/server/controllers/user/lib/is_reserved_word.js
@@ -27,6 +27,7 @@ const reservedWords = new Set([
   'item',
   'items',
   'last',
+  'latest',
   'lend',
   'listings',
   'local',

--- a/server/controllers/users/by_creation_date.js
+++ b/server/controllers/users/by_creation_date.js
@@ -1,0 +1,16 @@
+import { omitPrivateData } from '#controllers/user/lib/authorized_user_data_pickers'
+import { getUsersByCreationDate } from '#controllers/users/lib/users'
+
+const sanitization = {
+  limit: {},
+  offset: {},
+}
+
+const controller = async ({ limit, offset }) => {
+  const users = await getUsersByCreationDate({ limit, offset })
+  return {
+    users: users.map(omitPrivateData()),
+  }
+}
+
+export default { sanitization, controller }

--- a/server/controllers/users/lib/users.js
+++ b/server/controllers/users/lib/users.js
@@ -1,0 +1,15 @@
+import { map } from 'lodash-es'
+import dbFactory from '#db/couchdb/base'
+
+const db = await dbFactory('users')
+
+export async function getUsersByCreationDate ({ limit = 100, offset = 0 }) {
+  const { rows } = await db.view('users', 'byCreation', {
+    include_docs: true,
+    limit,
+    skip: offset,
+    startkey: [ Date.now() ],
+    descending: true,
+  })
+  return map(rows, 'doc')
+}

--- a/server/controllers/users/users.js
+++ b/server/controllers/users/users.js
@@ -1,3 +1,4 @@
+import byCreationDate from '#controllers/users/by_creation_date'
 import ActionsControllers from '#lib/actions_controllers'
 import byIds from './by_ids.js'
 import byUsernames from './by_usernames.js'
@@ -16,6 +17,9 @@ export default {
     authentified: {
       // TODO: maybe, merge this endpoint with search-by-position
       nearby,
+    },
+    admin: {
+      'by-creation-date': byCreationDate,
     },
   }),
 }

--- a/tests/api/users/by_creation_date.js
+++ b/tests/api/users/by_creation_date.js
@@ -1,0 +1,15 @@
+import { map } from 'lodash-es'
+import { buildUrl } from '#lib/utils/url'
+import { adminReq, getReservedUser } from '#tests/api/utils/utils'
+
+const getUrl = query => buildUrl('/api/users', { action: 'by-creation-date', ...query })
+
+describe('users:by-creation-date', () => {
+  it('should get the latest users', async () => {
+    const user = await getReservedUser()
+    const { users } = await adminReq('get', getUrl({ limit: 2 }))
+    users.should.be.an.Array()
+    users.length.should.equal(2)
+    map(users, '_id').should.containEql(user._id)
+  })
+})


### PR DESCRIPTION
To simplify the work of casually checking the kind of activity going on. The need arised in development (as I wanted to easy recover a user I had created to continue to play with its particuliar case), but could typically be useful to observe the latest spammers' tricks in prod

Client PR: https://github.com/inventaire/inventaire-client/pull/412

Fixes #455