### PR TITLE
get_entities_by_isbns: refresh seeds when requested

### DIFF
--- a/server/controllers/entities/lib/get_entities_by_isbns.js
+++ b/server/controllers/entities/lib/get_entities_by_isbns.js
@@ -1,7 +1,7 @@
 import { difference } from 'lodash-es'
 import { getInvEntitiesByIsbns } from '#controllers/entities/lib/entities'
 import { prefixifyIsbn } from '#controllers/entities/lib/prefix'
-import getResolvedEntry from '#data/dataseed/get_resolved_entry'
+import { enrichAndGetEditionEntityFromIsbn } from '#data/dataseed/enrich_and_get_edition_entity_from_isbn'
 import { parseIsbn } from '#lib/isbn/parse'
 import formatEditionEntity from './format_edition_entity.js'
 
@@ -10,7 +10,7 @@ export default async (rawIsbns, params = {}) => {
   const { autocreate, refresh } = params
   let entities
   if (autocreate && refresh) {
-    entities = await Promise.all(isbns.map(isbn => getResolvedEntry(isbn)))
+    entities = await Promise.all(isbns.map(isbn => enrichAndGetEditionEntityFromIsbn(isbn)))
   } else {
     entities = await getInvEntitiesByIsbns(isbns)
   }
@@ -27,7 +27,7 @@ export default async (rawIsbns, params = {}) => {
 
   // The cases where autocreate && refresh was already checked above
   if (autocreate && !refresh) {
-    const resolvedEditions = await Promise.all(missingIsbns.map(isbn => getResolvedEntry(isbn)))
+    const resolvedEditions = await Promise.all(missingIsbns.map(isbn => enrichAndGetEditionEntityFromIsbn(isbn)))
     const newEntities = []
     const notFound = []
     for (const resolvedEdition of resolvedEditions) {

--- a/server/controllers/entities/lib/get_entities_by_isbns.js
+++ b/server/controllers/entities/lib/get_entities_by_isbns.js
@@ -7,9 +7,13 @@ import formatEditionEntity from './format_edition_entity.js'
 
 export default async (rawIsbns, params = {}) => {
   const [ isbns, redirections ] = getRedirections(rawIsbns)
-  const { autocreate } = params
-  // search entities by isbn locally
-  let entities = await getInvEntitiesByIsbns(isbns)
+  const { autocreate, refresh } = params
+  let entities
+  if (autocreate && refresh) {
+    entities = await Promise.all(isbns.map(isbn => getResolvedEntry(isbn)))
+  } else {
+    entities = await getInvEntitiesByIsbns(isbns)
+  }
   const foundIsbns = entities.map(getIsbn13h)
   const missingIsbns = difference(isbns, foundIsbns)
 
@@ -21,7 +25,8 @@ export default async (rawIsbns, params = {}) => {
   }
   const results = { entities }
 
-  if (autocreate) {
+  // The cases where autocreate && refresh was already checked above
+  if (autocreate && !refresh) {
     const resolvedEditions = await Promise.all(missingIsbns.map(isbn => getResolvedEntry(isbn)))
     const newEntities = []
     const notFound = []

--- a/server/controllers/entities/lib/resolver/create_entity_from_seed.js
+++ b/server/controllers/entities/lib/resolver/create_entity_from_seed.js
@@ -44,6 +44,9 @@ export async function createEdition (edition, works, userId, batchId, enrich) {
     const title = buildBestEditionTitle(edition, works)
     edition.claims['wdt:P1476'] = [ title ]
   }
+  if (edition.claims['wdt:P1476']?.[0] && !edition.claims['wdt:P1680']) {
+    extractSubtitleFromTitle(edition.claims)
+  }
 
   // garantee that an edition shall not have label
   edition.labels = {}
@@ -117,3 +120,15 @@ const guessEditionTitleFromWorksLabels = works => {
   .join(' - ')
   .value()
 }
+
+function extractSubtitleFromTitle (claims) {
+  let title = claims['wdt:P1476'][0]
+  let subtitle
+  if (title.length > 10 && title.split(subtitleSeparator).length === 2) {
+    [ title, subtitle ] = title.split(subtitleSeparator)
+    claims['wdt:P1476'] = [ title.trim() ]
+    claims['wdt:P1680'] = [ subtitle.trim() ]
+  }
+}
+
+const subtitleSeparator = /[-—:] /

--- a/server/controllers/entities/lib/resolver/helpers.js
+++ b/server/controllers/entities/lib/resolver/helpers.js
@@ -1,5 +1,6 @@
+import ASCIIFolder from 'fold-to-ascii'
 import { compact, map } from 'lodash-es'
-import { someMatch } from '#lib/utils/base'
+import { someMatch, normalizeString } from '#lib/utils/base'
 import { getEntityNormalizedTerms } from '../terms_normalization.js'
 
 export const getAlreadyResolvedUris = seed => compact(map(seed, 'uri'))
@@ -24,4 +25,8 @@ export const resolveSeed = (seed, expectedEntityType) => entities => {
     }
   }
   return seed
+}
+
+export const normalizeTitle = title => {
+  if (title) return ASCIIFolder.foldMaintaining(normalizeString(title)).toLowerCase()
 }

--- a/server/controllers/entities/lib/resolver/resolve_edition_from_works.js
+++ b/server/controllers/entities/lib/resolver/resolve_edition_from_works.js
@@ -1,7 +1,6 @@
-import ASCIIFolder from 'fold-to-ascii'
 import { getInvEntitiesByClaim } from '#controllers/entities/lib/entities'
 import getInvEntityCanonicalUri from '#controllers/entities/lib/get_inv_entity_canonical_uri'
-import { normalizeString } from '#lib/utils/base'
+import { normalizeTitle } from '#controllers/entities/lib/resolver/helpers'
 
 export default async (editionSeed, worksSeeds) => {
   if (editionSeed.uri) return
@@ -30,8 +29,7 @@ const isMatchingEdition = (editionSeed, editionSeedTitle) => edition => {
 
 const getNormalizedTitle = ({ claims }) => {
   const title = claims['wdt:P1476']?.[0]
-  if (!title) return
-  return ASCIIFolder.foldMaintaining(normalizeString(title)).toLowerCase()
+  if (title) return normalizeTitle(title)
 }
 
 const editionSeedHasNoContradictingClaim = (editionSeed, edition) => {

--- a/server/data/dataseed/enrich_and_get_edition_entity_from_isbn.js
+++ b/server/data/dataseed/enrich_and_get_edition_entity_from_isbn.js
@@ -26,34 +26,34 @@ const importCircularDependencies = async () => {
 }
 setImmediate(importCircularDependencies)
 
-const getResolvedEntry = async isbn => {
+const _enrichAndGetEditionEntityFromIsbn = async isbn => {
   try {
     const entry = await getAuthoritiesAggregatedEntry(isbn)
     if (entry) {
-      const entity = await getEditionEntityFromEntry(entry)
+      const entity = await enrichAndGetEditionEntityFromEntry(entry)
       if (entity) return entity
     }
     if (dataseedEnabled) {
       const [ seed ] = await getSeedsByIsbns(isbn)
       if (seed?.title) {
         const dataseedEntry = await buildEntry(seed)
-        const entity = await getEditionEntityFromEntry(dataseedEntry)
+        const entity = await enrichAndGetEditionEntityFromEntry(dataseedEntry)
         if (entity) return entity
         return dataseedEntry
       }
     }
   } catch (err) {
-    logError(err, 'get_resolved_entry error')
+    logError(err, 'enrich_and_get_edition_entity_from_isbn error')
   }
   return { isbn, notFound: true }
 }
 
-export default temporarilyMemoize({
-  fn: getResolvedEntry,
+export const enrichAndGetEditionEntityFromIsbn = temporarilyMemoize({
+  fn: _enrichAndGetEditionEntityFromIsbn,
   ttlAfterFunctionCallReturned: 2000,
 })
 
-const getEditionEntityFromEntry = async entry => {
+const enrichAndGetEditionEntityFromEntry = async entry => {
   const { resolvedEntries } = await resolveUpdateAndCreate({ entries: [ entry ], ...resolverParams })
   const [ resolvedEntry ] = resolvedEntries
   if (resolvedEntry) {

--- a/server/data/dataseed/get_authorities_aggregated_entry.js
+++ b/server/data/dataseed/get_authorities_aggregated_entry.js
@@ -8,6 +8,8 @@ import bnf from '#data/bnf/get_bnf_entry_from_isbn'
 import openlibrary from '#data/openlibrary/get_openlibrary_entry_from_isbn'
 import wikidata from '#data/wikidata/get_wikidata_entry_from_isbn'
 import { isNonEmptyArray } from '#lib/boolean_validations'
+import { cache_ } from '#lib/cache'
+import { oneMonth } from '#lib/time'
 import { isNotEmpty, objLength } from '#lib/utils/base'
 import { logError } from '#lib/utils/logs'
 
@@ -31,7 +33,11 @@ export async function getAuthoritiesAggregatedEntry (isbn) {
 
 const wrap = isbn => async name => {
   try {
-    return await authorities[name](isbn)
+    return await cache_.get({
+      key: `seed:${name}:${isbn}`,
+      fn: () => authorities[name](isbn),
+      ttl: oneMonth,
+    })
   } catch (err) {
     logError(err, `${name} entry error`)
   }

--- a/tests/api/entities/resolver/resolve_and_create.test.js
+++ b/tests/api/entities/resolver/resolve_and_create.test.js
@@ -9,7 +9,7 @@ import {
   createWork,
 } from '#fixtures/entities'
 import { humanName } from '#fixtures/text'
-import { getByUris, getHistory } from '#tests/api/utils/entities'
+import { getByUri, getByUris, getHistory } from '#tests/api/utils/entities'
 import { authReq } from '#tests/api/utils/utils'
 import { shouldNotBeCalled } from '#tests/unit/utils'
 
@@ -57,6 +57,19 @@ describe('entities:resolve:create-unresolved', () => {
 
     should(editionClaims['wdt:P212'][0]).be.ok()
     newEditionTitle.should.equal(editionLabel)
+  })
+
+  it('should extract the subtitle from the title when meaningful', async () => {
+    const title = randomLabel()
+    const subtitle = randomLabel()
+    const { entries } = await resolveAndCreate({
+      edition: { isbn: generateIsbn13(), claims: { 'wdt:P1476': `${title} - ${subtitle}` } },
+      works: [ { labels: { en: title } } ],
+    })
+    const { uri } = entries[0].edition
+    const edition = await getByUri(uri)
+    edition.claims['wdt:P1476'][0].should.equal(title)
+    edition.claims['wdt:P1680'][0].should.equal(subtitle)
   })
 
   it('should create an edition with a title and no isbn', async () => {

--- a/tests/integration/data/enrich_and_get_edition_entity_from_isbn.test.js
+++ b/tests/integration/data/enrich_and_get_edition_entity_from_isbn.test.js
@@ -1,19 +1,19 @@
 import 'should'
 import { getEntityByUri } from '#controllers/entities/lib/get_entity_by_uri'
-import getResolvedEntry from '#data/dataseed/get_resolved_entry'
+import { enrichAndGetEditionEntityFromIsbn } from '#data/dataseed/enrich_and_get_edition_entity_from_isbn'
 
 describe('get resolved seed', () => {
   it('should get an edition entity when only one authority returns a seed', async () => {
     // Expect only BNF to return a seed. If that's not the case, you can find new candidates with
     // https://query.inventaire.io/#SELECT%20%2a%20%7B%0A%20%20%3Fitem%20wdt%3AP268%20%3FbnfId%20.%0A%20%20%3Fitem%20wdt%3AP629%20%3Fwork%20.%0A%20%20FILTER%20NOT%20EXISTS%20%7B%20%3Fwork%20wdt%3AP31%20%3Ftype%20%7D%20.%0A%20%20%3Fitem%20wdt%3AP212%20%3Fisbn%20.%0A%20%20%3Fitem%20wdt%3AP577%20%3Fdate%20.%0A%7D%0AORDER%20BY%20%3Fdate
-    const edition = await getResolvedEntry('978-0-316-76953-2')
+    const edition = await enrichAndGetEditionEntityFromIsbn('978-0-316-76953-2')
     edition.claims['wdt:P629'].should.deepEqual([ 'wd:Q183883' ])
     edition.claims['wdt:P268'].should.deepEqual([ '37461803r' ])
   })
 
   it('should get an edition entity when multiple authorities return a seed', async () => {
     // Expect both BNE and BNF to return seeds
-    const edition = await getResolvedEntry('84-00-06759-2')
+    const edition = await enrichAndGetEditionEntityFromIsbn('84-00-06759-2')
     // with the BNF seed to be considered more resolved, and thus be selected
     edition.claims['wdt:P268'].should.deepEqual([ '43031012r' ])
     const workUri = edition.claims['wdt:P629'][0]
@@ -28,18 +28,18 @@ describe('get resolved seed', () => {
   })
 
   it('should not get an entry from an unknown ISBN', async () => {
-    const edition = await getResolvedEntry('978-3-9818987-4-3')
+    const edition = await enrichAndGetEditionEntityFromIsbn('978-3-9818987-4-3')
     edition.notFound.should.be.true()
   })
 
   it('should get an edition from an ISBN found on Wikidata', async () => {
     // Expect the following triple to exist: wd:Q154763 wdt:P212 "978-85-359-1404-7"
-    const edition = await getResolvedEntry('978-85-359-1404-7')
+    const edition = await enrichAndGetEditionEntityFromIsbn('978-85-359-1404-7')
     edition.claims['wdt:P629'].should.deepEqual([ 'wd:Q154763' ])
   })
 
   it('should create local entity when resolved entity has an unknown type', async () => {
-    const edition = await getResolvedEntry('978-88-7799-292-5')
+    const edition = await enrichAndGetEditionEntityFromIsbn('978-88-7799-292-5')
     // BNF finds that the work is wd:Q238476, which is not identified
     // as a work by server/controllers/entities/lib/get_entity_type.js
     // wd:Q238476 should thus be discarded and an new inv entity should be set as wdt:P629

--- a/tests/integration/data/enrich_and_get_edition_entity_from_isbn.test.js
+++ b/tests/integration/data/enrich_and_get_edition_entity_from_isbn.test.js
@@ -1,8 +1,12 @@
 import 'should'
 import { getEntityByUri } from '#controllers/entities/lib/get_entity_by_uri'
 import { enrichAndGetEditionEntityFromIsbn } from '#data/dataseed/enrich_and_get_edition_entity_from_isbn'
+import { wait } from '#lib/promises'
 
 describe('get resolved seed', () => {
+  // Give the time to importCircularDependencies to run
+  before(async () => await wait(1000))
+
   it('should get an edition entity when only one authority returns a seed', async () => {
     // Expect only BNF to return a seed. If that's not the case, you can find new candidates with
     // https://query.inventaire.io/#SELECT%20%2a%20%7B%0A%20%20%3Fitem%20wdt%3AP268%20%3FbnfId%20.%0A%20%20%3Fitem%20wdt%3AP629%20%3Fwork%20.%0A%20%20FILTER%20NOT%20EXISTS%20%7B%20%3Fwork%20wdt%3AP31%20%3Ftype%20%7D%20.%0A%20%20%3Fitem%20wdt%3AP212%20%3Fisbn%20.%0A%20%20%3Fitem%20wdt%3AP577%20%3Fdate%20.%0A%7D%0AORDER%20BY%20%3Fdate


### PR DESCRIPTION
Currently, external databases (aka authorities) are checked when there is no entity in the local database for a given ISBN. The proposed change would be to re-check those external databases for existing edition entities when requested, that is when `autocreate=true&refresh=true`.

Writing a test is unfortunately not so straight forward, as you would need to create an edition/work/author with the right labels, so that the resolver can confidently update those entities. But as I expect it to become a popular feature from data admins, I'm sure we will notice if this breaks somehow ;)

Client PR https://github.com/inventaire/inventaire-client/pull/482