### PR TITLE
Automerge on claims

### DIFF
--- a/server/controllers/data/wp_extract.js
+++ b/server/controllers/data/wp_extract.js
@@ -1,4 +1,4 @@
-import getArticle from '#data/wikipedia/get_article'
+import { getWikipediaArticle } from '#data/wikipedia/get_article'
 import { error_ } from '#lib/error/error'
 import { normalizeWikimediaLang } from '#lib/wikimedia'
 
@@ -14,7 +14,7 @@ const controller = async ({ lang, title }) => {
   if (isInvalidTitle(title)) {
     throw error_.new('invalid title', 400, { title })
   }
-  return getArticle({ lang, title, introOnly: true })
+  return getWikipediaArticle({ lang, title, introOnly: true })
 }
 
 const isInvalidTitle = title => /[{}]/.test(title)

--- a/server/controllers/entities/lib/get_occurrences_from_entities.js
+++ b/server/controllers/entities/lib/get_occurrences_from_entities.js
@@ -9,15 +9,22 @@ export default (uri, suspectWorksLabels) => {
   .then(suggestionWorksData => {
     const occurrences = []
     for (const sugWork of suggestionWorksData) {
-      const sugWorkTerms = getEntityNormalizedTerms(sugWork)
-      const matchedTitles = intersection(suspectWorksLabels, sugWorkTerms)
+      const matchedTitles = filterMatchedTitles(sugWork, suspectWorksLabels)
       if (matchedTitles.length > 0) {
-        uri = sugWork.uri
-        occurrences.push({ uri, matchedTitles, structuredDataSource: true })
+        occurrences.push({
+          uri: sugWork.uri,
+          matchedTitles,
+          structuredDataSource: true,
+        })
       }
     }
     return occurrences
   })
+}
+
+function filterMatchedTitles (sugWork, suspectWorksLabels) {
+  const sugWorkTerms = getEntityNormalizedTerms(sugWork)
+  return intersection(suspectWorksLabels, sugWorkTerms)
 }
 
 const getSuggestionWorks = res => {

--- a/server/controllers/entities/lib/get_occurrences_from_external_sources.js
+++ b/server/controllers/entities/lib/get_occurrences_from_external_sources.js
@@ -97,7 +97,7 @@ const createOccurrencesFromUnstructuredArticle = worksLabels => article => {
   return { url: article.url, matchedTitles, structuredDataSource: false }
 }
 
-export function matchLabelsInArticle (labels, article) {
+function matchLabelsInArticle (labels, article) {
   if (!article.extract || labels.length === 0) return []
   const worksLabelsPattern = new RegExp(labels.map(normalize).join('|'), 'g')
   return uniq(normalize(article.extract).match(worksLabelsPattern))

--- a/server/controllers/entities/lib/get_occurrences_from_external_sources.js
+++ b/server/controllers/entities/lib/get_occurrences_from_external_sources.js
@@ -11,7 +11,7 @@ import getKjkAuthorWorksTitle from '#data/kjk/get_kjk_author_works_titles'
 import getNdlAuthorWorksTitle from '#data/ndl/get_ndl_author_works_titles'
 import getOlAuthorWorksTitles from '#data/openlibrary/get_ol_author_works_titles'
 import getSelibrAuthorWorksTitle from '#data/selibr/get_selibr_author_works_titles'
-import getWikipediaArticle from '#data/wikipedia/get_article'
+import { getWikipediaArticle } from '#data/wikipedia/get_article'
 import { isWdEntityUri } from '#lib/boolean_validations'
 import { assert_ } from '#lib/utils/assert_types'
 import { logError } from '#lib/utils/logs'
@@ -91,16 +91,16 @@ const getKjkOccurrences = getAndCreateOccurrencesFromIds('wdt:P1006', getKjkAuth
 const getNdlOccurrences = getAndCreateOccurrencesFromIds('wdt:P349', getNdlAuthorWorksTitle)
 
 const createOccurrencesFromUnstructuredArticle = worksLabels => article => {
-  if (!article.extract) return
+  if (!article.wikitext) return
   const matchedTitles = matchLabelsInArticle(worksLabels, article)
   if (matchedTitles.length <= 0) return
   return { url: article.url, matchedTitles, structuredDataSource: false }
 }
 
 function matchLabelsInArticle (labels, article) {
-  if (!article.extract || labels.length === 0) return []
+  if (!article.wikitext || labels.length === 0) return []
   const worksLabelsPattern = new RegExp(labels.map(normalize).join('|'), 'g')
-  return uniq(normalize(article.extract).match(worksLabelsPattern))
+  return uniq(normalize(article.wikitext).match(worksLabelsPattern))
 }
 
 const createOccurrencesFromExactTitles = worksLabels => result => {

--- a/server/controllers/entities/lib/resolver/resolve_on_terms.js
+++ b/server/controllers/entities/lib/resolver/resolve_on_terms.js
@@ -3,7 +3,7 @@ import typeSearch from '#controllers/search/lib/type_search'
 import { someMatch } from '#lib/utils/base'
 import { hasConvincingOccurrences } from '#server/controllers/tasks/lib/automerge'
 import getAuthorsUris from '../get_authors_uris.js'
-import getOccurrencesFromExternalSources from '../get_occurrences_from_external_sources.js'
+import { getOccurrencesFromExternalSources } from '../get_occurrences_from_external_sources.js'
 import { getEntityNormalizedTerms } from '../terms_normalization.js'
 import getWorksFromAuthorsUris from './get_works_from_authors_uris.js'
 

--- a/server/controllers/tasks/lib/automerge.js
+++ b/server/controllers/tasks/lib/automerge.js
@@ -9,12 +9,15 @@ const { _id: reconcilerUserId } = hardCodedUsers.reconciler
 const longTitleLimit = 12
 
 // Merge if perfect matched of works title and if title is long enough
-export async function automerge (suspectUri, suggestion) {
+export async function validateAndAutomerge (suspectUri, suggestion) {
   const { uri: suggestionUri } = suggestion
   if (!hasConvincingOccurrences(suggestion.occurrences)) {
     return [ suggestion ]
   }
+  return automerge(suspectUri, suggestionUri)
+}
 
+export async function automerge (suspectUri, suggestionUri) {
   log({ suspectUri, suggestionUri }, 'automerging')
 
   await mergeEntities({ userId: reconcilerUserId, fromUri: suspectUri, toUri: suggestionUri })

--- a/server/controllers/tasks/lib/check_entity.js
+++ b/server/controllers/tasks/lib/check_entity.js
@@ -1,5 +1,5 @@
 import { getEntityByUri } from '#controllers/entities/lib/get_entity_by_uri'
-import { createTask, getTasksBySuspectUris } from '#controllers/tasks/lib/tasks'
+import { createTasksFromSuggestions, getTasksBySuspectUris } from '#controllers/tasks/lib/tasks'
 import { error_ } from '#lib/error/error'
 import { info } from '#lib/utils/logs'
 import getNewTasks from './get_new_tasks.js'
@@ -29,7 +29,13 @@ export default async uri => {
 
   const existingTasks = await getExistingTasks(uri)
   const newSuggestions = await getNewTasks(entity, existingTasks)
-  await createTask(uri, 'deduplicate', entity.type, newSuggestions)
+  await createTasksFromSuggestions({
+    suspectUri: uri,
+    type: 'deduplicate',
+    entitiesType: entity.type,
+    suggestions: newSuggestions,
+  })
+
   await updateRelationScore(uri)
 }
 

--- a/server/controllers/tasks/lib/deduplicate_works.js
+++ b/server/controllers/tasks/lib/deduplicate_works.js
@@ -4,7 +4,7 @@ import { getEntitiesList } from '#controllers/entities/lib/get_entities_list'
 import { getEntityByUri } from '#controllers/entities/lib/get_entity_by_uri'
 import { haveExactMatch } from '#controllers/entities/lib/labels_match'
 import mergeEntities from '#controllers/entities/lib/merge_entities'
-import { createTask, getTasksBySuspectUris } from '#controllers/tasks/lib/tasks'
+import { createTasksFromSuggestions, getTasksBySuspectUris } from '#controllers/tasks/lib/tasks'
 import { error_ } from '#lib/error/error'
 
 export default async (workUri, isbn, userId) => {
@@ -30,7 +30,12 @@ export default async (workUri, isbn, userId) => {
   const existingTasks = await getExistingTasks(workUri)
   let newSuggestions = await filterNewTasks(existingTasks, suggestions)
   newSuggestions = map(newSuggestions, addToSuggestion(userId, isbn))
-  return createTask(workUri, 'deduplicate', work.type, newSuggestions)
+  return createTasksFromSuggestions({
+    suspectUri: workUri,
+    type: 'deduplicate',
+    entitiesType: work.type,
+    suggestions: newSuggestions,
+  })
 }
 
 const getSuggestionsOrAutomerge = async (work, editionWorks, userId) => {

--- a/server/controllers/tasks/lib/find_authors_with_isbns_in_wikipedia_articles.js
+++ b/server/controllers/tasks/lib/find_authors_with_isbns_in_wikipedia_articles.js
@@ -7,8 +7,7 @@ import { asyncFilter } from '#lib/promises'
 export async function findAuthorWithMatchingIsbnInWikipediaArticles (worksData, authors) {
   // worksData is built with getAuthorWorksData
   const { langs, worksUris } = worksData
-  const editions = await Promise.all(getEditionsFromWorks(worksUris))
-    .then(flatMap)
+  const editions = await getEditionsFromWorks(worksUris)
   const isbns = getIsbnsClaimValues(editions)
   if (isbns.length === 0) return
 
@@ -39,6 +38,8 @@ const hasMatchingIsbns = claimsIsbns => article => {
   }
 }
 
-function getEditionsFromWorks (worksUris) {
-  return worksUris.map(uri => getInvEntitiesByClaim('wdt:P629', uri, true, true))
+async function getEditionsFromWorks (worksUris) {
+  return Promise.all(worksUris.map(uri => {
+    return getInvEntitiesByClaim('wdt:P629', uri, true, true)
+  })).then(flatMap)
 }

--- a/server/controllers/tasks/lib/find_authors_with_isbns_in_wikipedia_articles.js
+++ b/server/controllers/tasks/lib/find_authors_with_isbns_in_wikipedia_articles.js
@@ -2,7 +2,7 @@ import { flatMap } from 'lodash-es'
 import { getInvEntitiesByClaim } from '#controllers/entities/lib/entities'
 import { getMostRelevantWikipediaArticles, matchLabelsInArticle } from '#controllers/entities/lib/get_occurrences_from_external_sources'
 
-export async function findAuthorsWithIsbnsInWikipediaArticles (worksData, authors) {
+export async function findAuthorWithMatchingIsbnInWikipediaArticles (worksData, authors) {
   // worksData is built with getAuthorWorksData
   const { langs, worksUris } = worksData
   const editions = await Promise.all(getEditionsFromWorks(worksUris))

--- a/server/controllers/tasks/lib/find_authors_with_isbns_in_wikipedia_articles.js
+++ b/server/controllers/tasks/lib/find_authors_with_isbns_in_wikipedia_articles.js
@@ -1,0 +1,38 @@
+import { flatMap } from 'lodash-es'
+import { getInvEntitiesByClaim } from '#controllers/entities/lib/entities'
+import { getMostRelevantWikipediaArticles, matchLabelsInArticle } from '#controllers/entities/lib/get_occurrences_from_external_sources'
+
+export async function findAuthorsWithIsbnsInWikipediaArticles (worksData, authors) {
+  // worksData is built with getAuthorWorksData
+  const { langs, worksUris } = worksData
+  const editions = await Promise.all(getEditionsFromWorks(worksUris))
+    .then(flatMap)
+  const isbns = getIsbnsClaimValues(editions)
+  if (isbns.length === 0) return
+  return authors.find(hasIsbnInWikipediaArticles(langs, isbns))
+}
+
+function getIsbnsClaimValues (editions) {
+  const isbns = []
+  editions.forEach(edition => {
+    const isbn = edition.claims['wdt:P212']?.[0]
+    if (isbn) isbns.push(isbn)
+  })
+  return isbns
+}
+
+const hasIsbnInWikipediaArticles = (langs, isbns) => async suggestion => {
+  const articles = await getMostRelevantWikipediaArticles(suggestion, langs)
+  if (articles.length === 0) return
+  const matchedArticle = articles.find(hasMatchingLabels(isbns))
+  if (matchedArticle) return suggestion
+}
+
+const hasMatchingLabels = article => labels => {
+  const matchedLabels = matchLabelsInArticle(labels, article)
+  return matchedLabels.length > 0
+}
+
+function getEditionsFromWorks (worksUris) {
+  return worksUris.map(uri => getInvEntitiesByClaim('wdt:P629', uri, true, true))
+}

--- a/server/controllers/tasks/lib/find_authors_with_isbns_in_wikipedia_articles.js
+++ b/server/controllers/tasks/lib/find_authors_with_isbns_in_wikipedia_articles.js
@@ -1,8 +1,9 @@
-import { flatMap, intersection } from 'lodash-es'
+import { flatMap } from 'lodash-es'
 import { getInvEntitiesByClaim } from '#controllers/entities/lib/entities'
 import { getMostRelevantWikipediaArticles } from '#controllers/entities/lib/get_occurrences_from_external_sources'
 import { normalizeIsbn, findIsbns, isValidIsbn } from '#lib/isbn/isbn'
 import { asyncFilter } from '#lib/promises'
+import { someMatch } from '#lib/utils/base'
 
 export async function findAuthorWithMatchingIsbnInWikipediaArticles (worksData, authors) {
   // worksData is built with getAuthorWorksData
@@ -34,7 +35,7 @@ const hasMatchingIsbns = claimsIsbns => article => {
   if (articleIsbns.length > 0) {
     const normalizedClaimsIsbns = claimsIsbns.map(normalizeIsbn)
     const normalizedArticleIsbns = articleIsbns.map(normalizeIsbn).filter(isValidIsbn)
-    return intersection(normalizedClaimsIsbns, normalizedArticleIsbns).length > 0
+    return someMatch(normalizedClaimsIsbns, normalizedArticleIsbns)
   }
 }
 

--- a/server/controllers/tasks/lib/find_authors_with_isbns_in_wikipedia_articles.js
+++ b/server/controllers/tasks/lib/find_authors_with_isbns_in_wikipedia_articles.js
@@ -13,12 +13,11 @@ export async function findAuthorsWithIsbnsInWikipediaArticles (worksData, author
 }
 
 function getIsbnsClaimValues (editions) {
-  const isbns = []
-  editions.forEach(edition => {
-    const isbn = edition.claims['wdt:P212']?.[0]
-    if (isbn) isbns.push(isbn)
+  return editions.flatMap(edition => {
+    const isbns13 = edition.claims['wdt:P212'] || []
+    const isbns10 = edition.claims['wdt:P957'] || []
+    return isbns13.concat(isbns10)
   })
-  return isbns
 }
 
 const hasIsbnInWikipediaArticles = (langs, isbns) => async suggestion => {

--- a/server/controllers/tasks/lib/find_authors_with_isbns_in_wikipedia_articles.js
+++ b/server/controllers/tasks/lib/find_authors_with_isbns_in_wikipedia_articles.js
@@ -30,7 +30,7 @@ const hasIsbnInWikipediaArticles = (langs, claimsIsbns) => async author => {
 }
 
 const hasMatchingIsbns = claimsIsbns => article => {
-  const articleIsbns = findIsbns(article.extract)
+  const articleIsbns = findIsbns(article.wikitext)
   if (articleIsbns.length > 0) {
     const normalizedClaimsIsbns = claimsIsbns.map(normalizeIsbn)
     const normalizedArticleIsbns = articleIsbns.map(normalizeIsbn).filter(isValidIsbn)

--- a/server/controllers/tasks/lib/get_new_tasks.js
+++ b/server/controllers/tasks/lib/get_new_tasks.js
@@ -10,7 +10,7 @@ import { automerge } from './automerge.js'
 
 export default async function (entity, existingTasks) {
   const [ newSuggestions, suspectWorksData ] = await Promise.all([
-    searchEntityDuplicatesSuggestions(entity, existingTasks),
+    searchEntityDuplicatesSuggestions(entity),
     getAuthorWorksData(entity._id),
   ])
   if (newSuggestions.length <= 0) return []

--- a/server/controllers/tasks/lib/get_new_tasks.js
+++ b/server/controllers/tasks/lib/get_new_tasks.js
@@ -18,7 +18,7 @@ export default async function (entity, existingTasks) {
     searchEntityDuplicatesSuggestions(entity),
     getAuthorWorksData(entity._id),
   ])
-  if (newSuggestionsSearchResults.length <= 0) return []
+  if (newSuggestionsSearchResults.length === 0) return []
   const { labels: worksLabels } = suspectWorksData
   const suggestions = await getAndFormatSuggestionsEntities(newSuggestionsSearchResults)
 
@@ -34,7 +34,7 @@ export default async function (entity, existingTasks) {
 }
 
 async function getAndFormatSuggestionsEntities (newSuggestionsSearchResults) {
-  const uris = newSuggestionsSearchResults.map(suggestion => suggestion.uri)
+  const uris = map(newSuggestionsSearchResults, 'uri')
   const { entities } = await getEntitiesByUris({ uris })
   newSuggestionsSearchResults.forEach(addLexicalScoreToSuggestionsEntities(entities))
   return Object.values(entities)
@@ -78,8 +78,7 @@ async function findSuggestionWithSameExternalId (suspect, suggestions) {
 function getExternalIdsClaimsValues (claims) {
   const externalIdsClaims = []
 
-  for (const prop in claims) {
-    const values = claims[prop]
+  for (const [ prop, values ] of Object.entries(claims)) {
     if (properties[prop]) {
       const { datatype, format } = properties[prop]
       if (datatype === 'external-id') {

--- a/server/controllers/tasks/lib/get_new_tasks.js
+++ b/server/controllers/tasks/lib/get_new_tasks.js
@@ -80,8 +80,8 @@ function getExternalIdsClaimsValues (claims) {
   for (const prop in claims) {
     const values = claims[prop]
     if (properties[prop]) {
-      const { isExternalId, format } = properties[prop]
-      if (isExternalId) {
+      const { datatype, format } = properties[prop]
+      if (datatype === 'external-id') {
         forceArray(values).forEach(value => {
           if (format) value = format(value)
           externalIdsClaims.push(value)

--- a/server/controllers/tasks/lib/get_new_tasks.js
+++ b/server/controllers/tasks/lib/get_new_tasks.js
@@ -11,7 +11,7 @@ import typeSearch from '#controllers/search/lib/type_search'
 import { isNonEmptyString, isNonEmptyArray } from '#lib/boolean_validations'
 import { forceArray } from '#lib/utils/base'
 import { automerge, validateAndAutomerge } from './automerge.js'
-import { findAuthorsWithIsbnsInWikipediaArticles } from './find_authors_with_isbns_in_wikipedia_articles.js'
+import { findAuthorWithMatchingIsbnInWikipediaArticles } from './find_authors_with_isbns_in_wikipedia_articles.js'
 
 export default async function (entity, existingTasks) {
   const [ newSuggestionsSearchResults, suspectWorksData ] = await Promise.all([
@@ -22,7 +22,7 @@ export default async function (entity, existingTasks) {
   const { labels: worksLabels } = suspectWorksData
   const suggestions = await getAndFormatSuggestionsEntities(newSuggestionsSearchResults)
 
-  const suggestionWithIsbnInWpArticle = await findAuthorsWithIsbnsInWikipediaArticles(suspectWorksData, suggestions)
+  const suggestionWithIsbnInWpArticle = await findAuthorWithMatchingIsbnInWikipediaArticles(suspectWorksData, suggestions)
   if (suggestionWithIsbnInWpArticle) {
     return automerge(entity.uri, suggestionWithIsbnInWpArticle.uri)
   }

--- a/server/controllers/tasks/lib/get_new_tasks.js
+++ b/server/controllers/tasks/lib/get_new_tasks.js
@@ -22,6 +22,7 @@ export default async function (entity, existingTasks) {
   const { labels: worksLabels } = suspectWorksData
   const suggestions = await getAndFormatSuggestionsEntities(newSuggestionsSearchResults)
 
+  // Early merge to avoid triggering external sources requests
   const suggestionWithIsbnInWpArticle = await findAuthorWithMatchingIsbnInWikipediaArticles(suspectWorksData, suggestions)
   if (suggestionWithIsbnInWpArticle) {
     return automerge(entity.uri, suggestionWithIsbnInWpArticle.uri)

--- a/server/controllers/tasks/lib/tasks.js
+++ b/server/controllers/tasks/lib/tasks.js
@@ -8,12 +8,12 @@ const db = await dbFactory('tasks')
 export async function createTask (suspectUri, type, entitiesType, suggestions) {
   // suggestions may only be an array of objects with a 'uri' key
   const newTasksObjects = suggestions.map(suggestion => {
-    const { _score, uri: suggestionUri, occurrences, reporter, clue } = suggestion
+    const { lexicalScore, uri: suggestionUri, occurrences, reporter, clue } = suggestion
 
     const newTask = { type, suspectUri, suggestionUri }
 
     assignKeyIfExists(newTask, 'entitiesType', entitiesType)
-    assignKeyIfExists(newTask, 'lexicalScore', _score)
+    assignKeyIfExists(newTask, 'lexicalScore', lexicalScore)
     assignKeyIfExists(newTask, 'reporter', reporter)
     assignKeyIfExists(newTask, 'externalSourcesOccurrences', occurrences)
     assignKeyIfExists(newTask, 'clue', clue)

--- a/server/controllers/tasks/lib/tasks.js
+++ b/server/controllers/tasks/lib/tasks.js
@@ -5,7 +5,7 @@ import Task from '#models/task'
 
 const db = await dbFactory('tasks')
 
-export async function createTask (suspectUri, type, entitiesType, suggestions) {
+export async function createTasksFromSuggestions ({ suspectUri, type, entitiesType, suggestions }) {
   // suggestions may only be an array of objects with a 'uri' key
   const newTasksObjects = suggestions.map(suggestion => {
     const { lexicalScore, uri: suggestionUri, occurrences, reporter, clue } = suggestion

--- a/server/data/wikipedia/get_article.js
+++ b/server/data/wikipedia/get_article.js
@@ -5,9 +5,9 @@ import { requests_ } from '#lib/requests'
 import { buildUrl } from '#lib/utils/url'
 import { normalizeSiteKey } from '#lib/wikimedia'
 
-export default params => {
+export async function getWikipediaArticle (params) {
   const { lang, title, introOnly } = params
-  const keyBase = introOnly ? 'wpextract' : 'wparticle'
+  const keyBase = introOnly ? 'wpextract' : 'wpwikitext'
   const key = `${keyBase}:${lang}:${title}`
   return cache_.get({
     key,
@@ -15,11 +15,30 @@ export default params => {
   })
 }
 
-const getArticle = async (lang, title, introOnly) => {
+async function getArticle (lang, title, introOnly) {
   const site = normalizeSiteKey(`${lang}wiki`)
   const url = getSitelinkUrl({ site, title })
   const { host } = new URL(url)
-  const queryUrl = apiQuery(host, title, introOnly)
+  if (introOnly) {
+    return getArticleIntroExtract({ host, title, lang, url })
+  } else {
+    return getArticleRawWikiText({ host, title, url })
+  }
+}
+
+async function getArticleIntroExtract ({ host, title, lang, url }) {
+  // doc:
+  // - https://en.wikipedia.org/w/api.php?action=help&modules=query
+  // - https://www.mediawiki.org/wiki/Extension:TextExtracts
+  const queryUrl = buildUrl(`https://${host}/w/api.php`, {
+    format: 'json',
+    action: 'query',
+    titles: title,
+    prop: 'extracts',
+    exintro: true,
+    // Return the article as plain text instead of html
+    explaintext: true,
+  })
   const { query } = await requests_.get(queryUrl)
   const { pages = [] } = query
   const extract = getCleanExtract(Object.values(pages))
@@ -31,28 +50,8 @@ const getArticle = async (lang, title, introOnly) => {
   }
 }
 
-const apiQuery = (host, title, introOnly) => {
-  // doc:
-  // - https://en.wikipedia.org/w/api.php?action=help&modules=query
-  // - https://www.mediawiki.org/wiki/Extension:TextExtracts
-  const queryObj = {
-    format: 'json',
-    action: 'query',
-    titles: title,
-    prop: 'extracts',
-    // Return the article as plain text instead of html
-    explaintext: true,
-  }
-
-  // Set exintro only if introOnly is true as any value
-  // will be interpreted as true
-  if (introOnly) queryObj.exintro = true
-
-  return buildUrl(`https://${host}/w/api.php`, queryObj)
-}
-
 // Commas between references aren't removed, thus the presence of aggregated commas
-const getCleanExtract = pages => {
+function getCleanExtract (pages) {
   const extract = pages?.[0]?.extract
   if (extract != null) {
     return extract
@@ -63,4 +62,10 @@ const getCleanExtract = pages => {
     // ex: https://fr.wikipedia.org/wiki/France
     .replaceAll('()', '')
   }
+}
+
+async function getArticleRawWikiText ({ host, title, url }) {
+  const rawArticleUrl = buildUrl(`https://${host}/w/index.php`, { title, action: 'raw' })
+  const rawArticle = await requests_.get(rawArticleUrl, { parseJson: false })
+  return { wikitext: rawArticle, url }
 }

--- a/server/lib/isbn/isbn.js
+++ b/server/lib/isbn/isbn.js
@@ -14,6 +14,10 @@ export const normalizeIsbn = text => {
 
 export const isNormalizedIsbn = text => /^(97(8|9))?\d{9}(\d|X)$/.test(text)
 
+// Generate a regex at every function call to be able to use g flag
+// see https://stackoverflow.com/questions/1520800/why-does-a-regexp-with-global-flag-give-wrong-results
+export const findIsbns = text => text.match(/(97(8|9))?[\d-]{9,14}([\dX])/g)
+
 export function looksLikeAnIsbn (text) {
   if (typeof text !== 'string') return false
   const cleanedText = normalizeIsbn(text)

--- a/server/lib/isbn/isbn.js
+++ b/server/lib/isbn/isbn.js
@@ -16,7 +16,10 @@ export const isNormalizedIsbn = text => /^(97(8|9))?\d{9}(\d|X)$/.test(text)
 
 // Generate a regex at every function call to be able to use g flag
 // see https://stackoverflow.com/questions/1520800/why-does-a-regexp-with-global-flag-give-wrong-results
-export const findIsbns = text => text.match(/(97(8|9))?[\d-]{9,14}([\dX])/g)
+export function findIsbns (text) {
+  const matches = text.match(/(97(8|9))?[\d-]{9,13}([\dX])/g) || []
+  return matches.map(normalizeIsbn).filter(isNormalizedIsbn)
+}
 
 export function looksLikeAnIsbn (text) {
   if (typeof text !== 'string') return false

--- a/server/lib/promises.js
+++ b/server/lib/promises.js
@@ -47,3 +47,8 @@ export const defer = () => {
     promise,
   }
 }
+
+export async function asyncFilter (array, testFn) {
+  const testsResults = await Promise.all(array.map(testFn))
+  return array.filter((_, index) => testsResults[index])
+}

--- a/tests/api/tasks/automerge.test.js
+++ b/tests/api/tasks/automerge.test.js
@@ -81,7 +81,7 @@ describe('tasks:automerge', () => {
     const wikidataUri = 'wd:Q259507'
     const humanLabel = 'bell hooks' // label from wd:Q259507
     const labels = { en: humanLabel }
-    const isbn = '978-0786825530' // should appear on https://en.wikipedia.org/wiki/Bell_hooks
+    const isbn = '978-0-89608-613-5' // should appear on https://en.wikipedia.org/wiki/Bell_hooks
 
     const human = await createHuman({ labels })
     // make sure edition is not already existing

--- a/tests/api/tasks/automerge.test.js
+++ b/tests/api/tasks/automerge.test.js
@@ -7,7 +7,7 @@ import { checkEntities } from '../utils/tasks.js'
 describe('tasks:automerge', () => {
   before(async () => {
     // Tests dependency: having a populated ElasticSearch wikidata index
-    const wikidataUris = [ 'wd:Q205739', 'wd:Q1748845', 'wd:Q2829704', 'wd:Q2300248' ]
+    const wikidataUris = [ 'wd:Q205739', 'wd:Q1748845', 'wd:Q2829704', 'wd:Q2300248', 'wd:Q259507' ]
     await findOrIndexEntities(wikidataUris)
   })
 
@@ -47,6 +47,17 @@ describe('tasks:automerge', () => {
     tasks.length.should.aboveOrEqual(1)
     const firstOccurenceMatch = tasks[0].externalSourcesOccurrences[0].matchedTitles[0]
     firstOccurenceMatch.should.equal(normalize(humanLabel))
+  })
+
+  it('should not automerge if work title found in unstructured data source is too short', async () => {
+    const humanLabel = 'Penelope Curtis' // wd:Q20630876
+    // string that should reasonably appear in a wikipedia article extract
+    const shortWorkLabel = 'The'
+    const human = await createHuman({ labels: { en: humanLabel } })
+    await createWorkWithAuthor(human, shortWorkLabel)
+    await checkEntities(human.uri)
+    const { entities } = await getByUris(human.uri)
+    entities[human.uri].should.be.ok()
   })
 })
 

--- a/tests/api/tasks/hooks.test.js
+++ b/tests/api/tasks/hooks.test.js
@@ -10,7 +10,7 @@ describe('tasks:hooks', () => {
     before(async () => {
       // Tests dependency: having a populated ElasticSearch wikidata index
       const wikidataUris = [
-        'wd:Q535', 'wd:Q54551995', // some Victor Hugos
+        'wd:Q535', 'wd:Q15339037', // some Victor Hugos
         'wd:Q3182477', 'wd:Q228024', // some John Smiths
         'wd:Q237087', // Fred Vargas
       ]


### PR DESCRIPTION
Adding two more criteria to the new tasks validations (happening when triggering `check-entities`)
It will ends up merging automatically more entities, and reduce the number of new tasks created.

- 6d3ad81 Merging based on WD structured data (external IDs claims). This could have been a maintenance sparql query, but automerge automates it nicely. Known case: inv entity had had an externalId before wd item
- d0ccd3e Merge if author's ISBNs appears in their related wikipedia article. This relies on cached wp page. The cost is to request author's graph to fetch isbns.