### PR TITLE
Let local and federated users without Wikidata OAuth credentials edit Wikidata entities, by using the Wikidata bot account credentials

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "turtle-validator": "^1.0.2",
         "type-fest": "^4.29.0",
         "typescript": "^5.6.2",
-        "wikibase-edit": "^7.2.0",
+        "wikibase-edit": "^7.2.2",
         "wikibase-sdk": "^10.2.1",
         "wikidata-lang": "^4.1.2"
       },
@@ -6736,9 +6736,9 @@
       }
     },
     "node_modules/wikibase-edit": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/wikibase-edit/-/wikibase-edit-7.2.0.tgz",
-      "integrity": "sha512-FwFgZ91nL6hrpJyAk/sc4vroJV/r7hBnORlqxfavhdjqxFSTIPEAaV+Fo/XJIbsuB/6d5kE60ARRkLszIcRMNw==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/wikibase-edit/-/wikibase-edit-7.2.2.tgz",
+      "integrity": "sha512-GD62k/9f1IGTFB5W5QbNbWbwtXyeRgiZMNdwn+nL7btBQd8R5m2prueXNfBKOB68y3lEf2pWcM9W0NPlmbA04A==",
       "license": "MIT",
       "dependencies": {
         "crypto-js": "^4.1.1",
@@ -11427,9 +11427,9 @@
       }
     },
     "wikibase-edit": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/wikibase-edit/-/wikibase-edit-7.2.0.tgz",
-      "integrity": "sha512-FwFgZ91nL6hrpJyAk/sc4vroJV/r7hBnORlqxfavhdjqxFSTIPEAaV+Fo/XJIbsuB/6d5kE60ARRkLszIcRMNw==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/wikibase-edit/-/wikibase-edit-7.2.2.tgz",
+      "integrity": "sha512-GD62k/9f1IGTFB5W5QbNbWbwtXyeRgiZMNdwn+nL7btBQd8R5m2prueXNfBKOB68y3lEf2pWcM9W0NPlmbA04A==",
       "requires": {
         "crypto-js": "^4.1.1",
         "lodash.isequal": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "turtle-validator": "^1.0.2",
     "type-fest": "^4.29.0",
     "typescript": "^5.6.2",
-    "wikibase-edit": "^7.2.0",
+    "wikibase-edit": "^7.2.2",
     "wikibase-sdk": "^10.2.1",
     "wikidata-lang": "^4.1.2"
   },

--- a/server/controllers/entities/lib/create_wd_entity.ts
+++ b/server/controllers/entities/lib/create_wd_entity.ts
@@ -1,5 +1,5 @@
 import { getClaimValue, getFirstClaimValue } from '#controllers/entities/lib/inv_claims_utils'
-import { getWikidataOAuthCredentials, assertUserHasWikidataOAuth } from '#controllers/entities/lib/wikidata_oauth'
+import { getWikidataOAuthCredentials, validateUserHasWikidataOAuth } from '#controllers/entities/lib/wikidata_oauth'
 import { newError } from '#lib/error/error'
 import type { MinimalRemoteUser } from '#lib/federation/remote_user'
 import { mapKeysValues, objectEntries } from '#lib/utils/base'
@@ -41,7 +41,7 @@ export type UnprefixedClaims = Record<WdPropertyId, UnprefixedClaimObject[]>
 export async function createWdEntity (params: CreateWdEntityParams) {
   const { labels, descriptions, claims, user, isAlreadyValidated = false } = params
   // Reserve wd entity creation to users who connected their Wikidata account, for now
-  assertUserHasWikidataOAuth(user)
+  validateUserHasWikidataOAuth(user)
   const { credentials, summarySuffix } = getWikidataOAuthCredentials(user)
 
   const entity: EntityDraft = { labels, descriptions, claims }

--- a/server/controllers/entities/lib/create_wd_entity.ts
+++ b/server/controllers/entities/lib/create_wd_entity.ts
@@ -1,5 +1,5 @@
 import { getClaimValue, getFirstClaimValue } from '#controllers/entities/lib/inv_claims_utils'
-import { getWikidataOAuthCredentials, validateWikidataOAuth } from '#controllers/entities/lib/wikidata_oauth'
+import { getWikidataOAuthCredentials, assertUserHasWikidataOAuth } from '#controllers/entities/lib/wikidata_oauth'
 import { newError } from '#lib/error/error'
 import type { MinimalRemoteUser } from '#lib/federation/remote_user'
 import { mapKeysValues, objectEntries } from '#lib/utils/base'
@@ -40,8 +40,9 @@ export type UnprefixedClaims = Record<WdPropertyId, UnprefixedClaimObject[]>
 
 export async function createWdEntity (params: CreateWdEntityParams) {
   const { labels, descriptions, claims, user, isAlreadyValidated = false } = params
-  validateWikidataOAuth(user)
-  const credentials = getWikidataOAuthCredentials(user)
+  // Reserve wd entity creation to users who connected their Wikidata account, for now
+  assertUserHasWikidataOAuth(user)
+  const { credentials, summarySuffix } = getWikidataOAuthCredentials(user)
 
   const entity: EntityDraft = { labels, descriptions, claims }
 
@@ -50,7 +51,7 @@ export async function createWdEntity (params: CreateWdEntityParams) {
   if (!isAlreadyValidated) await validateInvEntity(entity)
   validateWikidataCompliance(entity)
   const formattedEntity = format(entity)
-  const res = await wdEdit.entity.create(formattedEntity, { credentials })
+  const res = await wdEdit.entity.create(formattedEntity, { credentials, summarySuffix })
   const { entity: createdEntity } = res
   if (createdEntity == null) {
     throw newError('invalid wikidata-edit response', 500, { res })

--- a/server/controllers/entities/lib/move_to_wikidata.ts
+++ b/server/controllers/entities/lib/move_to_wikidata.ts
@@ -6,7 +6,7 @@ import { getPublicationYear } from '#controllers/entities/lib/get_publisher_publ
 import { expandInvClaims, getClaimValue, getFirstClaimValue } from '#controllers/entities/lib/inv_claims_utils'
 import { resolveExternalIds } from '#controllers/entities/lib/resolver/resolve_external_ids'
 import { omitLocalClaims } from '#controllers/entities/lib/update_wd_claim'
-import { assertUserHasWikidataOAuth, getWikidataOAuthCredentials } from '#controllers/entities/lib/wikidata_oauth'
+import { validateUserHasWikidataOAuth, getWikidataOAuthCredentials } from '#controllers/entities/lib/wikidata_oauth'
 import { temporarilyOverrideWdIdAndIsbnCache } from '#data/wikidata/get_wd_entities_by_isbns'
 import { isNonEmptyArray } from '#lib/boolean_validations'
 import { newError } from '#lib/error/error'
@@ -26,7 +26,7 @@ export async function moveInvEntityToWikidata (user: User | MinimalRemoteUser, i
   const userAcct = getUserAcct(user)
 
   // We currently require a Wikidata account to create a Wikidata entity, and thus also to move an entity to Wikidata
-  assertUserHasWikidataOAuth(user)
+  validateUserHasWikidataOAuth(user)
 
   const entityId = unprefixify(invEntityUri)
 

--- a/server/controllers/entities/lib/move_to_wikidata.ts
+++ b/server/controllers/entities/lib/move_to_wikidata.ts
@@ -6,7 +6,7 @@ import { getPublicationYear } from '#controllers/entities/lib/get_publisher_publ
 import { expandInvClaims, getClaimValue, getFirstClaimValue } from '#controllers/entities/lib/inv_claims_utils'
 import { resolveExternalIds } from '#controllers/entities/lib/resolver/resolve_external_ids'
 import { omitLocalClaims } from '#controllers/entities/lib/update_wd_claim'
-import { getWikidataOAuthCredentials } from '#controllers/entities/lib/wikidata_oauth'
+import { assertUserHasWikidataOAuth, getWikidataOAuthCredentials } from '#controllers/entities/lib/wikidata_oauth'
 import { temporarilyOverrideWdIdAndIsbnCache } from '#data/wikidata/get_wd_entities_by_isbns'
 import { isNonEmptyArray } from '#lib/boolean_validations'
 import { newError } from '#lib/error/error'
@@ -24,6 +24,9 @@ import { cacheEntityRelations } from './temporarily_cache_relations.js'
 
 export async function moveInvEntityToWikidata (user: User | MinimalRemoteUser, invEntityUri: InvEntityUri) {
   const userAcct = getUserAcct(user)
+
+  // We currently require a Wikidata account to create a Wikidata entity, and thus also to move an entity to Wikidata
+  assertUserHasWikidataOAuth(user)
 
   const entityId = unprefixify(invEntityUri)
 
@@ -136,14 +139,14 @@ function buildDescriptions (claims: ExpandedClaims): Descriptions {
 }
 
 async function setReverseClaims (claims: ExpandedClaims, wdEntityUri: WdEntityUri, user: User | MinimalRemoteUser) {
-  const credentials = getWikidataOAuthCredentials(user)
+  const { credentials, summarySuffix } = getWikidataOAuthCredentials(user)
   const entityType = getInvEntityType(claims['wdt:P31'])
   const newEntityId = unprefixify(wdEntityUri)
   if (entityType === 'edition') {
     for (const workClaim of uniq(claims['wdt:P629'])) {
       const workUri = getClaimValue(workClaim) as EntityValue
       const id = unprefixify(workUri)
-      await wdEdit.claim.create({ id, property: 'P747', value: newEntityId }, { credentials })
+      await wdEdit.claim.create({ id, property: 'P747', value: newEntityId }, { credentials, summarySuffix })
     }
   }
 }

--- a/server/controllers/entities/lib/update_wd_label.ts
+++ b/server/controllers/entities/lib/update_wd_label.ts
@@ -1,6 +1,6 @@
 import { triggerSubjectEntityCacheRefresh } from '#controllers/entities/lib/entities_relations_temporary_cache'
 import { prefixifyWd } from '#controllers/entities/lib/prefix'
-import { getWikidataOAuthCredentials, validateWikidataOAuth } from '#controllers/entities/lib/wikidata_oauth'
+import { getWikidataOAuthCredentials } from '#controllers/entities/lib/wikidata_oauth'
 import { isWdEntityId } from '#lib/boolean_validations'
 import { newError } from '#lib/error/error'
 import { newInvalidError } from '#lib/error/pre_filled'
@@ -15,10 +15,9 @@ export async function updateWdLabel (user: User | MinimalRemoteUser, id: WdEntit
   if (!isWdEntityId(id)) throw newInvalidError('id', id)
   if (isRemoteUser(user)) throw newError('remote users can not update wd label yet', 400)
 
-  validateWikidataOAuth(user)
-  const credentials = getWikidataOAuthCredentials(user)
+  const { credentials, summarySuffix } = getWikidataOAuthCredentials(user)
 
-  const res = await wdEdit.label.set({ id, language, value }, { credentials })
+  const res = await wdEdit.label.set({ id, language, value }, { credentials, summarySuffix })
   triggerSubjectEntityCacheRefresh(prefixifyWd(id))
   return res
 }

--- a/server/controllers/entities/lib/wikidata_oauth.ts
+++ b/server/controllers/entities/lib/wikidata_oauth.ts
@@ -11,7 +11,7 @@ export function hasWikidataOAuth (user: User | SpecialUser | MinimalRemoteUser |
   return 'oauth' in user && 'wikidata' in user.oauth && user.oauth.wikidata != null
 }
 
-export function assertUserHasWikidataOAuth (user: User | SpecialUser | MinimalRemoteUser | UserWithAcct) {
+export function validateUserHasWikidataOAuth (user: User | SpecialUser | MinimalRemoteUser | UserWithAcct) {
   if (!hasWikidataOAuth(user)) {
     throw newError('missing wikidata oauth tokens', 400)
   }

--- a/server/lib/federation/remote_user.ts
+++ b/server/lib/federation/remote_user.ts
@@ -71,7 +71,7 @@ export function buildLocalUserAcct (anonymizableId: AnonymizableUserId) {
   return buildUserAcct(anonymizableId, publicHost)
 }
 
-export function getUserAcct (user: User | SpecialUser | MinimalRemoteUser) {
+export function getUserAcct (user: User | SpecialUser | MinimalRemoteUser | UserWithAcct) {
   if ('acct' in user) {
     return user.acct
   } else {


### PR DESCRIPTION
The current motivation is to let federated users perform edits on Wikidata without having to connect their account, as the Wikidata OAuth workflow would require their local instance to have their own OAuth consumer tokens

But it's also nice for local users who might not want to create a Wikidata account, and can just edit from the very safeguarded Inventaire edition environment

This is a follow up to #796 

Example of an edit made by a user without Wikidata credentials: https://www.wikidata.org/w/index.php?title=Q112795079&diff=2304878238&oldid=2304858745

Client PR: https://github.com/inventaire/inventaire-client/pull/531