### PR TITLE
Shared inbox delivery

### DIFF
--- a/server/controllers/activitypub/lib/activities.ts
+++ b/server/controllers/activitypub/lib/activities.ts
@@ -1,7 +1,7 @@
 import { dbFactory } from '#db/couchdb/base'
 import { assert_ } from '#lib/utils/assert_types'
 import { createActivityDoc } from '#models/activity'
-import type { ActivityDoc, ActivityId } from '#types/activity'
+import type { ActivityDoc, ActivityId, ActorName } from '#types/activity'
 
 const db = await dbFactory('activities')
 
@@ -13,7 +13,7 @@ export const getActivityById = (id: ActivityId) => db.get<ActivityDoc>(id)
 export const getActivitiesByIds = db.byIds<ActivityDoc>
 export const deleteActivityById = db.delete
 
-export async function getFollowActivitiesByObject (name: string) {
+export async function getFollowActivitiesByObject (name: ActorName) {
   return db.getDocsByViewKey<ActivityDoc>('followActivitiesByObject', name)
 }
 

--- a/server/controllers/activitypub/lib/activities.ts
+++ b/server/controllers/activitypub/lib/activities.ts
@@ -1,7 +1,7 @@
 import { dbFactory } from '#db/couchdb/base'
 import { assert_ } from '#lib/utils/assert_types'
 import { createActivityDoc } from '#models/activity'
-import type { Activity, ActivityId } from '#types/activity'
+import type { ActivityDoc, ActivityId } from '#types/activity'
 
 const db = await dbFactory('activities')
 
@@ -9,23 +9,23 @@ const db = await dbFactory('activities')
 // grouping items (and entities) under the same activity, this
 // way ensures activities consistency which allows pagination based on offsets
 
-export const getActivityById = (id: ActivityId) => db.get<Activity>(id)
-export const getActivitiesByIds = db.byIds<Activity>
+export const getActivityById = (id: ActivityId) => db.get<ActivityDoc>(id)
+export const getActivitiesByIds = db.byIds<ActivityDoc>
 export const deleteActivityById = db.delete
 
 export async function getFollowActivitiesByObject (name: string) {
-  return db.getDocsByViewKey<Activity>('followActivitiesByObject', name)
+  return db.getDocsByViewKey<ActivityDoc>('followActivitiesByObject', name)
 }
 
 export async function createActivity (newActivity) {
   const activity = createActivityDoc(newActivity)
   const createdActivity = await db.postAndReturn(activity)
-  return createdActivity as Activity
+  return createdActivity as ActivityDoc
 }
 
 export async function getActivitiesByActorName ({ name, limit = 10, offset = 0 }: { name: string, limit?: number, offset?: number }) {
   assert_.string(name)
-  return db.getDocsByViewQuery<Activity>('byActorNameAndDate', {
+  return db.getDocsByViewQuery<ActivityDoc>('byActorNameAndDate', {
     limit,
     skip: offset,
     startkey: [ name, Date.now() ],
@@ -47,5 +47,5 @@ export async function getActivitiesCountByName (name: string) {
 }
 
 export function getActivityByExternalId (externalId: string) {
-  return db.findDocByViewKey<Activity>('byExternalId', externalId)
+  return db.findDocByViewKey<ActivityDoc>('byExternalId', externalId)
 }

--- a/server/controllers/activitypub/lib/build_attachments.ts
+++ b/server/controllers/activitypub/lib/build_attachments.ts
@@ -1,7 +1,7 @@
 import { compact, escape, identity } from 'lodash-es'
 import { getEntityByUri } from '#controllers/entities/lib/get_entity_by_uri'
 import { isNonEmptyString } from '#lib/boolean_validations'
-import type { Attachment } from '#types/activity'
+import type { PropertyValueAttachment } from '#types/activity'
 import { buildLink, entityUrl, defaultLabel, propertyLabel } from './helpers.js'
 import { platforms } from './platforms.js'
 import { propertiesDisplay } from './properties_display.js'
@@ -21,7 +21,7 @@ export default async function (entity) {
 const buildAttachment = (claims, attachmentsList) => async prop => {
   const claimValues = claims[prop]
   if (!claimValues) return
-  const attachment: Attachment = {
+  const attachment: PropertyValueAttachment = {
     type: 'PropertyValue',
     name: propertyLabel(prop),
     value: null,

--- a/server/controllers/activitypub/lib/entity_patch_activities.ts
+++ b/server/controllers/activitypub/lib/entity_patch_activities.ts
@@ -1,13 +1,14 @@
 import { logError } from '#lib/utils/logs'
+import type { CreateActivity, ActorName } from '#types/activity'
 import formatEntityPatchesActivities from './format_entity_patches_activities.js'
 import { postActivityToActorFollowersInboxes } from './post_activity.js'
 
 export async function deliverEntityActivitiesFromPatch (patch) {
   try {
-    const activities = await getActivitiesFromPatch(patch)
+    const activities: CreateActivity[] = await getActivitiesFromPatch(patch)
     if (activities.length === 0) return
     await Promise.all(activities.map(activity => {
-      const actorName = new URL(activity.actor).searchParams.get('name')
+      const actorName: ActorName = new URL(activity.actor).searchParams.get('name')
       return postActivityToActorFollowersInboxes({ activity, actorName })
     }))
   } catch (err) {

--- a/server/controllers/activitypub/lib/format_entity_patches_activities.ts
+++ b/server/controllers/activitypub/lib/format_entity_patches_activities.ts
@@ -4,6 +4,8 @@ import { prefixifyInv } from '#controllers/entities/lib/prefix'
 import { i18n } from '#lib/emails/i18n/i18n'
 import { getBestLangValue } from '#lib/get_best_lang_value'
 import config from '#server/config'
+import type { CreateActivity, NoteActivity } from '#types/activity'
+import type { Url } from '#types/common'
 import { makeUrl, getEntityActorName, getActivityIdFromPatchId, context } from './helpers.js'
 
 const origin = config.getPublicOrigin()
@@ -30,27 +32,28 @@ async function formatEntityPatchActivity (row, rowIndex) {
   const subjectLabel = getLabel(subjectEntity)
   const objectLabel = getLabel(objectEntity)
   const activityId = getActivityIdFromPatchId(patchId, rowIndex)
-  const id = `${origin}/api/activitypub?action=activity&id=${activityId}`
+  const id: Url = `${origin}/api/activitypub?action=activity&id=${activityId}`
   const name = getEntityActorName(objectUri)
-  const actor = makeUrl({ params: { action: 'actor', name } })
+  const actor: Url = makeUrl({ params: { action: 'actor', name } })
   const subjectUrl = `${origin}/entity/${subjectUri}`
   const objectUrl = `${origin}/entity/${objectUri}`
 
-  const object = {
+  const object: NoteActivity = {
     id,
     type: 'Note',
     content: `<p>${i18n('en', activityText[property], { subjectLabel, subjectUrl, objectLabel, objectUrl })}</p>`,
     published: new Date(timestamp).toISOString(),
   }
 
-  return {
+  const createdActivity: CreateActivity = {
     id: `${id}#create`,
     '@context': context,
     type: 'Create',
     object,
     actor,
-    to: 'Public',
+    to: [ 'Public' ],
   }
+  return createdActivity
 }
 
 function getLabel (entity) {

--- a/server/controllers/activitypub/lib/format_items_activities.ts
+++ b/server/controllers/activitypub/lib/format_items_activities.ts
@@ -3,7 +3,7 @@ import { context } from '#controllers/activitypub/lib/helpers'
 import { addSnapshotToItem } from '#controllers/items/lib/snapshot/snapshot'
 import { i18n } from '#lib/emails/i18n/i18n'
 import config from '#server/config'
-import type { Activity, ItemNote } from '#types/activity'
+import type { ActivityDoc, ItemNote } from '#types/activity'
 import type { AbsoluteUrl, RelativeUrl } from '#types/common'
 import type { WikimediaLanguageCode } from 'wikibase-sdk'
 
@@ -11,7 +11,7 @@ const origin = config.getPublicOrigin()
 const maxLinksToDisplay = 3
 
 export function createItemsNote ({ allActivitiesItems, lang = 'en', name, actor, parentLink }: ItemNote) {
-  return async function (activityDoc: Activity) {
+  return async function (activityDoc: ActivityDoc) {
     const { since, until } = activityDoc.object.items
     // todo: pre-sorting the items per range
     const publicRangeItems = allActivitiesItems.filter(itemsWithinActivityRange(since, until))

--- a/server/controllers/activitypub/lib/format_items_activities.ts
+++ b/server/controllers/activitypub/lib/format_items_activities.ts
@@ -3,9 +3,8 @@ import { context } from '#controllers/activitypub/lib/helpers'
 import { addSnapshotToItem } from '#controllers/items/lib/snapshot/snapshot'
 import { i18n } from '#lib/emails/i18n/i18n'
 import config from '#server/config'
-import type { ActivityDoc, ItemNote } from '#types/activity'
-import type { AbsoluteUrl, RelativeUrl } from '#types/common'
-import type { WikimediaLanguageCode } from 'wikibase-sdk'
+import type { ActivityDoc, ItemNote, NoteActivity, CreateActivity, Attachment } from '#types/activity'
+import type { Url, AbsoluteUrl, RelativeUrl } from '#types/common'
 
 const origin = config.getPublicOrigin()
 const maxLinksToDisplay = 3
@@ -24,23 +23,24 @@ export function createItemsNote ({ allActivitiesItems, lang = 'en', name, actor,
     // itemsLength as in OrderedItems (not user's item)
     const itemsLength = publicRangeItems.length
 
-    const id = `${origin}/api/activitypub?action=activity&id=${activityDoc._id}`
+    const id: Url = `${origin}/api/activitypub?action=activity&id=${activityDoc._id}`
 
-    const object = {
+    const object: NoteActivity = {
       id,
       type: 'Note',
       content: buildContent({ links, name, lang, itemsLength, parentLink }),
       published: new Date(until).toISOString(),
       attachment: compact(firstItems.map(buildAttachment)),
     }
-    return {
+    const createdActivity: CreateActivity = {
       id: `${id}#create`,
       '@context': context,
       type: 'Create',
       object,
       actor,
-      to: 'Public',
+      to: [ 'Public' ],
     }
+    return createdActivity
   }
 }
 
@@ -72,7 +72,8 @@ function buildLinkContentFromItem (item) {
 interface BuildContentOptions {
   links: LinkContent[]
   name: string
-  lang: WikimediaLanguageCode
+  // Using User.language type
+  lang: string
   itemsLength: number
   parentLink: RelativeUrl
 }
@@ -99,9 +100,10 @@ function buildContent ({ links, name, lang = 'en', itemsLength, parentLink }: Bu
 function buildAttachment (item) {
   const imageUrl = item.snapshot['entity:image']
   if (!imageUrl) return
-  return {
+  const attachment: Attachment = {
     type: 'Image',
     mediaType: 'image/jpeg',
     url: `${origin}${imageUrl}`,
   }
+  return attachment
 }

--- a/server/controllers/activitypub/lib/format_shelf_items_activities.ts
+++ b/server/controllers/activitypub/lib/format_shelf_items_activities.ts
@@ -1,5 +1,6 @@
 import { compact } from 'lodash-es'
 import { getPublicItemsByShelfAndDate } from '#controllers/items/lib/items'
+import type { CreateActivity } from '#types/activity'
 import type { RelativeUrl, AbsoluteUrl } from '#types/common'
 import { createItemsNote, findFullRangeFromActivities } from './format_items_activities.js'
 import { makeUrl } from './helpers.js'
@@ -15,6 +16,6 @@ export default async function (activitiesDocs, shelfId, name) {
     until,
   })
 
-  const formattedActivities = await Promise.all(activitiesDocs.map(createItemsNote({ allActivitiesItems, name, actor, parentLink })))
+  const formattedActivities: CreateActivity[] = await Promise.all(activitiesDocs.map(createItemsNote({ allActivitiesItems, name, actor, parentLink })))
   return compact(formattedActivities)
 }

--- a/server/controllers/activitypub/lib/format_user_items_activities.ts
+++ b/server/controllers/activitypub/lib/format_user_items_activities.ts
@@ -1,16 +1,18 @@
 import { compact } from 'lodash-es'
 import { getPublicItemsByOwnerAndDate } from '#controllers/items/lib/items'
 import { isNonEmptyArray } from '#lib/boolean_validations'
+import type { ActivityDoc, CreateActivity } from '#types/activity'
 import type { RelativeUrl, AbsoluteUrl } from '#types/common'
+import type { User } from '#types/user'
 import { createItemsNote, findFullRangeFromActivities } from './format_items_activities.js'
 import { makeUrl } from './helpers.js'
 
-export default async function (activitiesDocs, user) {
+export default async function (activitiesDocs: ActivityDoc[], user: User) {
   if (!isNonEmptyArray(activitiesDocs)) return []
   const { stableUsername: name } = user
   const actor: AbsoluteUrl = makeUrl({ params: { action: 'actor', name } })
   const parentLink: RelativeUrl = `/users/${name}`
-  const { lang } = user
+  const { language } = user
   const { since, until } = findFullRangeFromActivities(activitiesDocs)
 
   const allActivitiesItems = await getPublicItemsByOwnerAndDate({
@@ -19,6 +21,6 @@ export default async function (activitiesDocs, user) {
     until,
   })
 
-  const formattedActivities = await Promise.all(activitiesDocs.map(createItemsNote({ allActivitiesItems, lang, name, actor, parentLink })))
+  const formattedActivities: CreateActivity[] = await Promise.all(activitiesDocs.map(createItemsNote({ allActivitiesItems, lang: language, name, actor, parentLink })))
   return compact(formattedActivities)
 }

--- a/server/controllers/activitypub/lib/get_actor.ts
+++ b/server/controllers/activitypub/lib/get_actor.ts
@@ -1,8 +1,9 @@
 import { getEntityActorName } from '#controllers/activitypub/lib/helpers'
 import { unprefixify } from '#controllers/entities/lib/prefix'
 import config from '#server/config'
-import type { Attachment, ActivityLink, ActorActivity, ActorParams, LocalActorUrl } from '#types/activity'
+import type { PropertyValueAttachment, ActivityLink, ActorActivity, ActorParams, LocalActorUrl, ShelfActorName, EntityActorName } from '#types/activity'
 import type { AbsoluteUrl } from '#types/common'
+import type { Username } from '#types/user'
 import buildAttachments from './build_attachments.js'
 import { buildLink, getActorTypeFromName, defaultLabel, entityUrl } from './helpers.js'
 import { getSharedKeyPair } from './shared_key_pair.js'
@@ -11,7 +12,7 @@ import { validateShelf, validateUser, validateEntity } from './validations.js'
 const origin = config.getPublicOrigin()
 const publicOrigin = origin.split('://')[1]
 
-async function getShelfActor (name) {
+async function getShelfActor (name: ShelfActorName) {
   const { shelf, owner } = await validateShelf(name)
   const { description } = shelf
   const links: ActivityLink[] = [
@@ -28,7 +29,7 @@ async function getShelfActor (name) {
   })
 }
 
-async function getUserActor (username) {
+async function getUserActor (username: Username) {
   const { user } = await validateUser(username)
   const { picture, stableUsername, bio } = user
   const links: ActivityLink[] = [
@@ -43,7 +44,7 @@ async function getUserActor (username) {
   })
 }
 
-async function getEntityActor (name) {
+async function getEntityActor (name: EntityActorName) {
   const { entity } = await validateEntity(name)
   const actorName = getEntityActorName(entity.uri)
   const { uri } = entity
@@ -62,7 +63,7 @@ async function getEntityActor (name) {
     }
     links.push(wdLink)
   }
-  const attachments: Attachment[] = await buildAttachments(entity)
+  const attachments: PropertyValueAttachment[] = await buildAttachments(entity)
   let summary
   if ('descriptions' in entity && 'en' in entity.descriptions) {
     summary = entity.descriptions.en
@@ -117,7 +118,7 @@ async function buildActorObject ({ actorName, displayName, summary, imagePath, l
     const linksAttachments = links.map(({ name, url }) => {
       const [ protocol, urlWithoutProtocol ] = url.split('://')
       const value = `<span class="invisible">${protocol}://</span><span>${urlWithoutProtocol}</span>`
-      const attachment: Attachment = {
+      const attachment: PropertyValueAttachment = {
         type: 'PropertyValue',
         name,
         url,

--- a/server/controllers/activitypub/lib/helpers.ts
+++ b/server/controllers/activitypub/lib/helpers.ts
@@ -5,7 +5,7 @@ import { i18n } from '#lib/emails/i18n/i18n'
 import { notFoundError } from '#lib/error/error'
 import { stringifyQuery } from '#lib/utils/url'
 import config from '#server/config'
-import type { Context } from '#types/activity'
+import type { FollowActivity, Context, ActivityDoc } from '#types/activity'
 import type { AbsoluteUrl, RelativeUrl } from '#types/common'
 
 const publicOrigin = config.getPublicOrigin()
@@ -60,4 +60,18 @@ export const context: Context[] = [
 
 export function setActivityPubContentType (res) {
   res.header('content-type', 'application/activity+json')
+}
+
+export function serializeFollowActivity (followActivityDoc: ActivityDoc) {
+  const { actor, externalId, object } = followActivityDoc
+  const followedActorUri = makeUrl({ params: { action: 'actor', name: object.name } })
+
+  const followActivity: FollowActivity = {
+    '@context': context,
+    type: 'Follow',
+    object: followedActorUri,
+    id: externalId,
+    actor: actor.uri,
+  }
+  return followActivity
 }

--- a/server/controllers/activitypub/lib/post_activity.ts
+++ b/server/controllers/activitypub/lib/post_activity.ts
@@ -4,7 +4,7 @@ import { newError } from '#lib/error/error'
 import { requests_, sanitizeUrl } from '#lib/requests'
 import { warn, logError } from '#lib/utils/logs'
 import config from '#server/config'
-import type { ActorName, PostActivity } from '#types/activity'
+import type { ActorName, PostActivity, BodyTo } from '#types/activity'
 import type { AbsoluteUrl } from '#types/common'
 import { getFollowActivitiesByObject } from './activities.js'
 import { makeUrl } from './helpers.js'
@@ -13,55 +13,6 @@ import { getSharedKeyPair } from './shared_key_pair.js'
 const timeout = 30 * 1000
 const { sanitizeUrls } = config.activitypub
 
-export async function signAndPostActivity ({ actorName, recipientActorUri, activity }: { actorName: ActorName, recipientActorUri: AbsoluteUrl, activity: PostActivity }) {
-  let actorRes
-  try {
-    if (sanitizeUrls) recipientActorUri = await sanitizeUrl(recipientActorUri)
-    actorRes = await requests_.get(recipientActorUri, { timeout })
-  } catch (err) {
-    logError(err, 'signAndPostActivity private error')
-    throw newError('Cannot fetch remote actor information, cannot post activity', 400, { recipientActorUri, activity })
-  }
-  const inboxUri = actorRes.inbox
-  if (!inboxUri) {
-    return warn({ actorName, recipientActorUri, activity }, 'No inbox found, cannot post activity')
-  }
-
-  if (!isUrl(inboxUri)) {
-    return warn({ actorName, recipientActorUri, activity, inboxUri }, 'Invalid inbox URL, cannot post activity')
-  }
-
-  const { privateKey, publicKeyHash } = await getSharedKeyPair()
-
-  const keyActorUrl = makeUrl({ params: { action: 'actor', name: actorName } })
-
-  const body = Object.assign({}, activity)
-
-  body.to = [ recipientActorUri, 'Public' ]
-  const postHeaders = signRequest({
-    url: inboxUri,
-    method: 'post',
-    keyId: `${keyActorUrl}#${publicKeyHash}`,
-    privateKey,
-    body,
-  })
-  postHeaders['content-type'] = 'application/activity+json'
-  try {
-    await requests_.post(inboxUri, {
-      headers: postHeaders,
-      body,
-      timeout,
-      parseJson: false,
-      retryOnceOnError: true,
-    })
-  } catch (err) {
-    err.context = err.context || {}
-    Object.assign(err.context, { inboxUri, activity })
-    logError(err, 'Posting activity to inbox failed')
-  }
-}
-
-type BodyTo = (AbsoluteUrl | 'Public')[]
 export async function postActivity ({ actorName, inboxUri, bodyTo, activity }: { actorName: ActorName, inboxUri: AbsoluteUrl, bodyTo: BodyTo, activity: PostActivity }) {
   const { privateKey, publicKeyHash } = await getSharedKeyPair()
 
@@ -92,7 +43,6 @@ export async function postActivity ({ actorName, inboxUri, bodyTo, activity }: {
   }
 }
 
-// TODO: use sharedInbox
 export async function postActivityToActorFollowersInboxes ({ activity, actorName }: { activity: PostActivity, actorName: ActorName }) {
   const followActivities = await getFollowActivitiesByObject(actorName)
   const inboxUrisByBodyTos: Record<AbsoluteUrl, BodyTo> = {}
@@ -104,14 +54,15 @@ export async function postActivityToActorFollowersInboxes ({ activity, actorName
   }))
 }
 
-async function fetchInboxUri ({ actorUri, activity }: { actorUri: AbsoluteUrl, activity: PostActivity }) {
+export async function fetchInboxUri ({ actorUri, activity }: { actorUri: AbsoluteUrl, activity: PostActivity }) {
   let actorRes
   try {
     // Improvements to ease other instances: Either cache requests or
     // optimize by not requesting the same shared inboxes over and over,
     // aka Only do one request to all actorUris that have the same domain and a sharedInbox,
     // assuming server sharedInbox is the same for all instance actors
-    actorRes = await requests_.get(actorUri, { timeout, sanitize })
+    if (sanitizeUrls) actorUri = await sanitizeUrl(actorUri)
+    actorRes = await requests_.get(actorUri, { timeout })
   } catch (err) {
     logError(err, 'signAndPostActivity private error')
     throw newError('Cannot fetch remote actor information, cannot post activity', 400, { actorUri, activity })

--- a/server/controllers/activitypub/lib/post_activity.ts
+++ b/server/controllers/activitypub/lib/post_activity.ts
@@ -3,9 +3,10 @@ import { signRequest } from '#controllers/activitypub/lib/security'
 import { isUrl } from '#lib/boolean_validations'
 import { newError } from '#lib/error/error'
 import { requests_, sanitizeUrl } from '#lib/requests'
-import { assert_ } from '#lib/utils/assert_types'
 import { warn, logError } from '#lib/utils/logs'
 import config from '#server/config'
+import type { AcceptActivity } from '#types/activity'
+import type { AbsoluteUrl } from '#types/common'
 import { getFollowActivitiesByObject } from './activities.js'
 import { makeUrl } from './helpers.js'
 import { getSharedKeyPair } from './shared_key_pair.js'
@@ -13,10 +14,7 @@ import { getSharedKeyPair } from './shared_key_pair.js'
 const timeout = 30 * 1000
 const { sanitizeUrls } = config.activitypub
 
-export async function signAndPostActivity ({ actorName, recipientActorUri, activity }) {
-  assert_.string(actorName)
-  assert_.string(recipientActorUri)
-  assert_.object(activity)
+export async function signAndPostActivity ({ actorName, recipientActorUri, activity }: { actorName: string, recipientActorUri: AbsoluteUrl, activity: AcceptActivity }) {
   let actorRes
   try {
     if (sanitizeUrls) recipientActorUri = await sanitizeUrl(recipientActorUri)

--- a/server/controllers/activitypub/lib/post_activity.ts
+++ b/server/controllers/activitypub/lib/post_activity.ts
@@ -5,7 +5,7 @@ import { newError } from '#lib/error/error'
 import { requests_, sanitizeUrl } from '#lib/requests'
 import { warn, logError } from '#lib/utils/logs'
 import config from '#server/config'
-import type { AcceptActivity } from '#types/activity'
+import type { ActorName, PostActivity } from '#types/activity'
 import type { AbsoluteUrl } from '#types/common'
 import { getFollowActivitiesByObject } from './activities.js'
 import { makeUrl } from './helpers.js'
@@ -14,7 +14,7 @@ import { getSharedKeyPair } from './shared_key_pair.js'
 const timeout = 30 * 1000
 const { sanitizeUrls } = config.activitypub
 
-export async function signAndPostActivity ({ actorName, recipientActorUri, activity }: { actorName: string, recipientActorUri: AbsoluteUrl, activity: AcceptActivity }) {
+export async function signAndPostActivity ({ actorName, recipientActorUri, activity }: { actorName: ActorName, recipientActorUri: AbsoluteUrl, activity: PostActivity }) {
   let actorRes
   try {
     if (sanitizeUrls) recipientActorUri = await sanitizeUrl(recipientActorUri)
@@ -63,7 +63,7 @@ export async function signAndPostActivity ({ actorName, recipientActorUri, activ
 }
 
 // TODO: use sharedInbox
-export async function postActivityToActorFollowersInboxes ({ activity, actorName }) {
+export async function postActivityToActorFollowersInboxes ({ activity, actorName }: { activity: PostActivity, actorName: ActorName }) {
   const followActivities = await getFollowActivitiesByObject(actorName)
   if (followActivities.length === 0) return
   const followersActorsUris = uniq(map(followActivities, 'actor.uri'))

--- a/server/db/couchdb/design_docs/activities.ts
+++ b/server/db/couchdb/design_docs/activities.ts
@@ -1,8 +1,8 @@
 import { emit } from '#db/couchdb/couchdb_views_context'
-import type { Activity } from '#types/activity'
+import type { ActivityDoc } from '#types/activity'
 import type { Views } from '#types/couchdb'
 
-export const views: Views<Activity> = {
+export const views: Views<ActivityDoc> = {
   byActorNameAndDate: {
     map: doc => emit([ doc.actor.name, doc.updated ], null),
     reduce: '_count',

--- a/server/models/activity.ts
+++ b/server/models/activity.ts
@@ -1,6 +1,6 @@
 import { newError } from '#lib/error/error'
 import { assert_ } from '#lib/utils/assert_types'
-import type { Activity } from '#types/activity'
+import type { ActivityDoc } from '#types/activity'
 import attributes from './attributes/activity.js'
 import { baseActivityValidations } from './validations/activity.js'
 
@@ -13,7 +13,7 @@ export function createActivityDoc (activity) {
   delete activity.context
   delete activity['@context']
 
-  const newActivity: Partial<Activity> = {}
+  const newActivity: Partial<ActivityDoc> = {}
   Object.keys(activity).forEach(key => {
     const value = activity[key]
     if (!attributes.includes(key)) {

--- a/server/types/activity.ts
+++ b/server/types/activity.ts
@@ -146,3 +146,5 @@ export interface Outbox {
   next: Url
   totalItems?: number
 }
+
+export type BodyTo = (AbsoluteUrl | 'Public')[]

--- a/server/types/activity.ts
+++ b/server/types/activity.ts
@@ -3,52 +3,9 @@ import type { CouchDoc, CouchUuid } from '#types/couchdb'
 import type { Item } from '#types/item'
 import type { WikimediaLanguageCode } from 'wikibase-sdk'
 
-export type ActivityType = 'Create' | 'Delete' | 'Follow' | 'Undo'
-
-interface NameObj {
-  name: string
-}
-
-export interface UriObj {
-  uri: string
-}
-
-interface ItemsObj {
-  items: {
-    since: EpochTimeStamp
-    until: EpochTimeStamp
-  }
-}
-
-export type ObjectType = NameObj & ItemsObj & Url
-
+export type ActivityType = 'Create' | 'Delete' | 'Follow' | 'Undo' | 'Accept' | 'Follow'
+export type Context = 'https://www.w3.org/ns/activitystreams' | 'https://w3id.org/security/v1'
 export type LocalActorUrl = Url
-
-export type Actor = NameObj & UriObj
-
-export interface Activity extends CouchDoc {
-  _id: CouchUuid
-  type: string
-  actor: Actor
-  object: ObjectType
-  externalId: string
-  content: string
-  created: EpochTimeStamp
-  updated: EpochTimeStamp
-}
-
-export type ActivityId = CouchUuid
-
-interface Note {
-  name: string
-  actor: AbsoluteUrl
-  lang?: WikimediaLanguageCode
-  parentLink: RelativeUrl
-}
-
-export interface ItemNote extends Note {
-  allActivitiesItems: Item[]
-}
 
 export interface Attachment {
   type: 'PropertyValue'
@@ -56,13 +13,6 @@ export interface Attachment {
   value?: string
   url?: Url
 }
-
-export interface ActivityLink {
-  name: 'shelf' | 'inventory' | 'wikidata.org' | string
-  url: Url
-}
-
-export type Context = 'https://www.w3.org/ns/activitystreams' | 'https://w3id.org/security/v1'
 
 export interface ActorActivity {
   '@context': Context[]
@@ -86,6 +36,73 @@ export interface ActorActivity {
     url: string
   }
   attachment?: Attachment[]
+}
+
+interface BaseActivity {
+  '@context'?: any[]
+  id: Url
+  to?: string[]
+  cc?: string[]
+  actor?: Url | ActorActivity
+  type: ActivityType
+}
+
+interface NameObj {
+  name: string
+}
+
+export interface UriObj {
+  uri: string
+}
+
+interface ItemsObj {
+  items: {
+    since: EpochTimeStamp
+    until: EpochTimeStamp
+  }
+}
+
+export type ObjectType = NameObj & ItemsObj & Url
+
+export type Actor = NameObj & UriObj
+
+export interface ActivityDoc extends CouchDoc {
+  _id: CouchUuid
+  type: ActivityType
+  actor: Actor
+  object: ObjectType
+  externalId: string
+  content: string
+  created: EpochTimeStamp
+  updated: EpochTimeStamp
+}
+
+export interface FollowActivity extends BaseActivity {
+  type: 'Follow'
+  object: Url
+}
+
+export interface AcceptActivity extends BaseActivity {
+  type: 'Accept'
+  object: FollowActivity
+}
+
+export type ActivityId = CouchUuid
+
+interface Note {
+  name: string
+  actor: AbsoluteUrl
+  lang?: WikimediaLanguageCode
+  parentLink: RelativeUrl
+}
+
+export interface ItemNote extends Note {
+  allActivitiesItems: Item[]
+}
+
+export interface ActivityLink {
+  name: 'shelf' | 'inventory' | 'wikidata.org' | string
+  url: Url
 }
 
 export interface ActorParams {

--- a/server/types/activity.ts
+++ b/server/types/activity.ts
@@ -5,7 +5,7 @@ import type { WikimediaLanguageCode } from 'wikibase-sdk'
 
 export type ActivityType = 'Create' | 'Delete' | 'Follow' | 'Undo' | 'Accept' | 'Follow'
 export type Context = 'https://www.w3.org/ns/activitystreams' | 'https://w3id.org/security/v1'
-export type LocalActorUrl = Url
+export type LocalActorUrl = AbsoluteUrl
 
 export interface Attachment {
   type: 'PropertyValue'
@@ -47,12 +47,12 @@ interface BaseActivity {
   type: ActivityType
 }
 
-interface NameObj {
+export interface NameObj {
   name: string
 }
 
 export interface UriObj {
-  uri: string
+  uri: LocalActorUrl
 }
 
 interface ItemsObj {
@@ -71,7 +71,7 @@ export interface ActivityDoc extends CouchDoc {
   type: ActivityType
   actor: Actor
   object: ObjectType
-  externalId: string
+  externalId: Url
   content: string
   created: EpochTimeStamp
   updated: EpochTimeStamp

--- a/server/types/shelf.ts
+++ b/server/types/shelf.ts
@@ -5,10 +5,11 @@ import type { UserId } from '#types/user'
 import type { VisibilityKey } from '#types/visibility'
 
 export type ShelfId = CouchUuid
+export type ShelfName = string
 
 export interface Shelf extends CouchDoc {
   _id: ShelfId
-  name: string
+  name: ShelfName
   slug: string
   description?: string
   owner: UserId

--- a/tests/api/activitypub/inbox_follow.test.ts
+++ b/tests/api/activitypub/inbox_follow.test.ts
@@ -75,7 +75,9 @@ describe('activitypub:inbox:Follow', () => {
       activity['@context'].should.deepEqual([ 'https://www.w3.org/ns/activitystreams' ])
       activity.type.should.equal('Accept')
       activity.actor.should.equal(actorUrl)
-      activity.object.should.startWith(remoteHost)
+      activity.object.type.should.equal('Follow')
+      activity.object.actor.should.startWith(remoteHost)
+      activity.object.object.should.startWith(actorUrl)
     })
   })
 


### PR DESCRIPTION
This PR allows posting `Accept` and `Create` activities to shared inboxes when available.
The difficulty was to refactor `signAndPostActivities` (renamed `postActivities`) to be able to build `body.to` array per instances. While I could not figure out in the documentation if this was necessary, it seems more logical to have adequate `body.to` (aka list of followers + a `Public` element)

This PR also adds some types on the ActivityPub part (related to #706), which is why it should be merged before any other [AP related PRs](https://wiki.inventaire.io/wiki/NGI_Zero_Discovery_grants#3._Push_forward_ActivityPub)

Solves #575