### PR TITLE
Listing move element

### DIFF
--- a/server/controllers/listings/lib/elements.ts
+++ b/server/controllers/listings/lib/elements.ts
@@ -4,7 +4,7 @@ import { isNonEmptyArray } from '#lib/boolean_validations'
 import { maxKey, minKey } from '#lib/couch'
 import { newError } from '#lib/error/error'
 import { combinations } from '#lib/utils/base'
-import { nextHighestOrdinal } from '#lib/utils/lexicographic_ordinal'
+import { getNextHighestOrdinal } from '#lib/utils/lexicographic_ordinal'
 import { createElementDoc, updateElementDoc } from '#models/element'
 import type { ListingElement } from '#types/element'
 
@@ -55,7 +55,7 @@ export async function createListingElements ({ listing, uris, userId }) {
 
   const elementsToCreate = []
   uris.forEach(uri => {
-    const ordinal = nextHighestOrdinal([ ...elements, ...elementsToCreate ])
+    const ordinal = getNextHighestOrdinal([ ...elements, ...elementsToCreate ])
     const newDoc = createElementDoc({
       list: listingId,
       uri,
@@ -68,8 +68,8 @@ export async function createListingElements ({ listing, uris, userId }) {
   return db.fetch<ListingElement>(elementsIds)
 }
 
-export async function updateElementDocAttributes (element, newAttributes, listingElements) {
-  const updatedElement = updateElementDoc(newAttributes, element, listingElements)
+export async function updateElementDocAttributes ({ element, newAttributes, elements }: { element: ListingElement, newAttributes: any, elements: ListingElement[] }) {
+  const updatedElement = updateElementDoc(newAttributes, element, elements)
   return db.putAndReturn(updatedElement)
 }
 

--- a/server/controllers/listings/lib/listings.ts
+++ b/server/controllers/listings/lib/listings.ts
@@ -11,7 +11,7 @@ import { createListingDoc, updateListingDocAttributes } from '#models/listing'
 import type { NewCouchDoc } from '#types/couchdb'
 import type { ListingElement } from '#types/element'
 import type { EntityUri } from '#types/entity'
-import type { Listing, ListingId, ListingWithElements } from '#types/listing'
+import type { Listing, ListingId, ListingWithElements, ListingType } from '#types/listing'
 import type { UserId } from '#types/user'
 
 const { updatable: updateAttributes, entityTypesByListingType } = listingAttributes
@@ -100,7 +100,7 @@ export async function deleteUserListingsAndElements (userId: UserId) {
   ])
 }
 
-export async function validateEntitiesCanBeAdded (uris: EntityUri[], listingType) {
+export async function validateEntitiesCanBeAdded (uris: EntityUri[], listingType: ListingType) {
   const { notFound, entities } = await getEntitiesByUris({ uris })
   const allowlistedEntityTypes = entityTypesByListingType[listingType]
   const wrongTypeEntity = Object.values(entities).find(entity => {

--- a/server/controllers/listings/lib/listings.ts
+++ b/server/controllers/listings/lib/listings.ts
@@ -100,7 +100,7 @@ export async function deleteUserListingsAndElements (userId: UserId) {
   ])
 }
 
-async function validateEntitiesCanBeAdded (uris: EntityUri[], listingType) {
+export async function validateEntitiesCanBeAdded (uris: EntityUri[], listingType) {
   const { notFound, entities } = await getEntitiesByUris({ uris })
   const allowlistedEntityTypes = entityTypesByListingType[listingType]
   const wrongTypeEntity = Object.values(entities).find(entity => {

--- a/server/controllers/listings/update_element.ts
+++ b/server/controllers/listings/update_element.ts
@@ -1,7 +1,7 @@
 import { pick } from 'lodash-es'
 import { getElementById, updateElementDocAttributes } from '#controllers/listings/lib/elements'
 import { filterFoundElementsUris } from '#controllers/listings/lib/helpers'
-import { getListingById, getListingWithElements, validateListingOwnership } from '#controllers/listings/lib/listings'
+import { getListingById, getListingWithElements, validateListingOwnership, validateEntitiesCanBeAdded } from '#controllers/listings/lib/listings'
 import { checkSpamContent } from '#controllers/user/lib/spam'
 import { isNonEmptyArray } from '#lib/boolean_validations'
 import { notFoundError, newError } from '#lib/error/error'
@@ -61,6 +61,7 @@ async function validateUpdateListing (reqUserId: UserId, element: ListingElement
   const listing: Listing = await getListingById(element.list)
   validateListingOwnership(reqUserId, listing)
   validateListingOwnership(reqUserId, recipientListing)
+  validateEntitiesCanBeAdded([ element.uri ], recipientListing.type)
   if (recipientListing._id === listing._id) {
     throw newError('element already belongs to the list', 400, { listId: listing._id })
   }

--- a/server/controllers/listings/update_element.ts
+++ b/server/controllers/listings/update_element.ts
@@ -16,6 +16,7 @@ const sanitization = {
     optional: true,
   },
   ordinal: { optional: true },
+  list: { optional: true },
 }
 
 async function controller (params: SanitizedParameters, req: AuthentifiedReq) {

--- a/server/lib/utils/lexicographic_ordinal.ts
+++ b/server/lib/utils/lexicographic_ordinal.ts
@@ -10,7 +10,7 @@ export function findNewOrdinal (element: ListingElement, elements: ListingElemen
 
   // Place element in last position if newOrdinal is too high
   if (elements.length < newOrdinal) newOrdinal = elements.length - 1
-  if (elements[newOrdinal]._id === element._id) return
+  if (elements[newOrdinal]?._id === element._id) return
   removeElementIfNecessary(element, elements, newOrdinal)
   return findNewLexicographicOrdinal(newOrdinal, elements)
 }
@@ -28,7 +28,7 @@ function findNewLexicographicOrdinal (newOrdinal: number, currentElements: Listi
   let precedentElementIndex, beforeOrdinal
   if (newOrdinal === 0) {
     precedentElementIndex = 0
-    // See nextHighestOrdinal comment on why '0' can be set as beforeOrdinal
+    // See getNextHighestOrdinal comment on why '0' can be set as beforeOrdinal
     beforeOrdinal = '0'
   } else {
     precedentElementIndex = newOrdinal - 1
@@ -37,17 +37,17 @@ function findNewLexicographicOrdinal (newOrdinal: number, currentElements: Listi
   const afterElement = currentElements[newOrdinal]
   let afterOrdinal
   if (!afterElement) {
-    afterOrdinal = nextHighestOrdinal(currentElements)
+    afterOrdinal = getNextHighestOrdinal(currentElements)
   } else {
     afterOrdinal = afterElement.ordinal
   }
   const lexicographicOrdinal = findOrdinalBetween(beforeOrdinal, afterOrdinal)
-  if (currentElements[precedentElementIndex].ordinal !== lexicographicOrdinal) {
+  if (currentElements[precedentElementIndex]?.ordinal !== lexicographicOrdinal) {
     return lexicographicOrdinal
   }
 }
 
-export function nextHighestOrdinal (elements: ListingElement[]) {
+export function getNextHighestOrdinal (elements: ListingElement[]) {
   // First element's ordinal can not be the first lexicographical possibility (aka '0'),
   // since some ordinal slots should be available before first element,
   // to be able to replace first element when needed.

--- a/server/models/element.ts
+++ b/server/models/element.ts
@@ -24,6 +24,7 @@ export const attributes = {
     'comment',
   ],
   updatable: [
+    'list',
     'uri',
     'ordinal',
     'comment',

--- a/server/types/listing.ts
+++ b/server/types/listing.ts
@@ -6,7 +6,7 @@ import type { VisibilityKey } from '#types/visibility'
 
 export type ListingId = CouchUuid
 
-export type ListingType = keyof typeof listingAttributes.type
+export type ListingType = typeof listingAttributes.type[number]
 
 export interface Listing extends CouchDoc {
   _id: ListingId

--- a/tests/api/fixtures/listings.ts
+++ b/tests/api/fixtures/listings.ts
@@ -52,7 +52,9 @@ export async function createListingWithElements (userPromise?: AwaitableUserWith
   return { listing: updatedListing, user, uris }
 }
 
-export const createElement = async ({ visibility = [ 'public' ], uri, listing }: { visibility?: VisibilityKey[], uri?: EntityUri, listing?: Listing }, userPromise?: AwaitableUserWithCookie) => {
+export const createElement = async (params = {}, userPromise?: AwaitableUserWithCookie) => {
+  const { visibility = [ 'public' ] }: { visibility?: VisibilityKey[] } = params
+  let { uri, listing }: { uri?: EntityUri, listing?: Listing } = params
   userPromise = userPromise || getUser()
   if (!listing) {
     const fixtureListing = await createListing(userPromise, { visibility })

--- a/tests/api/listings/update_element.test.ts
+++ b/tests/api/listings/update_element.test.ts
@@ -1,4 +1,6 @@
 import { sentence } from '#fixtures/text'
+import should from 'should'
+import { createListing } from '#fixtures/listings'
 import { wait } from '#lib/promises'
 import { getListingById, getByIdWithElements } from '#tests/api/utils/listings'
 import { getUserB, authReq } from '#tests/api/utils/utils'
@@ -87,6 +89,20 @@ describe('element:update', () => {
     })
     const updatedElementListing2 = await getListingById({ user: getUserB(), id: listing._id })
     updatedElementListing2.elements[0].comment.should.equal('')
+  })
+
+describe('element:update:list', () => {
+  it('should update attribute with the recipient listing id', async () => {
+    const { listing } = await createListing()
+    const { listing: elementListing } = await createListingWithElements()
+    const { elements } = elementListing
+    const element = elements[0]
+    await authReq('post', endpoint, {
+      id: element._id,
+      list: listing._id,
+    })
+    const res = await getByIdWithElements({ id: listing._id })
+    res.elements[0]._id.should.equal(element._id)
   })
 })
 

--- a/tests/api/listings/update_element.test.ts
+++ b/tests/api/listings/update_element.test.ts
@@ -153,6 +153,20 @@ describe('element:update:list', () => {
       err.statusCode.should.equal(400)
     }
   })
+
+  it('should update ordinal to the last position of the recipient listing elements', async () => {
+    const elementsLength = 4
+    const { listing: elementListing } = await createListingWithElements()
+    const { listing: recipientListing } = await createListingWithElements(null, elementsLength)
+    const { elements } = elementListing
+    const element = elements[0]
+    await authReq('post', endpoint, {
+      id: element._id,
+      list: recipientListing._id,
+    })
+    const res = await getByIdWithElements({ id: recipientListing._id })
+    res.elements[elementsLength]._id.should.equal(element._id)
+  })
 })
 
 describe('element:update:ordinal', () => {

--- a/tests/api/listings/update_element.test.ts
+++ b/tests/api/listings/update_element.test.ts
@@ -154,6 +154,27 @@ describe('element:update:list', () => {
     }
   })
 
+  it('should reject when the recipient listing type and the entity type do not match', async () => {
+    try {
+      const { listing } = await createListingWithElements()
+      const element = listing.elements[0]
+      const { listing: recipientListing } = await createListing(null, { type: 'author' })
+      await addElements(getUser(), {
+        id: recipientListing._id,
+        uris: [ element.uri ],
+      })
+      await authReq('post', endpoint, {
+        id: element._id,
+        list: recipientListing._id,
+      })
+      .then(shouldNotBeCalled)
+    } catch (err) {
+      rethrowShouldNotBeCalledErrors(err)
+      err.body.status_verbose.should.startWith('cannot add this entity type to this list')
+      err.statusCode.should.equal(403)
+    }
+  })
+
   it('should update ordinal to the last position of the recipient listing elements', async () => {
     const elementsLength = 4
     const { listing: elementListing } = await createListingWithElements()

--- a/tests/api/listings/update_element.test.ts
+++ b/tests/api/listings/update_element.test.ts
@@ -49,39 +49,41 @@ describe('element:update', () => {
       err.statusCode.should.equal(403)
     }
   })
+
+  it('should create and update element attribute', async () => {
+    const { element } = await createElement()
+    const comment = sentence()
+    const createdRes = await authReq('post', endpoint, {
+      id: element._id,
+      comment,
+    })
+    const comment2 = sentence()
+    createdRes.comment.should.equal(comment)
+    const updatedRes = await authReq('post', endpoint, {
+      id: element._id,
+      comment: comment2,
+    })
+    updatedRes.comment.should.equal(comment2)
+  })
 })
 
-it('should create and update element attribute', async () => {
-  const { element } = await createElement()
-  const comment = sentence()
-  const createdRes = await authReq('post', endpoint, {
-    id: element._id,
-    comment,
+describe('element:update:comment', () => {
+  it('should be able to remove a comment', async () => {
+    const { listing, element } = await createElement()
+    const comment = sentence()
+    await authReq('post', endpoint, {
+      id: element._id,
+      comment,
+    })
+    const updatedElementListing = await getListingById({ user: getUserB(), id: listing._id })
+    updatedElementListing.elements[0].comment.should.equal(comment)
+    await authReq('post', endpoint, {
+      id: element._id,
+      comment: null,
+    })
+    const updatedElementListing2 = await getListingById({ user: getUserB(), id: listing._id })
+    updatedElementListing2.elements[0].comment.should.equal('')
   })
-  const comment2 = sentence()
-  createdRes.comment.should.equal(comment)
-  const updatedRes = await authReq('post', endpoint, {
-    id: element._id,
-    comment: comment2,
-  })
-  updatedRes.comment.should.equal(comment2)
-})
-
-it('should be able to remove a comment', async () => {
-  const { listing, element } = await createElement()
-  const comment = sentence()
-  await authReq('post', endpoint, {
-    id: element._id,
-    comment,
-  })
-  const updatedElementListing = await getListingById({ user: getUserB(), id: listing._id })
-  updatedElementListing.elements[0].comment.should.equal(comment)
-  await authReq('post', endpoint, {
-    id: element._id,
-    comment: null,
-  })
-  const updatedElementListing2 = await getListingById({ user: getUserB(), id: listing._id })
-  updatedElementListing2.elements[0].comment.should.equal('')
 })
 
 describe('element:update:list', () => {


### PR DESCRIPTION
This PR updates the element's foreign key `list`, which will have the effect of moving the element to another list, called the `recipient list`.
Moving to another list is not authorised if an element with the same URI is already existing in the recipient list, which avoids dealing with potential comment be erased (and element removal).

Goes with client PR https://github.com/inventaire/inventaire-client/pull/523

To be merged after #752 