### PR TITLE
items: remove shelves ids that the requesting user is not authorized to access

### DIFF
--- a/tests/api/items/get_by_ids.test.js
+++ b/tests/api/items/get_by_ids.test.js
@@ -104,8 +104,7 @@ describe('items:get-by-ids', () => {
       res.items[0].shelves.should.deepEqual([ shelf._id ])
     })
 
-    // TODO: actually remove private shelves ids
-    xit('should not include private shelf id', async () => {
+    it('should not include private shelf id', async () => {
       const shelfData = { visibility: [] }
       const itemData = { visibility: [ 'public' ] }
       const { item } = await createShelfWithItem(shelfData, itemData)


### PR DESCRIPTION
This should prevent "unauthorized shelves access" errors that you see on items that belong to shelves you are not authorized to access. Example: https://inventaire.io/items/4519939c6c5fb623a53e04e57a3ef551