### PR TITLE
Listing entities type

### DIFF
--- a/server/controllers/listings/create.ts
+++ b/server/controllers/listings/create.ts
@@ -10,6 +10,11 @@ const sanitization = {
     optional: true,
     default: [],
   },
+  type: {
+    allowlist: [ 'work' ],
+    optional: true,
+    default: 'work',
+  },
 }
 
 async function controller (params: SanitizedParameters, req: AuthentifiedReq) {

--- a/server/controllers/listings/create.ts
+++ b/server/controllers/listings/create.ts
@@ -1,7 +1,10 @@
 import { createListing } from '#controllers/listings/lib/listings'
 import { checkSpamContent } from '#controllers/user/lib/spam'
+import listingAttributes from '#models/attributes/listing'
 import type { SanitizedParameters } from '#types/controllers_input_sanitization_parameters'
 import type { AuthentifiedReq } from '#types/server'
+
+const { type: listingTypes } = listingAttributes
 
 const sanitization = {
   name: {},
@@ -11,7 +14,7 @@ const sanitization = {
     default: [],
   },
   type: {
-    allowlist: [ 'work' ],
+    allowlist: listingTypes,
     optional: true,
     default: 'work',
   },
@@ -24,12 +27,13 @@ async function controller (params: SanitizedParameters, req: AuthentifiedReq) {
 }
 
 function formatNewListing (params) {
-  const { name, description, visibility, reqUserId: creator } = params
+  const { name, description, visibility, type, reqUserId: creator } = params
   const listingData = {
     name,
     description,
     visibility,
     creator,
+    type,
   }
   return createListing(listingData)
 }

--- a/server/controllers/listings/lib/listings.ts
+++ b/server/controllers/listings/lib/listings.ts
@@ -14,7 +14,7 @@ import type { EntityUri } from '#types/entity'
 import type { Listing, ListingId, ListingWithElements } from '#types/listing'
 import type { UserId } from '#types/user'
 
-const { updatable: updateAttributes } = listingAttributes
+const { updatable: updateAttributes, entityTypesByListingType } = listingAttributes
 
 const db = await dbFactory('lists')
 
@@ -102,7 +102,10 @@ export async function deleteUserListingsAndElements (userId: UserId) {
 
 async function validateEntitiesCanBeAdded (uris: EntityUri[], listingType) {
   const { notFound, entities } = await getEntitiesByUris({ uris })
-  const wrongTypeEntity = Object.values(entities).find(entity => entity.type !== listingType)
+  const allowlistedEntityTypes = entityTypesByListingType[listingType]
+  const wrongTypeEntity = Object.values(entities).find(entity => {
+    return !allowlistedEntityTypes.includes(entity.type)
+  })
   if (wrongTypeEntity !== undefined) {
     const { uri, type } = wrongTypeEntity
     throw newError('cannot add this entity type to this list', 403, { listingType, entityType: type, uri })

--- a/server/models/attributes/listing.ts
+++ b/server/models/attributes/listing.ts
@@ -10,5 +10,8 @@ export default {
     'creator',
     'type',
   ]),
-  type: [ 'work' ],
+  type: [ 'work', 'serie' ],
+  entityTypesByListingType: {
+    work: [ 'work', 'serie' ],
+  },
 }

--- a/server/models/attributes/listing.ts
+++ b/server/models/attributes/listing.ts
@@ -8,5 +8,7 @@ export default {
   updatable,
   validAtCreation: updatable.concat([
     'creator',
+    'type',
   ]),
+  type: [ 'work' ],
 }

--- a/server/models/attributes/listing.ts
+++ b/server/models/attributes/listing.ts
@@ -4,16 +4,18 @@ const updatable = [
   'name',
 ]
 
+const entityTypesByListingType = {
+  work: [ 'work', 'serie' ],
+  author: [ 'human' ],
+  publisher: [ 'publisher' ],
+}
+
 export default {
   updatable,
   validAtCreation: updatable.concat([
     'creator',
     'type',
   ]),
-  type: [ 'work', 'author', 'publisher' ],
-  entityTypesByListingType: {
-    work: [ 'work', 'serie' ],
-    author: [ 'human' ],
-    publisher: [ 'publisher' ],
-  },
+  type: Object.keys(entityTypesByListingType),
+  entityTypesByListingType,
 }

--- a/server/models/attributes/listing.ts
+++ b/server/models/attributes/listing.ts
@@ -10,8 +10,10 @@ export default {
     'creator',
     'type',
   ]),
-  type: [ 'work', 'serie' ],
+  type: [ 'work', 'author', 'publisher' ],
   entityTypesByListingType: {
     work: [ 'work', 'serie' ],
+    author: [ 'human' ],
+    publisher: [ 'publisher' ],
   },
 }

--- a/server/models/listing.ts
+++ b/server/models/listing.ts
@@ -10,6 +10,7 @@ export function createListingDoc (listing) {
   assert_.string(listing.creator)
   assert_.string(listing.name)
 
+  listing.type ??= 'work'
   const newListing: Partial<Listing> = {}
   Object.keys(listing).forEach(key => {
     const value = listing[key] || defaultValues[key]

--- a/server/models/validations/listing.ts
+++ b/server/models/validations/listing.ts
@@ -1,4 +1,5 @@
 import { isVisibilityKeyArray } from '#models/validations/visibility'
+import attributes from '../attributes/listing.js'
 import commonValidations from './common.js'
 
 const { pass, BoundedString, userId } = commonValidations
@@ -9,6 +10,7 @@ const listingsValidations = {
   visibility: isVisibilityKeyArray,
   creator: userId,
   name: BoundedString(0, 128),
+  type: type => attributes.type.includes(type),
 }
 
 export default listingsValidations

--- a/server/types/listing.ts
+++ b/server/types/listing.ts
@@ -1,3 +1,4 @@
+import type listingAttributes from '#models/attributes/listing'
 import type { CouchDoc, CouchUuid } from '#types/couchdb'
 import type { ListingElement } from '#types/element'
 import type { UserId } from '#types/user'
@@ -5,8 +6,11 @@ import type { VisibilityKey } from '#types/visibility'
 
 export type ListingId = CouchUuid
 
+export type ListingType = keyof typeof listingAttributes.type
+
 export interface Listing extends CouchDoc {
   _id: ListingId
+  type: ListingType
   name: string
   description?: string
   creator: UserId

--- a/tests/api/listings/add_elements.test.ts
+++ b/tests/api/listings/add_elements.test.ts
@@ -1,5 +1,5 @@
 import { map, uniq } from 'lodash-es'
-import { createEdition, someFakeUri, createHuman } from '#fixtures/entities'
+import { createEdition, someFakeUri, createHuman, createSerie} from '#fixtures/entities'
 import { createListing, createElement } from '#fixtures/listings'
 import { getByIdWithElements } from '#tests/api/utils/listings'
 import { getUserB, authReq } from '#tests/api/utils/utils'
@@ -131,5 +131,16 @@ describe('listings:add-elements', () => {
     })
     const updatedListing = await getByIdWithElements({ id: listing._id })
     updatedListing.elements.length.should.equal(0)
+  })
+
+  it('should add a serie to a work listing', async () => {
+    const { listing } = await createListing()
+    const { uri } = await createSerie()
+    await authReq('post', `${endpoint}add-elements`, {
+      id: listing._id,
+      uris: [ uri ],
+    })
+    const updatedListing = await getByIdWithElements({ id: listing._id })
+    updatedListing.elements.length.should.equal(1)
   })
 })

--- a/tests/api/listings/add_elements.test.ts
+++ b/tests/api/listings/add_elements.test.ts
@@ -1,5 +1,5 @@
 import { map, uniq } from 'lodash-es'
-import { createEdition, someFakeUri, createHuman, createSerie} from '#fixtures/entities'
+import { createWork, someFakeUri, createHuman, createSerie } from '#fixtures/entities'
 import { createListing, createElement } from '#fixtures/listings'
 import { getByIdWithElements } from '#tests/api/utils/listings'
 import { getUserB, authReq } from '#tests/api/utils/utils'
@@ -49,12 +49,12 @@ describe('listings:add-elements', () => {
 
   it('should add uri and create element', async () => {
     const { listing } = await createListing()
-    const { uri } = await createEdition()
+    const { uri } = await createWork()
     await authReq('post', `${endpoint}add-elements`, {
       id: listing._id,
       uris: [ uri ],
     })
-    const { uri: uri2 } = await createEdition()
+    const { uri: uri2 } = await createWork()
     await authReq('post', `${endpoint}add-elements`, {
       id: listing._id,
       uris: [ uri2 ],
@@ -81,7 +81,7 @@ describe('listings:add-elements', () => {
   it('should reject adding an element to a listing of another creator', async () => {
     try {
       const { listing } = await createListing(getUserB())
-      const { uri } = await createEdition()
+      const { uri } = await createWork()
       await authReq('post', `${endpoint}add-elements`, {
         id: listing._id,
         uris: [ uri ],
@@ -97,10 +97,10 @@ describe('listings:add-elements', () => {
   it('should give different ordinals to multiple elements created at the same time', async () => {
     const { listing } = await createListing()
     const editions = await Promise.all([
-      createEdition(),
-      createEdition(),
-      createEdition(),
-      createEdition(),
+      createWork(),
+      createWork(),
+      createWork(),
+      createWork(),
     ])
     const uris = map(editions, 'uri')
     await authReq('post', `${endpoint}add-elements`, {

--- a/tests/api/listings/create.test.ts
+++ b/tests/api/listings/create.test.ts
@@ -29,14 +29,14 @@ describe('listings:create', () => {
     }
   })
 
-  it('should default to private visibility', async () => {
-    const name = listingName()
-    const { list: listing } = await authReq('post', endpoint, { name })
-    listing.visibility.should.deepEqual([])
-    listing.name.should.equal(name)
-  })
-
   describe('visibility', () => {
+    it('should default to private visibility', async () => {
+      const name = listingName()
+      const { list: listing } = await authReq('post', endpoint, { name })
+      listing.visibility.should.deepEqual([])
+      listing.name.should.equal(name)
+    })
+
     it('should create a listing with friends-only visibility', async () => {
       const visibility = [ 'friends' ]
       const { list: listing } = await authReq('post', endpoint, { name: listingName(), visibility })
@@ -68,6 +68,13 @@ describe('listings:create', () => {
         err.statusCode.should.equal(400)
         err.body.status_verbose.should.equal('user is not in that group')
       })
+    })
+  })
+
+  describe('entities type', () => {
+    it('should default to work type', async () => {
+      const { list: listing } = await authReq('post', endpoint, { name: listingName() })
+      listing.type.should.equal('work')
     })
   })
 })

--- a/tests/api/listings/create.test.ts
+++ b/tests/api/listings/create.test.ts
@@ -76,5 +76,13 @@ describe('listings:create', () => {
       const { list: listing } = await authReq('post', endpoint, { name: listingName() })
       listing.type.should.equal('work')
     })
+
+    it('should create listing with author type', async () => {
+      const { list: listing } = await authReq('post', endpoint, {
+        name: listingName(),
+        type: 'author',
+      })
+      listing.type.should.equal('author')
+    })
   })
 })


### PR DESCRIPTION
Add a `type` key (maybe `entitiesType` is more DSL friendly?) on Listing model.

Solves issue #716
client PR [502](https://github.com/inventaire/inventaire-client/pull/502)