### PR TITLE
get Openlibrary summaries by ISBN

### DIFF
--- a/server/controllers/data/lib/summaries/bnf.js
+++ b/server/controllers/data/lib/summaries/bnf.js
@@ -14,16 +14,17 @@ export async function getBnfSummary ({ claims, refresh }) {
   }`
   const headers = { accept: '*/*' }
   const url = `https://data.bnf.fr/sparql?default-graph-uri=&format=json&timeout=${timeout}&query=${fixedEncodeURIComponent(sparql)}`
-  const text = await cache_.get({
+  const res = await cache_.get({
     key: `summary:${property}:${id}`,
     refresh,
     fn: async () => {
       const response = await requests_.get(url, { headers, timeout })
       const simplifiedResults = simplifySparqlResults(response)
-      return simplifiedResults[0]?.summary
+      return { text: simplifiedResults[0]?.summary }
     },
   })
-  if (text) {
+  if (res?.text) {
+    const { text } = res
     return {
       text,
       name: 'BNF',

--- a/server/controllers/data/lib/summaries/bnf.js
+++ b/server/controllers/data/lib/summaries/bnf.js
@@ -4,12 +4,14 @@ import { requests_ } from '#lib/requests'
 import { fixedEncodeURIComponent } from '#lib/utils/url'
 
 const timeout = 10 * 1000
+const property = 'wdt:P268'
 
-export default async ({ id, refresh }) => {
+export async function getBnfSummary ({ claims, refresh }) {
+  const id = claims[property]?.[0]
+  if (!id) return
   const sparql = `SELECT * {
     <http://data.bnf.fr/ark:/12148/cb${id}#about> <http://purl.org/dc/terms/abstract> ?summary .
   }`
-  const property = 'wdt:P268'
   const headers = { accept: '*/*' }
   const url = `https://data.bnf.fr/sparql?default-graph-uri=&format=json&timeout=${timeout}&query=${fixedEncodeURIComponent(sparql)}`
   const text = await cache_.get({
@@ -27,6 +29,8 @@ export default async ({ id, refresh }) => {
       name: 'BNF',
       link: `https://catalogue.bnf.fr/ark:/12148/cb${id}`,
       lang: 'fr',
+      key: 'wdt:P268',
+      claim: { id, property },
     }
   }
 }

--- a/server/controllers/data/lib/summaries/getters.js
+++ b/server/controllers/data/lib/summaries/getters.js
@@ -1,32 +1,24 @@
 import { logError } from '#lib/utils/logs'
-import bnf from './bnf.js'
-import { getOpenLibrarySummaryByIsbn, getOpenLibrarySummaryByOpenLibraryId } from './openlibrary.js'
+import { getBnfSummary } from './bnf.js'
+import { getOpenLibrarySummary } from './openlibrary.js'
 
-const summaryGettersByClaimProperty = {
-  'wdt:P212': getOpenLibrarySummaryByIsbn,
-  'wdt:P268': bnf,
-  'wdt:P648': getOpenLibrarySummaryByOpenLibraryId,
-}
+const getters = [
+  getBnfSummary,
+  getOpenLibrarySummary,
+]
 
-const propertiesWithGetters = Object.keys(summaryGettersByClaimProperty)
-
-const getSummaryFromPropertyClaims = ({ claims, refresh }) => async property => {
-  const id = claims[property]?.[0]
-  if (!id) return
+const getSummaryFromPropertyClaims = ({ claims, refresh }) => async getter => {
   let summaryData
   try {
-    summaryData = await summaryGettersByClaimProperty[property]({ id, refresh })
+    summaryData = await getter({ claims, refresh })
   } catch (err) {
-    err.context = { id, property }
+    err.context = { getter }
     logError(err, 'getSummaryFromPropertyClaims')
     return
   }
-  if (!summaryData) return
-  summaryData.key = property
-  summaryData.claim = { id, property }
   return summaryData
 }
 
-export const getSummariesFromClaims = async ({ claims, refresh }) => {
-  return Promise.all(propertiesWithGetters.map(getSummaryFromPropertyClaims({ claims, refresh })))
+export async function getSummariesFromClaims ({ claims, refresh }) {
+  return Promise.all(getters.map(getSummaryFromPropertyClaims({ claims, refresh })))
 }

--- a/server/controllers/data/lib/summaries/getters.js
+++ b/server/controllers/data/lib/summaries/getters.js
@@ -12,8 +12,10 @@ const getSummaryFromPropertyClaims = ({ claims, refresh }) => async getter => {
   try {
     summaryData = await getter({ claims, refresh })
   } catch (err) {
-    err.context = { getter }
-    logError(err, 'getSummaryFromPropertyClaims')
+    if (err.statusCode !== 404) {
+      err.context = { getter }
+      logError(err, 'getSummaryFromPropertyClaims')
+    }
     return
   }
   return summaryData

--- a/server/controllers/data/lib/summaries/getters.js
+++ b/server/controllers/data/lib/summaries/getters.js
@@ -1,10 +1,11 @@
 import { logError } from '#lib/utils/logs'
 import bnf from './bnf.js'
-import openlibrary from './openlibrary.js'
+import { getOpenLibrarySummaryByIsbn, getOpenLibrarySummaryByOpenLibraryId } from './openlibrary.js'
 
 const summaryGettersByClaimProperty = {
+  'wdt:P212': getOpenLibrarySummaryByIsbn,
   'wdt:P268': bnf,
-  'wdt:P648': openlibrary,
+  'wdt:P648': getOpenLibrarySummaryByOpenLibraryId,
 }
 
 const propertiesWithGetters = Object.keys(summaryGettersByClaimProperty)

--- a/server/controllers/data/lib/summaries/openlibrary.js
+++ b/server/controllers/data/lib/summaries/openlibrary.js
@@ -35,15 +35,22 @@ export async function getOpenLibrarySummary ({ claims, refresh }) {
     key: cacheKey,
     refresh,
     fn: async () => {
-      const { bio, description, languages } = await requests_.get(url, { timeout })
-      const text = bio || description
-      if (!text) return
-      let lang
-      if (languages?.[0]) lang = parseLanguage(languages[0])
-      if (text.value) {
-        return { text: text.value, lang }
-      } else if (typeof text === 'string') {
-        return { text, lang }
+      try {
+        const { bio, description, languages } = await requests_.get(url, { timeout })
+        const text = bio || description
+        if (!text) return
+        let lang
+        if (languages?.[0]) lang = parseLanguage(languages[0])
+        if (text.value) {
+          return { text: text.value, lang }
+        } else if (typeof text === 'string') {
+          return { text, lang }
+        }
+      } catch (err) {
+        if (err.statusCode === 404) return
+        // Prevent logging long HTML responses
+        if (err.body?.includes('<html')) err.body = '[HTML response]'
+        throw err
       }
     },
   })

--- a/server/controllers/data/lib/summaries/openlibrary.js
+++ b/server/controllers/data/lib/summaries/openlibrary.js
@@ -4,14 +4,32 @@ import { requests_ } from '#lib/requests'
 
 const timeout = 10 * 1000
 
-export async function getOpenLibrarySummaryByOpenLibraryId ({ id, refresh }) {
-  const lastLetter = id.slice(-1)[0]
-  const section = openLibrarySectionByLetter[lastLetter]
-  const link = `https://openlibrary.org/${section}/${id}`
-  const url = `${link}.json`
-  const property = 'wdt:P648'
+export async function getOpenLibrarySummary ({ claims, refresh }) {
+  const id = claims['wdt:P648']?.[0]
+  const isbn13h = claims['wdt:P212']?.[0]
+  let link, url, property, key, cacheKey, claim
+  if (id) {
+    const lastLetter = id.slice(-1)[0]
+    const section = openLibrarySectionByLetter[lastLetter]
+    link = `https://openlibrary.org/${section}/${id}`
+    url = `${link}.json`
+    property = 'wdt:P648'
+    key = property
+    cacheKey = `summary:${key}:${id}`
+    claim = { id, property }
+  } else if (isbn13h) {
+    const isbn13 = normalizeIsbn(isbn13h)
+    link = `https://openlibrary.org/isbn/${isbn13}`
+    url = `${link}.json`
+    property = 'wdt:P212'
+    key = `${property}:openlibrary`
+    cacheKey = `summary:${key}:${isbn13}`
+    claim = { id: isbn13h, property }
+  } else {
+    return
+  }
   const text = await cache_.get({
-    key: `summary:${property}:${id}`,
+    key: cacheKey,
     refresh,
     fn: async () => {
       const { bio, description } = await requests_.get(url, { timeout })
@@ -26,7 +44,9 @@ export async function getOpenLibrarySummaryByOpenLibraryId ({ id, refresh }) {
       text,
       name: 'OpenLibrary',
       link,
+      key,
       lang: 'en',
+      claim,
     }
   }
 }
@@ -35,29 +55,4 @@ const openLibrarySectionByLetter = {
   A: 'authors',
   W: 'works',
   M: 'books',
-}
-
-export async function getOpenLibrarySummaryByIsbn ({ id, refresh }) {
-  const isbn = normalizeIsbn(id)
-  const link = `https://openlibrary.org/isbn/${isbn}`
-  const url = `${link}.json`
-  const property = 'wdt:P212'
-  const text = await cache_.get({
-    key: `summary:${property}:ol:${isbn}`,
-    refresh,
-    fn: async () => {
-      const { description: text } = await requests_.get(url, { timeout })
-      if (!text) return
-      if (text.value) return text.value
-      else if (typeof text === 'string') return text
-    },
-  })
-  if (text) {
-    return {
-      text,
-      name: 'OpenLibrary',
-      link,
-      lang: 'en',
-    }
-  }
 }

--- a/tests/api/data/summaries.test.js
+++ b/tests/api/data/summaries.test.js
@@ -107,6 +107,20 @@ describe('summaries', () => {
       summaryData.link.should.equal(`https://openlibrary.org/isbn/${normalizeIsbn(isbn)}`)
       summaryData.lang.should.equal('en')
     })
+
+    it('should ignore unknown ISBNs', async () => {
+      const isbn = '978-99993-999-9-9'
+      const property = 'wdt:P212'
+      const edition = await existsOrCreate({
+        createFn: createEdition,
+        claims: {
+          [property]: [ isbn ],
+        },
+      })
+      const { uri } = edition
+      const { summaries } = await publicReq('get', `${endpoint}&uri=${uri}`)
+      summaries.length.should.equal(0)
+    })
   })
 
   describe('bnf', () => {

--- a/tests/api/data/summaries.test.js
+++ b/tests/api/data/summaries.test.js
@@ -83,8 +83,8 @@ describe('summaries', () => {
       })
       const { uri } = edition
       const { summaries } = await publicReq('get', `${endpoint}&uri=${uri}`)
-      const summaryData = summaries.find(summaryData => summaryData.key === property)
-      summaryData.key.should.equal(property)
+      const summaryData = summaries.find(summaryData => summaryData.key === 'wdt:P212:openlibrary')
+      summaryData.key.should.equal('wdt:P212:openlibrary')
       summaryData.text.should.startWith('According to Godin')
       summaryData.claim.id.should.equal(isbn)
       summaryData.claim.property.should.equal(property)

--- a/tests/api/data/summaries.test.js
+++ b/tests/api/data/summaries.test.js
@@ -38,6 +38,21 @@ describe('summaries', () => {
       summaryData.lang.should.equal('en')
     })
 
+    it('should detect summary language', async () => {
+      const olId = 'OL40222382M'
+      const work = await existsOrCreate({
+        createFn: createEdition,
+        claims: {
+
+          [property]: [ olId ],
+        },
+      })
+      const { uri } = work
+      const { summaries } = await publicReq('get', `${endpoint}&uri=${uri}`)
+      const summaryData = summaries.find(summaryData => summaryData.key === property)
+      summaryData.lang.should.equal('fr')
+    })
+
     it('should return empty summaries when no description is provided', async () => {
       const olId = 'OL4104668W'
       const work = await existsOrCreate({

--- a/tests/api/data/summaries.test.js
+++ b/tests/api/data/summaries.test.js
@@ -1,5 +1,6 @@
 import should from 'should'
 import { createWork, createEdition, createHuman } from '#fixtures/entities'
+import { normalizeIsbn } from '#lib/isbn/isbn'
 import { requests_ } from '#lib/requests'
 import { getByUri } from '#tests/api/utils/entities'
 import { shouldNotBeCalled } from '#tests/unit/utils'
@@ -69,6 +70,27 @@ describe('summaries', () => {
       const { summaries } = await publicReq('get', `${endpoint}&uri=${uri}`)
       const summaryData = summaries.find(summaryData => summaryData.key === property)
       summaryData.text.should.containEql('Pratchett')
+    })
+
+    it('should find summaries by ISBN', async () => {
+      const isbn = '978-1-59184-233-0'
+      const property = 'wdt:P212'
+      const edition = await existsOrCreate({
+        createFn: createEdition,
+        claims: {
+          [property]: [ isbn ],
+        },
+      })
+      const { uri } = edition
+      const { summaries } = await publicReq('get', `${endpoint}&uri=${uri}`)
+      const summaryData = summaries.find(summaryData => summaryData.key === property)
+      summaryData.key.should.equal(property)
+      summaryData.text.should.startWith('According to Godin')
+      summaryData.claim.id.should.equal(isbn)
+      summaryData.claim.property.should.equal(property)
+      summaryData.name.should.equal('OpenLibrary')
+      summaryData.link.should.equal(`https://openlibrary.org/isbn/${normalizeIsbn(isbn)}`)
+      summaryData.lang.should.equal('en')
     })
   })
 

--- a/tests/api/data/summaries.test.js
+++ b/tests/api/data/summaries.test.js
@@ -224,7 +224,11 @@ const existsOrCreate = async ({ claims, createFn = createWork }) => {
     const entity = await createFn({ claims })
     return entity
   } catch (err) {
-    const existingEntityUri = err.body.context.entity
-    return getByUri(existingEntityUri)
+    if (err.body.status_verbose === 'this property value is already used') {
+      const existingEntityUri = err.body.context.entity
+      return getByUri(existingEntityUri)
+    } else {
+      throw err
+    }
   }
 }

--- a/tests/api/utils/entities.js
+++ b/tests/api/utils/entities.js
@@ -22,9 +22,9 @@ export const getByUris = (uris, relatives, refresh) => {
   return publicReq('get', url)
 }
 
-export const getByUri = (uri, refresh) => {
-  return getByUris(uri, null, refresh)
-  .then(res => res.entities[uri])
+export async function getByUri (uri, refresh) {
+  const res = await getByUris(uri, null, refresh)
+  return Object.values(res.entities)[0]
 }
 
 export async function getEntitiesAttributesByUris ({ uris, attributes, relatives, refresh }) {


### PR DESCRIPTION
In the current implementation, OpenLibrary summaries are only fetched when there is a know OpenLibrary identifier, but summaries for editions could also be fetched by ISBN