### PR TITLE
Allow the resolver to update Wikidata entities

### DIFF
--- a/config/default.cjs
+++ b/config/default.cjs
@@ -217,12 +217,23 @@ const config = {
 
   deduplicateRequests: true,
 
+  // Keys for users OAuth
   // Doc: https://www.mediawiki.org/wiki/OAuth/For_Developers
   // Request tokens at
   // https://meta.wikimedia.org/wiki/Special:OAuthConsumerRegistration/propose
   wikidataOAuth: {
     consumer_key: 'your-consumer-key',
     consumer_secret: 'your-consumer-secret',
+  },
+
+  // Keys for server own OAuth, used to let the server perform automated edits on Wikidata
+  // Request tokens at
+  // https://meta.wikimedia.org/wiki/Special:OAuthConsumerRegistration/propose?wpownerOnly=1
+  botAccountWikidataOAuth: {
+    consumer_key: 'your-consumer-key',
+    consumer_secret: 'your-consumer-secret',
+    token: 'your-access-key',
+    token_secret: 'your-access-secret',
   },
 
   snapshotsDebounceTime: 5000,

--- a/config/default.cjs
+++ b/config/default.cjs
@@ -236,6 +236,10 @@ const config = {
     token_secret: 'your-access-secret',
   },
 
+  wikidataEdit: {
+    maxlag: undefined,
+  },
+
   snapshotsDebounceTime: 5000,
 
   jobs: {

--- a/config/production-alt.cjs
+++ b/config/production-alt.cjs
@@ -40,6 +40,11 @@ const config = {
   dataseed: {
     enabled: false,
   },
+
+  wikidataEdit: {
+    // Bots requests triggering Wikidata edits can be patient
+    maxlag: 5,
+  },
 }
 
 module.exports = config

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "turtle-validator": "^1.0.2",
         "type-fest": "^4.21.0",
         "typescript": "^5.6.2",
-        "wikibase-edit": "^5.3.2",
+        "wikibase-edit": "^7.2.0",
         "wikibase-sdk": "^10.2.1",
         "wikidata-lang": "^4.1.2"
       },
@@ -1962,14 +1962,6 @@
       "version": "2.11.0",
       "license": "MIT"
     },
-    "node_modules/cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
-      "dependencies": {
-        "node-fetch": "2.6.7"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "4.0.2",
       "license": "MIT",
@@ -1979,7 +1971,9 @@
       }
     },
     "node_modules/crypto-js": {
-      "version": "3.3.0",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
       "license": "MIT"
     },
     "node_modules/dashdash": {
@@ -6583,26 +6577,18 @@
       }
     },
     "node_modules/wikibase-edit": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/wikibase-edit/-/wikibase-edit-5.3.3.tgz",
-      "integrity": "sha512-AguiYFDe+Rb1YMbhFdqzFw4jdy3gOv/d0CYcKQ2MNC79fSibBoDZ9wJWgkhxx3nxKjBBtz5EQyL4SOVCYcH2zw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/wikibase-edit/-/wikibase-edit-7.2.0.tgz",
+      "integrity": "sha512-FwFgZ91nL6hrpJyAk/sc4vroJV/r7hBnORlqxfavhdjqxFSTIPEAaV+Fo/XJIbsuB/6d5kE60ARRkLszIcRMNw==",
+      "license": "MIT",
       "dependencies": {
-        "cross-fetch": "^3.0.4",
-        "crypto-js": "^3.1.9-1",
+        "crypto-js": "^4.1.1",
         "lodash.isequal": "^4.5.0",
         "oauth-1.0a": "^2.2.6",
-        "wikibase-sdk": "^8.0.0"
+        "wikibase-sdk": "^10.1.0"
       },
       "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/wikibase-edit/node_modules/wikibase-sdk": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/wikibase-sdk/-/wikibase-sdk-8.1.1.tgz",
-      "integrity": "sha512-1NjMnfNQ4OaLh0dFAeTMvV3vGAq6HXsNKGfYUJYOVyBPGBDMunlY3QZ8+72hLV5FiKmc6Bzg1xbI0jCHfHmIew==",
-      "engines": {
-        "node": ">= 10.0.0"
+        "node": ">= 18"
       }
     },
     "node_modules/wikibase-sdk": {
@@ -7955,14 +7941,6 @@
         }
       }
     },
-    "cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
-      "requires": {
-        "node-fetch": "2.6.7"
-      }
-    },
     "cross-spawn": {
       "version": "4.0.2",
       "requires": {
@@ -7971,7 +7949,9 @@
       }
     },
     "crypto-js": {
-      "version": "3.3.0"
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "dashdash": {
       "version": "1.14.1",
@@ -11248,22 +11228,14 @@
       }
     },
     "wikibase-edit": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/wikibase-edit/-/wikibase-edit-5.3.3.tgz",
-      "integrity": "sha512-AguiYFDe+Rb1YMbhFdqzFw4jdy3gOv/d0CYcKQ2MNC79fSibBoDZ9wJWgkhxx3nxKjBBtz5EQyL4SOVCYcH2zw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/wikibase-edit/-/wikibase-edit-7.2.0.tgz",
+      "integrity": "sha512-FwFgZ91nL6hrpJyAk/sc4vroJV/r7hBnORlqxfavhdjqxFSTIPEAaV+Fo/XJIbsuB/6d5kE60ARRkLszIcRMNw==",
       "requires": {
-        "cross-fetch": "^3.0.4",
-        "crypto-js": "^3.1.9-1",
+        "crypto-js": "^4.1.1",
         "lodash.isequal": "^4.5.0",
         "oauth-1.0a": "^2.2.6",
-        "wikibase-sdk": "^8.0.0"
-      },
-      "dependencies": {
-        "wikibase-sdk": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/wikibase-sdk/-/wikibase-sdk-8.1.1.tgz",
-          "integrity": "sha512-1NjMnfNQ4OaLh0dFAeTMvV3vGAq6HXsNKGfYUJYOVyBPGBDMunlY3QZ8+72hLV5FiKmc6Bzg1xbI0jCHfHmIew=="
-        }
+        "wikibase-sdk": "^10.1.0"
       }
     },
     "wikibase-sdk": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "turtle-validator": "^1.0.2",
     "type-fest": "^4.21.0",
     "typescript": "^5.6.2",
-    "wikibase-edit": "^5.3.2",
+    "wikibase-edit": "^7.2.0",
     "wikibase-sdk": "^10.2.1",
     "wikidata-lang": "^4.1.2"
   },

--- a/server/controllers/entities/lib/move_to_wikidata.ts
+++ b/server/controllers/entities/lib/move_to_wikidata.ts
@@ -1,13 +1,14 @@
-import { omitBy, uniq } from 'lodash-es'
+import { uniq } from 'lodash-es'
 import { getEntityById } from '#controllers/entities/lib/entities'
 import { getEntityByUri } from '#controllers/entities/lib/get_entity_by_uri'
 import { getInvEntityType } from '#controllers/entities/lib/get_entity_type'
 import { getPublicationYear } from '#controllers/entities/lib/get_publisher_publications'
 import { expandInvClaims, getClaimValue, getFirstClaimValue } from '#controllers/entities/lib/inv_claims_utils'
 import { resolveExternalIds } from '#controllers/entities/lib/resolver/resolve_external_ids'
+import { omitLocalClaims } from '#controllers/entities/lib/update_wd_claim'
 import { getWikidataOAuthCredentials } from '#controllers/entities/lib/wikidata_oauth'
 import { temporarilyOverrideWdIdAndIsbnCache } from '#data/wikidata/get_wd_entities_by_isbns'
-import { isInvPropertyUri, isNonEmptyArray } from '#lib/boolean_validations'
+import { isNonEmptyArray } from '#lib/boolean_validations'
 import { newError } from '#lib/error/error'
 import { normalizeIsbn } from '#lib/isbn/isbn'
 import { logError } from '#lib/utils/logs'
@@ -68,7 +69,7 @@ export async function moveInvEntityToWikidata (user: User, invEntityUri: InvEnti
   const descriptions = buildDescriptions(claims)
 
   // Local claims will be preserved in a local layer during merge
-  const claimsWithoutLocalClaims = omitBy(claims, (propertyClaims, property) => isInvPropertyUri(property))
+  const claimsWithoutLocalClaims = omitLocalClaims(claims)
   const { uri: wdEntityUri } = await createWdEntity({
     labels,
     descriptions,

--- a/server/controllers/entities/lib/resolver/resolve_edition.ts
+++ b/server/controllers/entities/lib/resolver/resolve_edition.ts
@@ -1,9 +1,8 @@
 import { getEntitiesByIsbns } from '#controllers/entities/lib/get_entities_by_isbns'
+import { getEntityByUri } from '#controllers/entities/lib/get_entity_by_uri'
+import { isWdEntityUri } from '#lib/boolean_validations'
 import type { SanitizedResolverEntry } from '#server/types/resolver'
 import { resolveExternalIds } from './resolve_external_ids.js'
-// Do not try to resolve edition on Wikidata while Wikidata editions are in quarantine
-// cf https://github.com/inventaire/inventaire/issues/182
-const resolveOnWikidata = false
 
 export async function resolveEdition (entry: SanitizedResolverEntry) {
   const { isbn, claims } = entry.edition
@@ -13,7 +12,7 @@ export async function resolveEdition (entry: SanitizedResolverEntry) {
     matchingTriples,
   ] = await Promise.all([
     resolveByIsbn(isbn),
-    resolveExternalIds(claims, { resolveOnWikidata }),
+    resolveExternalIds(claims),
   ])
   // TODO: handle possible conflict between uriFoundByIsbn and urisFoundByExternalIds
   let uri
@@ -21,6 +20,11 @@ export async function resolveEdition (entry: SanitizedResolverEntry) {
     uri = uriFoundByIsbn
   } else if (matchingTriples && matchingTriples.length === 1) {
     uri = matchingTriples[0].subject
+    if (isWdEntityUri(uri)) {
+      const entity = await getEntityByUri({ uri })
+      // Get the canonical uri and check that the type is correct
+      uri = entity.type === 'edition' ? entity.uri : null
+    }
   }
   if (uri != null) entry.edition.uri = uri
   return entry

--- a/server/controllers/entities/lib/special_entity_images_getter.ts
+++ b/server/controllers/entities/lib/special_entity_images_getter.ts
@@ -1,7 +1,7 @@
 import { map } from 'lodash-es'
-import { getCollectionEditions, getWorkEditions } from '#controllers/entities/lib/entities'
+import { getCollectionEditions, getUrlFromEntityImageHash, getWorkEditions } from '#controllers/entities/lib/entities'
 import { getFirstClaimValue } from '#controllers/entities/lib/inv_claims_utils'
-import { isLang } from '#lib/boolean_validations'
+import { isImageHash, isLang } from '#lib/boolean_validations'
 import { getOriginalLang } from '#lib/wikidata/get_original_lang'
 import { getEntityImagesFromClaims } from './get_entity_images_from_claims.js'
 import { getSerieParts } from './get_serie_parts.js'
@@ -86,5 +86,9 @@ function addImage (images, lang, limitPerLang, image) {
   // Index images by language so that we can illustrate a work
   // with the cover from an edition of the user's language
   // when possible
-  images[lang].push(image)
+  if (isImageHash(image)) {
+    images[lang].push(getUrlFromEntityImageHash(image))
+  } else {
+    images[lang].push(image)
+  }
 }

--- a/server/controllers/entities/lib/update_inv_claim.ts
+++ b/server/controllers/entities/lib/update_inv_claim.ts
@@ -10,12 +10,12 @@ import { getUserAccessLevels, type AccessLevel } from '#lib/user_access_levels'
 import { assert_ } from '#lib/utils/assert_types'
 import { isLocalEntityLayer, updateEntityDocClaim } from '#models/entity'
 import type { ExtendedEntityType, InvClaimValue, InvEntity, InvEntityDoc, InvEntityId, PropertyUri } from '#server/types/entity'
-import type { User, UserId } from '#server/types/user'
+import type { SpecialUser, User, UserId } from '#server/types/user'
 import inferredClaimUpdates from './inferred_claim_updates.js'
 import { validateAndFormatClaim } from './validate_and_format_claim.js'
 import { validateClaimProperty } from './validate_claim_property.js'
 
-async function _updateInvClaim (user: User, id: InvEntityId, property: PropertyUri, oldVal?: InvClaimValue, newVal?: InvClaimValue) {
+async function _updateInvClaim (user: User | SpecialUser, id: InvEntityId, property: PropertyUri, oldVal?: InvClaimValue, newVal?: InvClaimValue) {
   assert_.object(user)
   const { _id: userId } = user
   const userAccessLevels = getUserAccessLevels(user)

--- a/server/controllers/entities/lib/update_wd_entity_local_claims.ts
+++ b/server/controllers/entities/lib/update_wd_entity_local_claims.ts
@@ -5,9 +5,9 @@ import { updateInvClaim } from '#controllers/entities/lib/update_inv_claim'
 import { newError } from '#lib/error/error'
 import { getUserAccessLevels } from '#lib/user_access_levels'
 import type { InvClaimValue, PropertyUri, WdEntityId } from '#server/types/entity'
-import type { User } from '#server/types/user'
+import type { SpecialUser, User } from '#server/types/user'
 
-export async function updateWdEntityLocalClaims (user: User, wdId: WdEntityId, property: PropertyUri, oldValue: InvClaimValue, newValue: InvClaimValue) {
+export async function updateWdEntityLocalClaims (user: User | SpecialUser, wdId: WdEntityId, property: PropertyUri, oldValue: InvClaimValue, newValue: InvClaimValue) {
   if (property === 'invp:P1') {
     throw newError('entity local layer linking property (invp:P1) can not be updated', 400, { wdId, property, oldValue, newValue })
   }

--- a/server/controllers/entities/lib/wikidata_oauth.ts
+++ b/server/controllers/entities/lib/wikidata_oauth.ts
@@ -1,15 +1,25 @@
 import { newError } from '#lib/error/error'
 import config from '#server/config'
+import type { SpecialUser, User } from '#server/types/user'
 
-const { wikidataOAuth } = config
+const { wikidataOAuth, botAccountWikidataOAuth } = config
 
-export function validateWikidataOAuth (user) {
+export function validateWikidataOAuth (user: User | SpecialUser) {
+  if ('special' in user) return
   const userWikidataOAuth = user.oauth != null ? user.oauth.wikidata : undefined
   if (userWikidataOAuth == null) {
     throw newError('missing wikidata oauth tokens', 400)
   }
 }
 
-export const getWikidataOAuthCredentials = user => ({
-  oauth: Object.assign({}, wikidataOAuth, user.oauth.wikidata),
-})
+export function getWikidataOAuthCredentials (user: User | SpecialUser) {
+  if ('special' in user) {
+    return {
+      oauth: botAccountWikidataOAuth,
+    }
+  } else {
+    return {
+      oauth: { ...wikidataOAuth, ...user.oauth.wikidata },
+    }
+  }
+}

--- a/server/controllers/user/lib/user.ts
+++ b/server/controllers/user/lib/user.ts
@@ -19,6 +19,7 @@ const db = await dbFactory('users')
 const searchUsersByPosition = searchUsersByPositionFactory(db, 'users')
 const searchUsersByDistance = searchUsersByDistanceFactory('users')
 
+// TODO: include SpecialUser in possibly returned type
 export const getUserById = db.get<User>
 export const getUsersByIds = db.byIds<User>
 

--- a/server/db/couchdb/hard_coded_documents.ts
+++ b/server/db/couchdb/hard_coded_documents.ts
@@ -16,7 +16,7 @@ export const specialUserDocBase = {
 } as const
 
 function buildSpecialUserDoc (username, idLastCharacters) {
-  const specialUser: Omit<SpecialUser, '_rev' | 'type' | 'stableUsername'> = {
+  const specialUser: Omit<SpecialUser, '_rev' | 'type' | 'stableUsername' | 'roles'> = {
     _id: `00000000000000000000000000000${idLastCharacters}`,
     username,
     ...specialUserDocBase,

--- a/server/lib/user_access_levels.ts
+++ b/server/lib/user_access_levels.ts
@@ -1,5 +1,5 @@
 import { uniq } from 'lodash-es'
-import type { User } from '#server/types/user'
+import type { SpecialUser, User } from '#server/types/user'
 
 export const rolesByAccess = {
   public: [ 'public', 'authentified', 'dataadmin', 'admin' ] as const,
@@ -20,7 +20,7 @@ for (const access in rolesByAccess) {
   }
 }
 
-export function getUserAccessLevels (user: User): AccessLevel[] {
+export function getUserAccessLevels (user: User | SpecialUser): AccessLevel[] {
   if (!user) return []
   const { roles: userRoles } = user
   if (!userRoles || userRoles.length === 0) return []

--- a/server/lib/wikidata/data_model_adapter.ts
+++ b/server/lib/wikidata/data_model_adapter.ts
@@ -13,23 +13,22 @@ export function flattenQualifierProperties (simplifiedClaims, rawClaims) {
   }
 }
 
-export function relocateQualifierProperties (invEntity: { claims: UnprefixedClaims }) {
-  const { claims } = invEntity
+export function relocateQualifierProperties (claims: UnprefixedClaims) {
   const series = claims.P179
   const seriesOrdinals = claims.P1545
 
   if (!seriesOrdinals) return
 
   if (!series) {
-    throw newError('a serie ordinal can not be move to Wikidata without a serie', 400, invEntity)
+    throw newError('a serie ordinal can not be move to Wikidata without a serie', 400, { claims })
   }
 
   if (series.length !== 1) {
-    throw newError('a serie ordinal can not be set on several serie claims', 400, invEntity)
+    throw newError('a serie ordinal can not be set on several serie claims', 400, { claims })
   }
 
   if (seriesOrdinals.length !== 1) {
-    throw newError('can not import several serie ordinals', 400, invEntity)
+    throw newError('can not import several serie ordinals', 400, { claims })
   }
 
   const seriesClaim = series[0]

--- a/server/lib/wikidata/edit.ts
+++ b/server/lib/wikidata/edit.ts
@@ -1,14 +1,18 @@
 import wbEdit from 'wikibase-edit'
 import { userAgent } from '#lib/requests'
 import { httpsAgent } from '#lib/requests_agent'
+import config from '#server/config'
+
+// Most edits are isolated edits from humans using the GUI, maxlag can thus be null
+// in environments where the server receives requests from humans waiting for the response
+// See https://github.com/maxlath/wikibase-edit/blob/main/docs/how_to.md#maxlag
+// and https://www.mediawiki.org/wiki/Manual:Maxlag_parameter
+const { maxlag } = config.wikidataEdit
 
 // Return an instance of wikibase-edit with the general config pre-set
 export default wbEdit({
   instance: 'https://www.wikidata.org',
   userAgent,
-  // Most edits are isolated edits from humans using the GUI, maxlag could thus be omitted
-  // See https://github.com/maxlath/wikibase-edit/blob/main/docs/how_to.md#maxlag
-  // and https://www.mediawiki.org/wiki/Manual:Maxlag_parameter
-  maxlag: null,
+  maxlag,
   httpRequestAgent: httpsAgent,
 })

--- a/server/types/config.ts
+++ b/server/types/config.ts
@@ -2,7 +2,7 @@
 
 import type { ImagePath } from '#server/types/image'
 import type { AbsoluteUrl, Path, RelativeUrl } from '#types/common'
-import type { Email } from '#types/user'
+import type { Email, OAuthConsumer, OwnerOnlyOAuthConsumer } from '#types/user'
 import type { ReadonlyDeep } from 'type-fest'
 
 export type Config = ReadonlyDeep<{
@@ -182,11 +182,13 @@ export type Config = ReadonlyDeep<{
 
   /** Doc: https://www.mediawiki.org/wiki/OAuth/For_Developers
    *  Request tokens at
-   *  https://meta.wikimedia.org/wiki/Special:OAuthConsumerRegistration/propose  */
-  wikidataOAuth: {
-    consumer_key: string
-    consumer_secret: string
-  }
+   *  https://meta.wikimedia.org/wiki/Special:OAuthConsumerRegistration/propose */
+  wikidataOAuth: OAuthConsumer
+
+  /** Keys for server own OAuth
+   *  Request tokens at
+   *  https://meta.wikimedia.org/wiki/Special:OAuthConsumerRegistration/propose?wpownerOnly=1 */
+  botAccountWikidataOAuth: OwnerOnlyOAuthConsumer
 
   snapshotsDebounceTime: number
 

--- a/server/types/config.ts
+++ b/server/types/config.ts
@@ -190,6 +190,10 @@ export type Config = ReadonlyDeep<{
    *  https://meta.wikimedia.org/wiki/Special:OAuthConsumerRegistration/propose?wpownerOnly=1 */
   botAccountWikidataOAuth: OwnerOnlyOAuthConsumer
 
+  wikidataEdit: {
+    maxlag?: number
+  }
+
   snapshotsDebounceTime: number
 
   jobs: {

--- a/server/types/user.ts
+++ b/server/types/user.ts
@@ -45,10 +45,16 @@ export type CreationStrategy = 'local' | 'browserid'
 export type UserImg = `/img/users/${ImageHash}`
 
 type OAuthProvider = 'wikidata'
-type OAuthProviderTokens = {
+
+export interface OAuthConsumer {
+  consumer_key: string
+  consumer_secret: string
+}
+export interface OAuthProviderTokens {
   token: string
   token_secret: string
 }
+export type OwnerOnlyOAuthConsumer = OAuthConsumer & OAuthProviderTokens
 
 export interface AbuseReport {
   type: string
@@ -94,8 +100,10 @@ export interface SpecialUser extends ReadonlyDeep<typeof specialUserDocBase> {
   _rev: CouchRevId
   // TODO: replace doc.special with doc.type='special'
   type: never
+  special: true
   username: string
   stableUsername: never
+  roles: never
 }
 
 export interface DeletedUser extends Pick<User, typeof userAttributes.critical[number]> {

--- a/tests/api/entities/resolver/resolve.test.ts
+++ b/tests/api/entities/resolver/resolve.test.ts
@@ -34,12 +34,20 @@ describe('entities:resolve', () => {
     }
   })
 
-  it('should resolve an edition entry from an ISBN', async () => {
+  it('should resolve an edition entry from a local ISBN', async () => {
     const { uri, isbn } = await createEditionWithIsbn()
     const entry = { edition: { isbn } }
     const { entries } = await resolve(entry)
     entries[0].should.be.an.Object()
     entries[0].edition.uri.should.equal(uri)
+  })
+
+  it('should resolve an edition entry from an external id found on a remote entity', async () => {
+    // Expect to find wdt:P648=OL22934376M on wd:Q116194196, with canonical uri=isbn:9780375759239
+    const entry = { edition: { claims: { 'wdt:P648': 'OL22934376M' } } }
+    const { entries } = await resolve(entry)
+    entries[0].should.be.an.Object()
+    entries[0].edition.uri.should.equal('isbn:9780375759239')
   })
 
   it('should resolve an edition from a known edition external id', async () => {

--- a/tests/api/entities/resolver/resolve_and_update.test.ts
+++ b/tests/api/entities/resolver/resolve_and_update.test.ts
@@ -256,18 +256,15 @@ describe('entities:resolver:update-resolved', () => {
         claims: { 'wdt:P577': entryDate },
       },
     }
-    const { version } = await getByUri(uri)
-    const preResolvedEntityVersion = version
-
     await resolveAndUpdate(entry)
     await wait(10)
-    const { version: postResolvedVersion } = await getByUri(uri)
-    postResolvedVersion.should.equal(preResolvedEntityVersion)
+    const { claims: udpatedClaims } = await getByUri(uri)
+    udpatedClaims['wdt:P577'].should.deepEqual([ entityDate ])
   })
 
   it('should update if entry date is more precise than entity date', async () => {
-    const entryDate = '2020-01-01'
     const entityDate = '2020'
+    const entryDate = '2020-01-01'
     const { uri, isbn } = await createEditionWithIsbn({ publicationDate: entityDate })
     const entry = {
       edition: {
@@ -275,13 +272,10 @@ describe('entities:resolver:update-resolved', () => {
         claims: { 'wdt:P577': entryDate },
       },
     }
-    const { version } = await getByUri(uri)
-    const preResolvedEntityVersion = version
-
     await resolveAndUpdate(entry)
     await wait(10)
-    const { version: postResolvedVersion } = await getByUri(uri)
-    postResolvedVersion.should.equal(preResolvedEntityVersion + 1)
+    const { claims: udpatedClaims } = await getByUri(uri)
+    udpatedClaims['wdt:P577'].should.deepEqual([ entryDate ])
   })
 
   it('should update if is an entry date and no current date', async () => {

--- a/tests/api/search/indexation_entities.test.ts
+++ b/tests/api/search/indexation_entities.test.ts
@@ -1,4 +1,5 @@
 import should from 'should'
+import { getUrlFromEntityImageHash } from '#controllers/entities/lib/entities'
 import { unprefixify } from '#controllers/entities/lib/prefix'
 import { indexesNamesByBaseNames } from '#db/elasticsearch/indexes'
 import { createHuman, createEdition, addSerie } from '#fixtures/entities'
@@ -33,7 +34,7 @@ describe('indexation:entities', () => {
     await updateLabel({ uri: workUri, lang: 'es', value: 'foo' })
     await wait(elasticsearchUpdateDelay)
     const result = await getIndexedDoc(entitiesIndex, unprefixify(workUri))
-    result._source.images[lang][0].should.equal(editionImageHash)
+    result._source.images[lang][0].should.equal(getUrlFromEntityImageHash(editionImageHash))
   })
 
   it('should index a serie with its works editions images per lang', async () => {
@@ -50,7 +51,7 @@ describe('indexation:entities', () => {
     await updateLabel({ uri: serieId, lang: 'es', value: 'foo' })
     await wait(elasticsearchUpdateDelay)
     const result = await getIndexedDoc(entitiesIndex, serieId)
-    result._source.images[lang][0].should.equal(editionImageHash)
+    result._source.images[lang][0].should.equal(getUrlFromEntityImageHash(editionImageHash))
   })
 
   it('should index the entity popularity', async () => {

--- a/tests/unit/libs/wikidata_data_model_converter.ts
+++ b/tests/unit/libs/wikidata_data_model_converter.ts
@@ -1,5 +1,5 @@
 import 'should'
-import { format, reshapeMonolingualTextClaims, type EntityDraft } from '#controllers/entities/lib/create_wd_entity'
+import { formatClaimsForWikidata, reshapeMonolingualTextClaims, type EntityDraft } from '#controllers/entities/lib/create_wd_entity'
 import { someReference } from '#fixtures/entities'
 import { relocateQualifierProperties } from '#lib/wikidata/data_model_adapter'
 import { shouldNotBeCalled } from '#tests/unit/utils/utils'
@@ -7,15 +7,13 @@ import { shouldNotBeCalled } from '#tests/unit/utils/utils'
 describe('wikidata data model converter', () => {
   describe('relocateQualifierProperties', () => {
     it('should pass when no serie ordinal is set', () => {
-      relocateQualifierProperties({ claims: {} })
+      relocateQualifierProperties({ })
     })
 
     it('should throw when no serie is set but a serie ordinal is', () => {
       try {
         relocateQualifierProperties({
-          claims: {
-            P1545: [ { value: '1' } ],
-          },
+          P1545: [ { value: '1' } ],
         })
         shouldNotBeCalled()
       } catch (err) {
@@ -25,19 +23,15 @@ describe('wikidata data model converter', () => {
 
     it('should not throw when several series are set but no ordinal', () => {
       relocateQualifierProperties({
-        claims: {
-          P179: [ { value: 'Q1' }, { value: 'Q2' } ],
-        },
+        P179: [ { value: 'Q1' }, { value: 'Q2' } ],
       })
     })
 
     it('should throw when several series are set with an ordinal', () => {
       try {
         relocateQualifierProperties({
-          claims: {
-            P179: [ { value: 'Q1' }, { value: 'Q2' } ],
-            P1545: [ { value: '1' } ],
-          },
+          P179: [ { value: 'Q1' }, { value: 'Q2' } ],
+          P1545: [ { value: '1' } ],
         })
         shouldNotBeCalled()
       } catch (err) {
@@ -48,10 +42,8 @@ describe('wikidata data model converter', () => {
     it('should throw when several serie ordinals are set', () => {
       try {
         relocateQualifierProperties({
-          claims: {
-            P179: [ { value: 'Q1' } ],
-            P1545: [ { value: '1' }, { value: '2' } ],
-          },
+          P179: [ { value: 'Q1' } ],
+          P1545: [ { value: '1' }, { value: '2' } ],
         })
         shouldNotBeCalled()
       } catch (err) {
@@ -64,7 +56,7 @@ describe('wikidata data model converter', () => {
         P179: [ { value: 'Q1', references: [ someReference ] } ],
         P1545: [ { value: '1' } ],
       }
-      relocateQualifierProperties({ claims })
+      relocateQualifierProperties(claims)
       claims.should.deepEqual({
         P179: [
           {
@@ -91,14 +83,14 @@ describe('wikidata data model converter', () => {
           'wdt:P1680': [ { value: "Essai sur l'imagination de la matière" } ],
         },
       } as EntityDraft
-      reshapeMonolingualTextClaims(entity)
+      reshapeMonolingualTextClaims(entity.claims)
       entity.claims['wdt:P1476'][0].value.should.deepEqual({ text: "L'Eau et les rêves", language: 'fr' })
       entity.claims['wdt:P1680'][0].value.should.deepEqual({ text: "Essai sur l'imagination de la matière", language: 'fr' })
     })
   })
 
-  describe('format', () => {
-    it('should format an entity to the wikibase-edit format', () => {
+  describe('formatClaimsForWikidata', () => {
+    it('should format claims to the wikibase-edit format', () => {
       const entity = {
         labels: {},
         claims: {
@@ -112,10 +104,10 @@ describe('wikidata data model converter', () => {
           'wdt:P1680': [ { value: "Essai sur l'imagination de la matière" } ],
         },
       } as EntityDraft
-      const formatted = format(entity)
-      formatted.claims.P31[0].value.should.equal('Q3331189')
-      formatted.claims.P1476[0].value.should.deepEqual({ text: "L'Eau et les rêves", language: 'fr' })
-      formatted.claims.P1680[0].value.should.deepEqual({ text: "Essai sur l'imagination de la matière", language: 'fr' })
+      const formattedClaims = formatClaimsForWikidata(entity.claims)
+      formattedClaims.P31[0].value.should.equal('Q3331189')
+      formattedClaims.P1476[0].value.should.deepEqual({ text: "L'Eau et les rêves", language: 'fr' })
+      formattedClaims.P1680[0].value.should.deepEqual({ text: "Essai sur l'imagination de la matière", language: 'fr' })
     })
   })
 })


### PR DESCRIPTION
Now that the server takes Wikidata editions into account (#753) and that it should soon be possible to move local entities  to Wikidata (#760), a missing brick was the possibility to perform the same kind of data enrichment we do on local entities directly on Wikidata entities, so that's what PR tries to do.

This is unfortunately hard to test as we don't mock edits on Wikidata, so Let's Test In Prod™ and see if further adjustments are needed.

One requirement was to make the resolver able to resolve to Wikidata editions, which is the other part of this PR.

~~PR based on #760~~