### PR TITLE
Landing map

### DIFF
--- a/server/controllers/groups/lib/groups.ts
+++ b/server/controllers/groups/lib/groups.ts
@@ -2,7 +2,7 @@ import { map, uniq, without } from 'lodash-es'
 import { getAllGroupsMembersIds } from '#controllers/groups/lib/users_lists'
 import { dbFactory } from '#db/couchdb/base'
 import { notFoundError } from '#lib/error/error'
-import searchGroupsByPositionFactory from '#lib/search_by_position'
+import { searchByPositionFactory } from '#lib/search_by_position'
 import { assertStrings, assertString } from '#lib/utils/assert_types'
 import { log } from '#lib/utils/logs'
 import { groupRoles } from '#models/attributes/group'
@@ -13,7 +13,7 @@ import type { UserId } from '#types/user'
 import { addSlug } from './slug.js'
 
 const db = await dbFactory('groups')
-const searchGroupsByPosition = searchGroupsByPositionFactory(db, 'groups')
+const searchGroupsByPosition = searchByPositionFactory(db, 'groups')
 
 export const getGroupById = (id: GroupId) => db.get<Group>(id)
 export async function getGroupsByIds (ids: GroupId[]) {

--- a/server/controllers/items/by_bbox.ts
+++ b/server/controllers/items/by_bbox.ts
@@ -1,0 +1,29 @@
+import { property } from 'lodash-es'
+import { filterMaximumItemsPerOwner } from '#controllers/items/lib/filter_maximum_items_per_owner'
+import { getItemsByUsers } from '#controllers/items/lib/get_items_by_users'
+import { getUsersByBbox } from '#controllers/user/lib/user'
+import type { SanitizedParameters } from '#types/controllers_input_sanitization_parameters'
+import type { Item } from '#types/item'
+import type { User, UserId } from '#types/user'
+
+const sanitization = {
+  bbox: {},
+  limit: {
+    default: 15,
+  },
+  lang: {
+    default: 'en',
+  },
+}
+
+async function controller (params: SanitizedParameters) {
+  const { bbox, limit, lang } = params
+  const foundUsers: User[] = await getUsersByBbox(bbox)
+  const usersIds: UserId[] = foundUsers.map(property('_id'))
+  const { items, users }: { items: Item[], users: User[] } = await getItemsByUsers({ ...params, usersIds })
+
+  const filteredItems = filterMaximumItemsPerOwner(items, lang, limit)
+  return { items: filteredItems, users }
+}
+
+export default { sanitization, controller }

--- a/server/controllers/items/items.ts
+++ b/server/controllers/items/items.ts
@@ -1,6 +1,7 @@
 import { updateSnapshotOnEntityChange } from '#controllers/items/lib/snapshot/update_snapshot_on_entity_change'
 import { actionsControllersFactory } from '#lib/actions_controllers'
 import bulkUpdate from './bulk_update.js'
+import byBbox from './by_bbox.js'
 import byEntities from './by_entities.js'
 import byIds from './by_ids.js'
 import byUserAndEntities from './by_user_and_entities.js'
@@ -19,6 +20,7 @@ import update from './update.js'
 export default {
   get: actionsControllersFactory({
     public: {
+      'by-bbox': byBbox,
       'by-ids': byIds,
       'by-users': byUsers,
       'by-entities': byEntities,

--- a/server/controllers/items/lib/filter_maximum_items_per_owner.ts
+++ b/server/controllers/items/lib/filter_maximum_items_per_owner.ts
@@ -1,0 +1,21 @@
+export function filterMaximumItemsPerOwner (items, lang, limit) {
+  const filteredItems = []
+  const discardedItems = []
+  const itemsCountByOwner = {}
+
+  for (const item of items) {
+    if (filteredItems.length === limit) return filteredItems
+    itemsCountByOwner[item.owner] ??= 0
+    if ((item.snapshot['entity:lang'] === lang) && (itemsCountByOwner[item.owner] < 3)) {
+      itemsCountByOwner[item.owner]++
+      filteredItems.push(item)
+    } else {
+      discardedItems.push(item)
+    }
+  }
+
+  const missingItemsCount = limit - filteredItems.length
+  const itemsToFill = discardedItems.slice(0, missingItemsCount)
+  filteredItems.push(...itemsToFill)
+  return filteredItems
+}

--- a/server/controllers/items/lib/filter_maximum_items_per_owner.ts
+++ b/server/controllers/items/lib/filter_maximum_items_per_owner.ts
@@ -1,4 +1,6 @@
-export function filterMaximumItemsPerOwner (items, lang, limit) {
+import type { SerializedItem } from '#types/item'
+
+export function filterMaximumItemsPerOwner (items: SerializedItem[], lang: string, limit: number) {
   const filteredItems = []
   const discardedItems = []
   const itemsCountByOwner = {}

--- a/server/controllers/items/recent_public.ts
+++ b/server/controllers/items/recent_public.ts
@@ -1,3 +1,4 @@
+import { filterMaximumItemsPerOwner } from '#controllers/items/lib/filter_maximum_items_per_owner'
 import { getPublicItemsByDate } from '#controllers/items/lib/items'
 import { removeUnauthorizedShelves } from '#controllers/items/lib/queries_commons'
 import type { SanitizedParameters } from '#types/controllers_input_sanitization_parameters'
@@ -21,31 +22,9 @@ const sanitization = {
 
 async function controller ({ assertImage, lang, limit, reqUserId }: SanitizedParameters) {
   let items = await getPublicItemsByDate(itemsQueryLimit, offset, assertImage, reqUserId)
-  items = selectRecentItems(items, lang, limit)
+  items = filterMaximumItemsPerOwner(items, lang, limit)
   await removeUnauthorizedShelves(items, reqUserId)
   return bundleOwnersToItems(items, reqUserId)
-}
-
-function selectRecentItems (items, lang, limit) {
-  const recentItems = []
-  const discardedItems = []
-  const itemsCountByOwner = {}
-
-  for (const item of items) {
-    if (recentItems.length === limit) return recentItems
-    if (itemsCountByOwner[item.owner] == null) { itemsCountByOwner[item.owner] = 0 }
-    if ((item.snapshot['entity:lang'] === lang) && (itemsCountByOwner[item.owner] < 3)) {
-      itemsCountByOwner[item.owner]++
-      recentItems.push(item)
-    } else {
-      discardedItems.push(item)
-    }
-  }
-
-  const missingItemsCount = limit - recentItems.length
-  const itemsToFill = discardedItems.slice(0, missingItemsCount)
-  recentItems.push(...itemsToFill)
-  return recentItems
 }
 
 export default { sanitization, controller }

--- a/server/controllers/user/lib/user.ts
+++ b/server/controllers/user/lib/user.ts
@@ -3,12 +3,13 @@ import { getNetworkIds } from '#controllers/user/lib/relations_status'
 import { dbFactory } from '#db/couchdb/base'
 import { defaultAvatar } from '#lib/assets'
 import { newError, notFoundError } from '#lib/error/error'
-import searchUsersByDistanceFactory from '#lib/search_by_distance'
-import searchUsersByPositionFactory from '#lib/search_by_position'
+import { searchByDistanceFactory } from '#lib/search_by_distance'
+import { searchByPositionFactory } from '#lib/search_by_position'
 import { assertArray, assertString } from '#lib/utils/assert_types'
 import { toLowerCase } from '#lib/utils/base'
 import { setUserDocOauthTokens, addUserDocRole, removeUserDocRole, setUserDocStableUsername } from '#models/user'
 import userValidations from '#models/validations/user'
+import type { LatLng } from '#types/common'
 import type { ImageHash } from '#types/image'
 import type { OAuthProvider, OAuthProviderUserData } from '#types/oauth'
 import type { DocWithUsernameInUserDb, Email, User, UserId, UserRole, Username } from '#types/user'
@@ -16,8 +17,8 @@ import { omitPrivateData, type UserExtraAttribute } from './authorized_user_data
 import { byEmail, byEmails, findOneByEmail } from './shared_user_handlers.js'
 
 const db = await dbFactory('users')
-const searchUsersByPosition = searchUsersByPositionFactory(db, 'users')
-const searchUsersByDistance = searchUsersByDistanceFactory('users')
+const searchUsersByPosition = searchByPositionFactory(db, 'users')
+const searchUsersByDistance = searchByDistanceFactory('users')
 
 // TODO: include SpecialUser in possibly returned type
 export const getUserById = db.get<User>
@@ -149,7 +150,7 @@ export function serializeUserData (user) {
   return user
 }
 
-export async function findNearby (latLng, meterRange, iterations = 0, strict = false) {
+export async function findNearby (latLng: LatLng, meterRange: number, iterations: number = 0, strict: boolean = false) {
   const usersIds = await searchUsersByDistance(latLng, meterRange)
   // Try to get the 10 closest (11 minus the main user)
   // If strict, don't increase the range, just return what was found;

--- a/server/controllers/user/lib/user.ts
+++ b/server/controllers/user/lib/user.ts
@@ -135,7 +135,7 @@ export async function getUsersNearby (userId: UserId, meterRange: number, strict
   return without(usersIds, userId)
 }
 
-export const getUserByPosition = searchUsersByPosition
+export const getUsersByBbox = searchUsersByPosition
 
 export async function imageIsUsed (imageHash: ImageHash) {
   assertString(imageHash)
@@ -149,7 +149,7 @@ export function serializeUserData (user) {
   return user
 }
 
-async function findNearby (latLng, meterRange, iterations = 0, strict = false) {
+export async function findNearby (latLng, meterRange, iterations = 0, strict = false) {
   const usersIds = await searchUsersByDistance(latLng, meterRange)
   // Try to get the 10 closest (11 minus the main user)
   // If strict, don't increase the range, just return what was found;

--- a/server/controllers/users/search_by_position.ts
+++ b/server/controllers/users/search_by_position.ts
@@ -1,4 +1,4 @@
-import { getUserByPosition, getUsersAuthorizedData } from '#controllers/user/lib/user'
+import { getUsersAuthorizedData, getUsersByBbox } from '#controllers/user/lib/user'
 import { reqHasAdminAccess } from '#lib/user_access_levels'
 import type { SanitizedParameters } from '#types/controllers_input_sanitization_parameters'
 import type { Req } from '#types/server'
@@ -9,7 +9,7 @@ const sanitization = {
 
 async function controller ({ bbox, reqUserId }: SanitizedParameters, req: Req) {
   const reqUserHasAdminAccess = reqHasAdminAccess(req)
-  let users = await getUserByPosition(bbox)
+  let users = await getUsersByBbox(bbox)
   users = await getUsersAuthorizedData(users, { reqUserId, reqUserHasAdminAccess })
   return { users }
 }

--- a/server/controllers/users/search_by_position.ts
+++ b/server/controllers/users/search_by_position.ts
@@ -9,9 +9,9 @@ const sanitization = {
 
 async function controller ({ bbox, reqUserId }: SanitizedParameters, req: Req) {
   const reqUserHasAdminAccess = reqHasAdminAccess(req)
-  let users = await getUsersByBbox(bbox)
-  users = await getUsersAuthorizedData(users, { reqUserId, reqUserHasAdminAccess })
-  return { users }
+  const usersPromise = getUsersByBbox(bbox)
+  const filteredUsers = await getUsersAuthorizedData(usersPromise, { reqUserId, reqUserHasAdminAccess })
+  return { users: filteredUsers }
 }
 
 export default { sanitization, controller }

--- a/server/lib/elasticsearch.ts
+++ b/server/lib/elasticsearch.ts
@@ -5,7 +5,7 @@ import { requests_ } from '#lib/requests'
 import { assertString } from '#lib/utils/assert_types'
 import config from '#server/config'
 import type { AbsoluteUrl } from '#types/common'
-import type { SearchRequest, SearchResponse } from '@elastic/elasticsearch/lib/api/types.js'
+import type { SearchRequest, SearchResponse, SearchHitsMetadata } from '@elastic/elasticsearch/lib/api/types.js'
 
 const { origin: elasticOrigin, selfSignedCertificate } = config.elasticsearch
 
@@ -25,8 +25,8 @@ export function buildSearcher (params) {
     const { limit, offset } = params
     try {
       const res: SearchResponse = await requests_.post(url, { body, ...elasticReqOptions })
-      const { hits, total } = getHitsAndTotal(res)
-      let continu
+      const { hits, total }: SearchHitsMetadata = getHitsAndTotal(res)
+      let continu: number
       if (isNumber(limit) && isNumber(offset)) {
         continu = limit + offset
       }

--- a/server/lib/sanitize/parameters.ts
+++ b/server/lib/sanitize/parameters.ts
@@ -112,6 +112,11 @@ function formatStringArrayElement (str) {
   else return str
 }
 
+function formatPipedPosition (str) {
+  const arrayOfNumbers = arrayOrPipedString(str)
+  return truncateLatLng(arrayOfNumbers)
+}
+
 const arrayOrPipedString = arrayOrSeparatedString('|')
 const arrayOrCommaSeparatedString = arrayOrSeparatedString(',')
 
@@ -142,6 +147,7 @@ const couchUuids = {
 }
 
 const arrayOfNumbers = {
+  format: arrayOrPipedString,
   validate: arrayOfAType(isNumber),
 }
 
@@ -341,7 +347,7 @@ export const sanitizationParameters = {
     rename: renameId,
   },
   position: {
-    format: truncateLatLng,
+    format: formatPipedPosition,
     validate: arrayOfNumbers.validate,
   },
   prefix: allowlistedString,

--- a/server/lib/search_by_distance.ts
+++ b/server/lib/search_by_distance.ts
@@ -1,24 +1,22 @@
 import { buildSearcher } from '#lib/elasticsearch'
 import { distanceBetween } from '#lib/geo'
-import { assertNumbers, assertNumber } from '#lib/utils/assert_types'
+import type { LatLng } from '#types/common'
 import type { SearchRequest } from '@elastic/elasticsearch/lib/api/types.js'
 
-export default dbBaseName => {
+export function searchByDistanceFactory (dbBaseName: string) {
   const searchByDistance = buildSearcher({
     dbBaseName,
     queryBuilder,
   })
 
-  return async (latLng, meterRange) => {
-    assertNumbers(latLng)
-    assertNumber(meterRange)
+  return async (latLng: LatLng, meterRange: number) => {
     const { hits } = await searchByDistance({ latLng, meterRange })
     return getIdsSortedByDistance(hits, latLng)
   }
 }
 
 // See https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-bounding-box-query.html
-function queryBuilder ({ latLng, meterRange }) {
+function queryBuilder ({ latLng, meterRange }: { latLng: LatLng, meterRange: number }) {
   const [ lat, lon ] = latLng
   const searchRequest: SearchRequest = {
     query: {

--- a/server/lib/search_by_position.ts
+++ b/server/lib/search_by_position.ts
@@ -1,24 +1,27 @@
 import { map } from 'lodash-es'
 import { buildSearcher } from '#lib/elasticsearch'
 import { assertNumbers } from '#lib/utils/assert_types'
+import type { BBox, Bounds } from '#types/common'
+import type { DbHandler } from '#types/couchdb'
+import type { User } from '#types/user'
 import type { SearchRequest } from '@elastic/elasticsearch/lib/api/types.js'
 
-export default (db, dbBaseName) => {
+export function searchByPositionFactory <D extends User> (db: DbHandler, dbBaseName: string) {
   const searchByPosition = buildSearcher({
     dbBaseName,
     queryBuilder,
   })
 
-  return async bbox => {
+  return async (bbox: BBox) => {
     assertNumbers(bbox)
     const { hits } = await searchByPosition(bbox)
     const ids = map(hits, '_id')
-    return db.byIds(ids)
+    return db.byIds<D>(ids)
   }
 }
 
-function queryBuilder ([ minLng, minLat, maxLng, maxLat ]) {
-  const bboxes = splitBboxOnAntiMeridian([ minLng, minLat, maxLng, maxLat ])
+function queryBuilder (bounds: Bounds) {
+  const boundss: Bounds[] = splitBboxOnAntiMeridian(bounds)
   const searchRequest: SearchRequest = {
     query: {
       // @ts-ignore somehow, the "should" assertion library is leaking global types
@@ -27,7 +30,7 @@ function queryBuilder ([ minLng, minLat, maxLng, maxLat ]) {
       bool: {
         filter: {
           bool: {
-            should: bboxes.map(buildGeoBoundingBoxClause),
+            should: boundss.map(buildGeoBoundingBoxClause),
           },
         },
       },
@@ -37,32 +40,32 @@ function queryBuilder ([ minLng, minLat, maxLng, maxLat ]) {
   return searchRequest
 }
 
-function splitBboxOnAntiMeridian ([ minLng, minLat, maxLng, maxLat ]) {
+function splitBboxOnAntiMeridian ([ minLng, minLat, maxLng, maxLat ]: Bounds) {
   if (minLng < -180 && maxLng > -180) {
     return [
       [ -180, minLat, maxLng, maxLat ],
       [ normalizeLongitude(minLng), minLat, 180, maxLat ],
-    ]
+    ] as Bounds[]
   } else if (maxLng > 180 && minLng < 180) {
     return [
       [ minLng, minLat, 180, maxLat ],
       [ -180, minLat, normalizeLongitude(maxLng), maxLat ],
-    ]
+    ] as Bounds[]
   } else {
     return [
       // Normalizing for the case where both minLng and maxLng are out of the [ -180, 180 ] range
       [ normalizeLongitude(minLng), minLat, normalizeLongitude(maxLng), maxLat ],
-    ]
+    ] as Bounds[]
   }
 }
 
-function normalizeLongitude (lng) {
+function normalizeLongitude (lng: number) {
   if (lng < -180) return lng + 360
   if (lng > 180) return lng - 360
   return lng
 }
 
-function buildGeoBoundingBoxClause ([ minLng, minLat, maxLng, maxLat ]) {
+function buildGeoBoundingBoxClause ([ minLng, minLat, maxLng, maxLat ]: Bounds) {
   const topLeft = { lat: maxLat, lon: minLng }
   const bottomRight = { lat: minLat, lon: maxLng }
   return {

--- a/server/lib/search_by_position.ts
+++ b/server/lib/search_by_position.ts
@@ -12,10 +12,11 @@ export function searchByPositionFactory <D extends User> (db: DbHandler, dbBaseN
     queryBuilder,
   })
 
-  return async (bbox: BBox) => {
+  return async (bbox: BBox, limit: number = 500) => {
     assertNumbers(bbox)
     const { hits } = await searchByPosition(bbox)
-    const ids = map(hits, '_id')
+    const limitedHits = hits.slice(0, limit)
+    const ids = map(limitedHits, '_id')
     return db.byIds<D>(ids)
   }
 }

--- a/server/types/common.ts
+++ b/server/types/common.ts
@@ -5,6 +5,7 @@ const { parse: isbnParser } = isbn3
 
 export type LatLng = [ number, number ]
 export type BBox = [ LatLng, LatLng ]
+export type Bounds = [ number, number, number, number ]
 
 export type HttpMethod = 'get' | 'post' | 'put' | 'delete' | 'options' | 'head'
 export type HttpHeaderKey =

--- a/tests/api/fixtures/users.ts
+++ b/tests/api/fixtures/users.ts
@@ -11,9 +11,10 @@ import { makeFriends } from '#tests/api/utils/relations'
 import { request, rawRequest } from '#tests/api/utils/request'
 import { deleteUser } from '#tests/api/utils/users'
 import type { Awaitable } from '#tests/api/utils/utils'
+import type { LatLng } from '#types/common'
 import type { User, UserRole } from '#types/user'
 
-export type CustomUserData = Record<string, string | number | boolean>
+export type CustomUserData = Record<string, string | number | boolean | number[]>
 
 const authEndpoint = `${localOrigin}/api/auth`
 
@@ -109,7 +110,7 @@ export function getRandomPosition () {
   return [
     getRandomLatitude(),
     getRandomLongitude(),
-  ]
+  ] as LatLng
 }
 export const getRandomLatitude = () => randomCoordinate(-90, 90)
 export const getRandomLongitude = () => randomCoordinate(-180, 180)

--- a/tests/api/items/get_by_bbox.test.ts
+++ b/tests/api/items/get_by_bbox.test.ts
@@ -1,0 +1,34 @@
+import 'should'
+import { map } from 'lodash-es'
+import { createItem } from '#fixtures/items'
+import { createUser, getRandomPosition } from '#fixtures/users'
+import { fixedEncodeURIComponent } from '#lib/utils/url'
+import { waitForIndexation } from '#tests/api/utils/search'
+import { publicReq } from '#tests/api/utils/utils'
+import type { LatLng } from '#types/common'
+
+const endpoint = '/api/items?action=by-bbox'
+
+const userPosition: LatLng = getRandomPosition()
+const [ lat, lng ] = userPosition
+let geolocatedUser
+const bbox: string = fixedEncodeURIComponent(JSON.stringify([
+  lng - 1, // minLng
+  lat - 1, // minLat
+  lng + 1, // maxLng
+  lat + 1, // maxLat
+]))
+
+describe('items:public:by-bbox', () => {
+  before(async () => {
+    geolocatedUser = await createUser({ position: userPosition })
+  })
+
+  it('should get public items nearby', async () => {
+    await waitForIndexation('users', geolocatedUser._id)
+    const item = await createItem(geolocatedUser)
+    const { items } = await publicReq('get', `${endpoint}&bbox=${bbox}`)
+    const itemsIds = map(items, '_id')
+    itemsIds.includes(item._id).should.be.true()
+  })
+})


### PR DESCRIPTION
This is mainly opening a `items/by-bbox` endpoint in order to serve the client landing page map [#527](https://github.com/inventaire/inventaire-client/pull/527)

This seems cleaner than going through the existing `by-position` endpoint, since the client is displaying the exact books of users displayed on the map, while `by-position` would serve every item within a range/radius, ending potentially displaying items which do not belong to anyone on the map.