### PR TITLE
Remove uniqueness constraint on external ids

### DIFF
--- a/server/controllers/entities/lib/properties/properties_config_bases.ts
+++ b/server/controllers/entities/lib/properties/properties_config_bases.ts
@@ -44,7 +44,7 @@ export const languageEntity = { ...entity, entityValueTypes: [ 'language' ] } as
 export const uniqueEntity = { ...entity, uniqueValue: true } as const
 
 export const concurrentAndUniqueString = { ...uniqueString, concurrency: true } as const
-export const concurrentAndUniqueExternalId = { ...concurrentAndUniqueString, datatype: 'external-id' } as const
+export const concurrentExternalId = { ...string, concurrency: true, datatype: 'external-id' } as const
 
 export const url = {
   datatype: 'url',

--- a/server/controllers/entities/lib/properties/properties_config_builders.ts
+++ b/server/controllers/entities/lib/properties/properties_config_builders.ts
@@ -7,7 +7,7 @@ import { objectValues } from '#lib/utils/base'
 import { getPluralType } from '#lib/wikidata/aliases'
 import type { EntityType } from '#types/entity'
 import { allowedValuesPerTypePerProperty } from './allowed_values_per_type_per_property.js'
-import { concurrentAndUniqueString, concurrentAndUniqueExternalId, uniqueEntity } from './properties_config_bases.js'
+import { concurrentAndUniqueString, concurrentExternalId, uniqueEntity } from './properties_config_bases.js'
 
 export function isbnProperty (num: 10 | 13) {
   return {
@@ -28,7 +28,7 @@ export function isbnProperty (num: 10 | 13) {
 // on their Wikidata property page P1793 statement
 export function externalId (regex) {
   return {
-    ...concurrentAndUniqueExternalId,
+    ...concurrentExternalId,
     format: trim,
     validate: ({ value }) => regex.test.bind(regex)(value),
   } as const
@@ -36,7 +36,7 @@ export function externalId (regex) {
 
 export function typedExternalId (regexPerType: Partial<Record<EntityType, RegExp>>) {
   return {
-    ...concurrentAndUniqueExternalId,
+    ...concurrentExternalId,
     typeSpecificValidation: true,
     format: trim,
     validate: ({ value, entityType }) => {
@@ -68,9 +68,9 @@ export function allowedPropertyValues (property: keyof typeof allowedValuesPerTy
   } as const
 }
 
-export function externalIdWithFormatter ({ regex, format }) {
+export function externalIdWithFormatter ({ regex, format }: { regex: RegExp, format: (str: string) => string }) {
   return {
-    ...concurrentAndUniqueExternalId,
+    ...concurrentExternalId,
     format,
     validate: ({ value }) => regex.test.bind(regex)(value),
   } as const

--- a/server/controllers/entities/lib/properties/properties_values_constraints.ts
+++ b/server/controllers/entities/lib/properties/properties_values_constraints.ts
@@ -330,7 +330,13 @@ export const propertiesValuesConstraints = {
   'wdt:P13137': externalId(strictlyPositiveIntegerPattern),
 } as const satisfies Readonly<Record<PropertyUri, PropertyValueConstraints>>
 
-export const getPropertyDatatype = property => propertiesValuesConstraints[property]?.datatype
+export function getPropertyDatatype (property: PropertyUri) {
+  return propertiesValuesConstraints[property]?.datatype
+}
+
+export function isExternaIdProperty (property: PropertyUri) {
+  return getPropertyDatatype(property) === 'external-id'
+}
 
 export type PropertiesValuesConstraints = typeof propertiesValuesConstraints
 
@@ -340,6 +346,4 @@ type ExternalIdPropertiesValuesConstraints = OmitNever<{
 
 export type ExternalIdProperty = keyof ExternalIdPropertiesValuesConstraints
 
-export const externalIdsProperties = objectKeys(propertiesValuesConstraints).filter(property => {
-  return propertiesValuesConstraints[property].datatype === 'external-id'
-}) as ExternalIdProperty[]
+export const externalIdsProperties = objectKeys(propertiesValuesConstraints).filter(isExternaIdProperty) as ExternalIdProperty[]

--- a/server/controllers/entities/lib/properties/properties_values_constraints.ts
+++ b/server/controllers/entities/lib/properties/properties_values_constraints.ts
@@ -343,15 +343,3 @@ export type ExternalIdProperty = keyof ExternalIdPropertiesValuesConstraints
 export const externalIdsProperties = objectKeys(propertiesValuesConstraints).filter(property => {
   return propertiesValuesConstraints[property].datatype === 'external-id'
 }) as ExternalIdProperty[]
-
-type ConcurrentIdPropertiesValuesConstraints = OmitNever<{
-  [P in keyof PropertiesValuesConstraints]: PropertiesValuesConstraints[P] & { concurrency: true }
-}>
-
-export type ConcurrentIdProperty = keyof ConcurrentIdPropertiesValuesConstraints
-
-/** concurrentIdsProperties extends externalIdsProperties by including concurrent string properties such as ISBNs */
-export const concurrentIdsProperties = objectKeys(propertiesValuesConstraints).filter(property => {
-  const prop = propertiesValuesConstraints[property]
-  return 'concurrency' in prop && prop.concurrency === true
-}) as ConcurrentIdProperty[]

--- a/server/controllers/tasks/lib/merge_validation.ts
+++ b/server/controllers/tasks/lib/merge_validation.ts
@@ -1,12 +1,19 @@
 import { pick } from 'lodash-es'
-import { concurrentIdsProperties, getPropertyDatatype } from '#controllers/entities/lib/properties/properties_values_constraints'
+import { getPropertyDatatype } from '#controllers/entities/lib/properties/properties_values_constraints'
 import { isNonEmptyArray } from '#lib/boolean_validations'
 import { newError } from '#lib/error/error'
 import { arrayIncludes, objectEntries } from '#lib/utils/base'
 import type { SerializedEntity, EntityUri } from '#types/entity'
 
+// If merged entities have different ISBN values, the merge should be aborted
+// This list could also be obtained with filtering properties with `(prop) => prop.uniqueValue && prop.concurrency`
+const conflictingProperties = [
+  'wdt:P212',
+  'wdt:P957',
+] as const
+
 export function validateAbsenceOfConflictingProperties (fromEntity: SerializedEntity, toEntity: SerializedEntity) {
-  const fromConcurrentIdsClaims = pick(fromEntity.claims, concurrentIdsProperties)
+  const fromConcurrentIdsClaims = pick(fromEntity.claims, conflictingProperties)
 
   for (const [ property, fromValues ] of objectEntries(fromConcurrentIdsClaims)) {
     const toPropertyValues = toEntity.claims[property]


### PR DESCRIPTION
Addressing #815 and limiting [`entities have conflicting properties`](https://github.com/inventaire/inventaire/issues/782#issuecomment-2700776541) errors to ISBN conflicts