### PR TITLE
Activity jobs delivery

### DIFF
--- a/config/default.cjs
+++ b/config/default.cjs
@@ -350,6 +350,9 @@ const config = {
     'wd:entity:indexation': {
       run: true,
     },
+    'post:activity': {
+      run: true,
+    },
   },
 
   // Keys for users Wikidata OAuth

--- a/server/controllers/activitypub/follow.ts
+++ b/server/controllers/activitypub/follow.ts
@@ -59,7 +59,8 @@ export async function follow (params: FollowArgs) {
 }
 
 async function sendAcceptActivity (followActivity: FollowActivity, actor: UriObj, object: NameObj, followCouchId: CouchUuid) {
-  const followedActorUri = makeUrl({ params: { action: 'actor', name: object.name } })
+  const actorName = object.name
+  const followedActorUri = makeUrl({ params: { action: 'actor', name: actorName } })
   const activity: AcceptActivity = {
     '@context': context,
     id: `${followedActorUri}#accept/follows-${followCouchId}`,

--- a/server/controllers/activitypub/follow.ts
+++ b/server/controllers/activitypub/follow.ts
@@ -59,8 +59,7 @@ export async function follow (params: FollowArgs) {
 }
 
 async function sendAcceptActivity (followActivity: FollowActivity, actor: UriObj, object: NameObj, followCouchId: CouchUuid) {
-  const actorName = object.name
-  const followedActorUri = makeUrl({ params: { action: 'actor', name: actorName } })
+  const followedActorUri = makeUrl({ params: { action: 'actor', name: object.name } })
   const activity: AcceptActivity = {
     '@context': context,
     id: `${followedActorUri}#accept/follows-${followCouchId}`,

--- a/server/controllers/activitypub/lib/post_activity.ts
+++ b/server/controllers/activitypub/lib/post_activity.ts
@@ -83,7 +83,7 @@ export async function fetchInboxUri ({ actorUri, activity }: { actorUri: Absolut
 
 async function buildAudience (activity, inboxUrisByBodyTos) {
   const actorUri: AbsoluteUrl = activity.actor.uri
-  const inboxUri = await fetchInboxUri({ actorUri, activity })
+  const inboxUri = await fetchInboxUri({ actorUri, activity }) as AbsoluteUrl
   if (inboxUri) {
     if (inboxUrisByBodyTos[inboxUri]) {
       inboxUrisByBodyTos[inboxUri] = inboxUrisByBodyTos[inboxUri].unshift(actorUri)

--- a/server/controllers/activitypub/lib/post_activity.ts
+++ b/server/controllers/activitypub/lib/post_activity.ts
@@ -1,4 +1,3 @@
-import { map, uniq } from 'lodash-es'
 import { makeActorKeyUrl } from '#controllers/activitypub/lib/get_actor'
 import { signRequest } from '#controllers/activitypub/lib/security'
 import { initJobQueue } from '#db/level/jobs'
@@ -83,8 +82,8 @@ async function buildAudience (activity, inboxUrisByBodyTos) {
   }
 }
 
-async function postActivityWorker (jobId, cb) {
-  const { inboxUri, postHeaders, body, activity } = cb
+async function postActivityWorker (jobId, activityData) {
+  const { inboxUri, postHeaders, body, activity } = activityData
   try {
     await requests_.post(inboxUri, {
       headers: postHeaders,

--- a/server/controllers/activitypub/lib/post_activity.ts
+++ b/server/controllers/activitypub/lib/post_activity.ts
@@ -25,11 +25,11 @@ export async function postActivity ({ actorName, inboxUri, bodyTo, activity }: {
 
 export async function postActivityToActorFollowersInboxes ({ activity, actorName }: { activity: PostActivity, actorName: ActorName }) {
   const followActivities = await getFollowActivitiesByObject(actorName)
-  const inboxUrisByBodyTos: Record<AbsoluteUrl, BodyTo> = {}
-  await whateverWorks(followActivities.map(activity => buildAudience(activity, inboxUrisByBodyTos)))
-  const inboxUris = Object.keys(inboxUrisByBodyTos) as AbsoluteUrl[]
+  const bodyToByInboxUris: Record<AbsoluteUrl, BodyTo> = {}
+  await whateverWorks(followActivities.map(activity => buildAudience(activity, bodyToByInboxUris)))
+  const inboxUris = Object.keys(bodyToByInboxUris) as AbsoluteUrl[]
   return Promise.all(inboxUris.map(inboxUri => {
-    const bodyTo: BodyTo = inboxUrisByBodyTos[inboxUri]
+    const bodyTo: BodyTo = bodyToByInboxUris[inboxUri]
     return postActivity({ actorName, inboxUri, bodyTo, activity })
   }))
 }
@@ -61,14 +61,14 @@ export async function fetchInboxUri ({ actorUri, activity }: { actorUri: Absolut
   }
 }
 
-async function buildAudience (activity, inboxUrisByBodyTos) {
+async function buildAudience (activity, bodyToByInboxUris) {
   const actorUri: AbsoluteUrl = activity.actor.uri
   const inboxUri = await fetchInboxUri({ actorUri, activity }) as AbsoluteUrl
   if (inboxUri) {
-    if (inboxUrisByBodyTos[inboxUri]) {
-      inboxUrisByBodyTos[inboxUri] = inboxUrisByBodyTos[inboxUri].unshift(actorUri)
+    if (bodyToByInboxUris[inboxUri]) {
+      bodyToByInboxUris[inboxUri] = bodyToByInboxUris[inboxUri].unshift(actorUri)
     } else {
-      inboxUrisByBodyTos[inboxUri] = [ actorUri, 'Public' ]
+      bodyToByInboxUris[inboxUri] = [ actorUri, 'Public' ]
     }
   }
 }

--- a/server/controllers/activitypub/lib/security.ts
+++ b/server/controllers/activitypub/lib/security.ts
@@ -1,4 +1,5 @@
 import { createSign, createVerify } from 'node:crypto'
+import { omit } from 'lodash-es'
 import { isNonEmptyPlainObject } from '#lib/boolean_validations'
 import { cache_ } from '#lib/cache'
 import { getSha256Base64Digest } from '#lib/crypto'
@@ -168,7 +169,7 @@ async function fetchActorPublicKeyPem (actorUrl: string) {
   const actor = await requests_.get(actorUrl as AbsoluteUrl)
   assertObject(actor)
   if (!('publicKey' in actor)) {
-    throw newError('no publicKey found', 400, { actor })
+    throw newError('no publicKey found', 400, { actor: omit(actor, 'privateKey') })
   }
   const { publicKey } = actor
   if (!publicKey) {

--- a/server/types/activity.ts
+++ b/server/types/activity.ts
@@ -140,6 +140,73 @@ export interface PublicKeyObject {
   publicKeyPem: string
 }
 
+interface BaseActivity {
+  '@context'?: any[]
+  id: Url
+  to?: string[]
+  cc?: string[]
+  actor?: Url | ActorActivity
+  type: ActivityType
+}
+
+interface NameObj {
+  name: string
+}
+
+export interface UriObj {
+  uri: string
+}
+
+interface ItemsObj {
+  items: {
+    since: EpochTimeStamp
+    until: EpochTimeStamp
+  }
+}
+
+export type ObjectType = NameObj & ItemsObj & Url
+
+export type Actor = NameObj & UriObj
+
+export interface ActivityDoc extends CouchDoc {
+  _id: CouchUuid
+  type: ActivityType
+  actor: Actor
+  object: ObjectType
+  externalId: string
+  content: string
+  created: EpochTimeStamp
+  updated: EpochTimeStamp
+}
+
+export interface FollowActivity extends BaseActivity {
+  type: 'Follow'
+  object: Url
+}
+
+export interface AcceptActivity extends BaseActivity {
+  type: 'Accept'
+  object: FollowActivity
+}
+
+export type ActivityId = CouchUuid
+
+interface Note {
+  name: string
+  actor: AbsoluteUrl
+  lang?: WikimediaLanguageCode
+  parentLink: RelativeUrl
+}
+
+export interface ItemNote extends Note {
+  allActivitiesItems: Item[]
+}
+
+export interface ActivityLink {
+  name: 'shelf' | 'inventory' | 'wikidata.org' | string
+  url: Url
+}
+
 export interface ActorParams {
   actorName: ActorName
   displayName: string

--- a/server/types/activity.ts
+++ b/server/types/activity.ts
@@ -52,7 +52,7 @@ export interface ActorActivity {
 }
 
 interface BaseActivity {
-  '@context'?: any[]
+  '@context'?: Context[]
   id: Url
   to?: string[]
   cc?: string[]
@@ -147,64 +147,6 @@ interface BaseActivity {
   cc?: string[]
   actor?: Url | ActorActivity
   type: ActivityType
-}
-
-interface NameObj {
-  name: string
-}
-
-export interface UriObj {
-  uri: string
-}
-
-interface ItemsObj {
-  items: {
-    since: EpochTimeStamp
-    until: EpochTimeStamp
-  }
-}
-
-export type ObjectType = NameObj & ItemsObj & Url
-
-export type Actor = NameObj & UriObj
-
-export interface ActivityDoc extends CouchDoc {
-  _id: CouchUuid
-  type: ActivityType
-  actor: Actor
-  object: ObjectType
-  externalId: string
-  content: string
-  created: EpochTimeStamp
-  updated: EpochTimeStamp
-}
-
-export interface FollowActivity extends BaseActivity {
-  type: 'Follow'
-  object: Url
-}
-
-export interface AcceptActivity extends BaseActivity {
-  type: 'Accept'
-  object: FollowActivity
-}
-
-export type ActivityId = CouchUuid
-
-interface Note {
-  name: string
-  actor: AbsoluteUrl
-  lang?: WikimediaLanguageCode
-  parentLink: RelativeUrl
-}
-
-export interface ItemNote extends Note {
-  allActivitiesItems: Item[]
-}
-
-export interface ActivityLink {
-  name: 'shelf' | 'inventory' | 'wikidata.org' | string
-  url: Url
 }
 
 export interface ActorParams {

--- a/server/types/config.ts
+++ b/server/types/config.ts
@@ -213,6 +213,9 @@ export type Config = ReadonlyDeep<{
     'wd:entity:indexation': {
       run: boolean
     }
+    'post:activity': {
+      run: boolean
+    }
   }
 
   // give priority to more urgent matters

--- a/tests/api/activitypub/inbox_follow.test.ts
+++ b/tests/api/activitypub/inbox_follow.test.ts
@@ -69,6 +69,8 @@ describe('activitypub:inbox:Follow', () => {
         object: actorUrl,
         url: inboxUrl,
       })
+      // Leave some time for 'post:activity' job to be processed
+      await wait(50)
       const { inbox } = await requests_.get(`${remoteHost}/shared_inbox_inspection`)
       inbox.length.should.above(0)
       const activity = inbox.find(a => a.type === 'Accept')


### PR DESCRIPTION
This PR allows the server to retry posting activities on remote instances after failing. 
It relies on function `initJobQueue` and leveldb in the background to achieve this.

Solves #719
To be merged after https://github.com/inventaire/inventaire/pull/801